### PR TITLE
tools: *: use proper python2 shebang line

### DIFF
--- a/tools/bf_autocorres.py
+++ b/tools/bf_autocorres.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python2
+
 '''
 Functions related to generating AutoCorres-based definitions and proofs from
 the bitfield generator.

--- a/tools/bitfield_gen.py
+++ b/tools/bitfield_gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #
 # Copyright 2014, NICTA

--- a/tools/invocation_header_gen.py
+++ b/tools/invocation_header_gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # Copyright 2014, NICTA
 #

--- a/tools/lex.py
+++ b/tools/lex.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python2
 #
 # @TAG(OTHER_BSD)
 #

--- a/tools/syscall_header_gen.py
+++ b/tools/syscall_header_gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # Copyright 2014, NICTA
 #

--- a/tools/umm.py
+++ b/tools/umm.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-
+#!/usr/bin/env python2
 #
 # Copyright 2014, NICTA
 #

--- a/tools/yacc.py
+++ b/tools/yacc.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python2
 #
 # @TAG(OTHER_BSD)
 #


### PR DESCRIPTION
This patch updates the #! line in all of the python tools such that the
python version required for the tools (python2) is explcitly stated, so
that systems which have `python` symlinked to `python3` can still
compile the kernel without modification to the system or scripts.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>