### PR TITLE
Change README `http://sel4.systems` links to HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ please see the [`sel4.systems`][1] website and associated [FAQ][2].
 This repository is usually not used in isolation, but as part of the build
 system in a larger project.
 
-  [1]: http://sel4.systems/
-  [2]: http://sel4.systems/FAQ/
+  [1]: https://sel4.systems/
+  [2]: https://sel4.systems/FAQ/
 
 
 Repository Overview


### PR DESCRIPTION
This commit changes the `http://sel4.systems` hyperlinks in the
`README.md` document to use HTTPS rather than unsecured HTTP.

The website at `sel4.systems.` seems to support HTTPS, with a
commonly-accepted (Gandi) certificate, so I see no sufficient reason to
not use HTTPS here.