### PR TITLE
Use usr/bin/env for all python bangpaths to enable virtualenv use.

### DIFF
--- a/libsel4/tools/syscall_stub_gen.py
+++ b/libsel4/tools/syscall_stub_gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2014, NICTA
 #

--- a/manual/tools/gen_env.py
+++ b/manual/tools/gen_env.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright 2014, NICTA
 #

--- a/tools/invocation_header_gen.py
+++ b/tools/invocation_header_gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 #
 # Copyright 2014, NICTA
 #

--- a/tools/syscall_header_gen.py
+++ b/tools/syscall_header_gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 #
 # Copyright 2014, NICTA
 #


### PR DESCRIPTION
Very useful with python3 as the default platform.
