### PR TITLE
Adjust Python interpreter in shebangs.

### DIFF
--- a/libsel4/tools/syscall_stub_gen.py
+++ b/libsel4/tools/syscall_stub_gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # Copyright 2014, NICTA
 #

--- a/manual/tools/gen_env.py
+++ b/manual/tools/gen_env.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # Copyright 2014, NICTA
 #

--- a/tools/bitfield_gen.py
+++ b/tools/bitfield_gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #
 # Copyright 2014, NICTA

--- a/tools/invocation_header_gen.py
+++ b/tools/invocation_header_gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # Copyright 2014, NICTA
 #

--- a/tools/syscall_header_gen.py
+++ b/tools/syscall_header_gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # Copyright 2014, NICTA
 #

--- a/tools/umm.py
+++ b/tools/umm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #
 # Copyright 2014, NICTA


### PR DESCRIPTION
The repository used both: /usr/bin/python and /usr/bin/env python.

The commit adjust the interpreter selection to /usr/bin/env python, such
that e.g. virtuelenvs are respected correctly.

This is needed when the system's Python is at version 3 and one wants a
local virtualenv for Python 2 or the tempita package.

Signed-off-by: Daniel J. Hofmann daniel@trvx.org
