### PR TITLE
Update libsel4 to not have any dependency on libc/HAVE_LIBC.

### DIFF
--- a/libsel4/Kbuild
+++ b/libsel4/Kbuild
@@ -9,4 +9,4 @@
 #
 
 libs-$(CONFIG_LIB_SEL4) += libsel4
-libsel4: $(libc) common
+libsel4: common

--- a/libsel4/Kconfig
+++ b/libsel4/Kconfig
@@ -10,7 +10,6 @@
 
 menuconfig LIB_SEL4
     bool "Build sel4 library"
-    depends on HAVE_LIBC
     default y
     help
         "Build the sel4 library"

--- a/libsel4/Makefile
+++ b/libsel4/Makefile
@@ -22,7 +22,12 @@ TARGETS          := libsel4.a
 
 # Source files required to build the target
 CFILES := \
-	$(patsubst $(SOURCE_DIR)/%,%,$(wildcard $(SOURCE_DIR)/src/*.c))
+	$(patsubst $(SOURCE_DIR)/%,%,$(wildcard $(SOURCE_DIR)/src/*.c)) \
+	$(patsubst $(SOURCE_DIR)/%,%,$(wildcard $(SOURCE_DIR)/src/${ARCH}/*.c))
+
+ASMFILES := \
+	$(patsubst $(SOURCE_DIR)/%,%,$(wildcard $(SOURCE_DIR)/src/*.S)) \
+	$(patsubst $(SOURCE_DIR)/%,%,$(wildcard $(SOURCE_DIR)/src/${ARCH}/*.S))
 
 # Header files/directories this library provides
 # Note: sel4_client.h may not have been built at the time this is evaluated.

--- a/libsel4/arch_include/arm/sel4/arch/stdint.h
+++ b/libsel4/arch_include/arm/sel4/arch/stdint.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2014, General Dynamics C4 Systems
+ *
+ * This software may be distributed and modified according to the terms of
+ * the GNU General Public License version 2. Note that NO WARRANTY is provided.
+ * See "LICENSE_GPLv2.txt" for details.
+ *
+ * @TAG(GD_GPL)
+ */
+
+#ifndef __ARCH_STDINT_H
+#define __ARCH_STDINT_H
+
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
+typedef unsigned long long uint64_t;
+
+typedef signed char int8_t;
+typedef signed short int16_t;
+typedef signed int int32_t;
+typedef signed long long int64_t;
+
+#endif

--- a/libsel4/arch_include/arm/sel4/arch/syscalls.h
+++ b/libsel4/arch_include/arm/sel4/arch/syscalls.h
@@ -12,8 +12,9 @@
 #define __LIBSEL4_ARCH_SYSCALLS_H
 
 #include <autoconf.h>
+#include <sel4/arch/functions.h>
 #include <sel4/types.h>
-#include <stdint.h>
+#include <libsel4_stdint.h>
 
 #define __SWINUM(x) ((x) & 0x00ffffff)
 

--- a/libsel4/arch_include/arm/sel4/arch/types.h
+++ b/libsel4/arch_include/arm/sel4/arch/types.h
@@ -12,7 +12,7 @@
 #define __LIBSEL4_ARCH_TYPES_H
 
 #include <sel4/macros.h>
-#include <stdint.h>
+#include <libsel4_stdint.h>
 
 #define seL4_WordBits 32
 

--- a/libsel4/arch_include/x86/sel4/arch/functions.h
+++ b/libsel4/arch_include/x86/sel4/arch/functions.h
@@ -12,7 +12,7 @@
 #define __LIBSEL4_ARCH_FUNCTIONS_H
 
 #include <sel4/types.h>
-#include <stddef.h> /* for NULL */
+#include <libsel4_stddef.h> /* for NULL */
 
 /* the segment loaded into GS points directly to the IPC buffer */
 

--- a/libsel4/arch_include/x86/sel4/arch/stdint.h
+++ b/libsel4/arch_include/x86/sel4/arch/stdint.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2014, General Dynamics C4 Systems
+ *
+ * This software may be distributed and modified according to the terms of
+ * the GNU General Public License version 2. Note that NO WARRANTY is provided.
+ * See "LICENSE_GPLv2.txt" for details.
+ *
+ * @TAG(GD_GPL)
+ */
+
+#ifndef __ARCH_STDINT_H
+#define __ARCH_STDINT_H
+
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
+typedef unsigned long long uint64_t;
+
+typedef signed char int8_t;
+typedef signed short int16_t;
+typedef signed int int32_t;
+typedef signed long long int64_t;
+
+#endif

--- a/libsel4/arch_include/x86/sel4/arch/syscalls.h
+++ b/libsel4/arch_include/x86/sel4/arch/syscalls.h
@@ -12,6 +12,7 @@
 #define __LIBSEL4_ARCH_SYSCALLS_H
 
 #include <autoconf.h>
+#include <sel4/arch/functions.h>
 #include <sel4/types.h>
 
 static inline void

--- a/libsel4/arch_include/x86/sel4/arch/types.h
+++ b/libsel4/arch_include/x86/sel4/arch/types.h
@@ -12,7 +12,7 @@
 #define __LIBSEL4_ARCH_TYPES_H
 
 #include <autoconf.h>
-#include <stdint.h>
+#include <libsel4_stdint.h>
 
 #define seL4_WordBits        32
 #define seL4_PageBits        12

--- a/libsel4/include/libsel4_assert.h
+++ b/libsel4/include/libsel4_assert.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2014, General Dynamics C4 Systems
+ *
+ * This software may be distributed and modified according to the terms of
+ * the GNU General Public License version 2. Note that NO WARRANTY is provided.
+ * See "LICENSE_GPLv2.txt" for details.
+ *
+ * @TAG(GD_GPL)
+ */
+
+#ifndef __ASSERT_H
+#define __ASSERT_H
+
+
+#ifdef DEBUG
+
+void _fail(
+    const char*  str,
+    const char*  file,
+    unsigned int line,
+    const char*  function
+);
+
+#ifndef fail
+#define fail(s) _fail(s, __FILE__, __LINE__, __func__)
+#endif
+
+void _assert_fail(
+    const char*  assertion,
+    const char*  file,
+    unsigned int line,
+    const char*  function
+);
+
+#ifndef assert
+#define assert(expr) \
+    if(!(expr)) _assert_fail(#expr, __FILE__, __LINE__, __FUNCTION__)
+#endif
+
+/* Create an assert that will trigger a compile error if it fails. */
+#ifndef compile_assert
+#define compile_assert(name, expr) \
+        typedef int __assert_failed_##name[(expr) ? 1 : -1];
+#endif
+
+#else /* !DEBUG */
+
+#include <libsel4_halt.h>
+
+#ifndef fail
+#define fail(s) halt()
+#endif
+
+#ifndef assert
+#define assert(expr)
+#endif
+
+#ifndef compile_assert
+#define compile_assert(name, expr)
+#endif
+
+#endif /* DEBUG */
+
+#endif

--- a/libsel4/include/libsel4_halt.h
+++ b/libsel4/include/libsel4_halt.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2015, Wink Saville
+ *
+ * This software may be distributed and modified according to the terms of
+ * the BSD 2-Clause license. Note that NO WARRANTY is provided.
+ * See "LICENSE_BSD2.txt" for details.
+ */
+
+#ifndef __HALT_H
+#define __HALT_H
+
+void halt(void);
+
+#endif

--- a/libsel4/include/libsel4_io.h
+++ b/libsel4/include/libsel4_io.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2014, General Dynamics C4 Systems
+ *
+ * This software may be distributed and modified according to the terms of
+ * the GNU General Public License version 2. Note that NO WARRANTY is provided.
+ * See "LICENSE_GPLv2.txt" for details.
+ *
+ * @TAG(GD_GPL)
+ */
+
+#ifndef __LIBSEL4_IO_H
+#define __LIBSEL4_IO_H
+
+#ifdef DEBUG
+void libsel4_putchar(const char c);
+unsigned int libsel4_puts(const char *s);
+unsigned int libsel4_printf(const char *format, ...);
+unsigned int libsel4_print_unsigned_long(unsigned long x, unsigned int ui_base);
+#else
+#define libsel4_putchar(c) ((void)(0))
+#define libsel4_puts(s) ((void)(0))
+#define libsel4_printf(...) ((void)(0))
+#define libsel4_print_unsigned_long(unsigned long x, unsigned int ui_base) ((void)(0))
+#endif
+
+#endif

--- a/libsel4/include/libsel4_stdarg.h
+++ b/libsel4/include/libsel4_stdarg.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2014, General Dynamics C4 Systems
+ *
+ * This software may be distributed and modified according to the terms of
+ * the GNU General Public License version 2. Note that NO WARRANTY is provided.
+ * See "LICENSE_GPLv2.txt" for details.
+ *
+ * @TAG(GD_GPL)
+ */
+
+#ifndef __LIBSEL4_STDARG_H
+#define __LIBSEL4_STDARG_H
+
+#ifndef va_start
+#define va_start(v,l) __builtin_va_start(v,l)
+#endif
+
+#ifndef va_end
+#define va_end(v) __builtin_va_end(v)
+#endif
+
+#ifndef va_arg
+#define va_arg(v,l) __builtin_va_arg(v,l)
+#endif
+
+#ifndef va_list
+typedef __builtin_va_list va_list;
+#endif
+
+#endif

--- a/libsel4/include/libsel4_stdbool.h
+++ b/libsel4/include/libsel4_stdbool.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2015, Wink Saville
+ *
+ * This software may be distributed and modified according to the terms of
+ * the BSD 2-Clause license. Note that NO WARRANTY is provided.
+ * See "LICENSE_BSD2.txt" for details.
+ */
+
+#ifndef __LIBSEL4_STDBOOL_H
+#define __LIBSEL4_STDBOOL_H
+
+#ifndef __cplusplus
+
+#ifndef true
+#define true 1
+#endif
+
+#ifndef false
+#define false 0
+#endif
+
+#ifndef bool
+#define bool _Bool
+#endif
+
+#endif
+
+#endif

--- a/libsel4/include/libsel4_stddef.h
+++ b/libsel4/include/libsel4_stddef.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2015, Wink Saville
+ *
+ * This software may be distributed and modified according to the terms of
+ * the BSD 2-Clause license. Note that NO WARRANTY is provided.
+ * See "LICENSE_BSD2.txt" for details.
+ */
+
+#ifndef __LIBSEL4_STDDEF_H
+#define __LIBSEL4_STDDEF_H
+
+#ifndef NULL
+
+#ifdef __cplusplus
+#define NULL 0L
+#else
+#define NULL ((void*)0)
+#endif
+
+#endif
+
+#endif

--- a/libsel4/include/libsel4_stdint.h
+++ b/libsel4/include/libsel4_stdint.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2015, Wink Saville
+ *
+ * This software may be distributed and modified according to the terms of
+ * the BSD 2-Clause license. Note that NO WARRANTY is provided.
+ * See "LICENSE_BSD2.txt" for details.
+ */
+
+#ifndef __LIBSEL4_STDINT_H
+#define __LIBSEL4_STDINT_H
+
+#include <sel4/arch/stdint.h>
+
+#endif

--- a/libsel4/include/sel4/benchmark.h
+++ b/libsel4/include/sel4/benchmark.h
@@ -17,7 +17,8 @@
 #define MAX_IPC_BUFFER (1024 - 1)
 
 #include <sel4/sel4.h>
-#include <stdint.h>
+#include <libsel4_stdint.h>
+#include <libsel4_io.h>
 
 static inline void
 seL4_BenchmarkDumpFullLog()
@@ -29,18 +30,18 @@ seL4_BenchmarkDumpFullLog()
         uint32_t requested = chunk > MAX_IPC_BUFFER ? MAX_IPC_BUFFER : chunk;
         uint32_t recorded = seL4_BenchmarkDumpLog(j, requested);
         for (uint32_t i = 0; i < recorded; i++) {
-            printf("%u\t", seL4_GetMR(i));
+            libsel4_printf("%u\t", seL4_GetMR(i));
         }
-        printf("\n");
+        libsel4_printf("\n");
         /* we filled the log buffer */
         if (requested != recorded) {
-            printf("Dumped %u of %u potential logs\n", j + recorded, potential_size);
+            libsel4_printf("Dumped %u of %u potential logs\n", j + recorded, potential_size);
             return;
         }
     }
 
     /* logged amount was smaller than log buffer */
-    printf("Dumped entire log, size %u\n", potential_size);
+    libsel4_printf("Dumped entire log, size %u\n", potential_size);
 }
 
 #endif /* CONFIG_BENCHMARK */

--- a/libsel4/include/sel4/bootinfo.h
+++ b/libsel4/include/sel4/bootinfo.h
@@ -13,7 +13,7 @@
 
 #include <autoconf.h>
 #include <sel4/types.h>
-#include <stdint.h>
+#include <libsel4_stdint.h>
 
 /* caps with fixed slot potitions in the root CNode */
 

--- a/libsel4/src/arm/libsel4_start.S
+++ b/libsel4/src/arm/libsel4_start.S
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2014, NICTA
+ *
+ * This software may be distributed and modified according to the terms of
+ * the BSD 2-Clause license. Note that NO WARRANTY is provided.
+ * See "LICENSE_BSD2.txt" for details.
+ *
+ * @TAG(NICTA_BSD)
+ */
+/*
+ * A default _libsel4_start. It initalizes sel4_BootInfo and invokes
+ * int main(void). The return value is ignored and then this hangs.
+ */
+
+#define __ASM__
+#include <autoconf.h>
+
+#include <sel4/arch/constants.h>
+
+
+    .global _libsel4_start
+
+    .text
+
+_libsel4_start:
+    /* Setup a stack for ourselves. */
+    ldr     sp, =_stack_top
+
+    /* Setup bootinfo. The pointer to the bootinfo struct starts in 'r0'. */
+    bl      seL4_InitBootInfo
+
+    /* Invoke 'int main(void);' */
+    bl      main
+
+    /* If main returns ignore result and die */
+1:  jmp     1b
+
+
+    .bss
+    .align  8
+
+_stack_bottom:
+    .space  16384
+_stack_top:
+
+#endif /* CONFIG_LIB_SEL4_PLAT_SUPPORT_SEL4_START */

--- a/libsel4/src/assert.c
+++ b/libsel4/src/assert.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014, General Dynamics C4 Systems
+ *
+ * This software may be distributed and modified according to the terms of
+ * the GNU General Public License version 2. Note that NO WARRANTY is provided.
+ * See "LICENSE_GPLv2.txt" for details.
+ *
+ * @TAG(GD_GPL)
+ */
+
+#include <libsel4_halt.h>
+#include <libsel4_io.h>
+
+#ifdef DEBUG
+
+void _fail(
+    const char*  s,
+    const char*  file,
+    unsigned int line,
+    const char*  function)
+{
+    libsel4_printf(
+        "seL4 called fail at %s:%u in function %s, saying \"%s\"\n",
+        file,
+        line,
+        function,
+        s
+    );
+    halt();
+}
+
+void _assert_fail(
+    const char*  assertion,
+    const char*  file,
+    unsigned int line,
+    const char*  function)
+{
+    libsel4_printf("seL4 failed assertion '%s' at %s:%u in function %s\n",
+           assertion,
+           file,
+           line,
+           function
+          );
+    halt();
+}
+
+#endif

--- a/libsel4/src/halt.c
+++ b/libsel4/src/halt.c
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2015, Wink Saville
+ *
+ * This software may be distributed and modified according to the terms of
+ * the BSD 2-Clause license. Note that NO WARRANTY is provided.
+ * See "LICENSE_BSD2.txt" for details.
+ */
+
+void halt(void) {
+    while(1) {
+    }
+}

--- a/libsel4/src/libsel4_io.c
+++ b/libsel4/src/libsel4_io.c
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2014, General Dynamics C4 Systems
+ *
+ * This software may be distributed and modified according to the terms of
+ * the GNU General Public License version 2. Note that NO WARRANTY is provided.
+ * See "LICENSE_GPLv2.txt" for details.
+ *
+ * @TAG(GD_GPL)
+ */
+
+#include <libsel4_stdint.h>
+#include <libsel4_stdarg.h>
+#include <libsel4_io.h>
+
+#include <sel4/arch/syscalls.h>
+
+#ifdef DEBUG
+
+static unsigned int
+print_string(const char *s)
+{
+    unsigned int n;
+
+    for (n = 0; *s; s++, n++) {
+        libsel4_putchar(*s);
+    }
+
+    return n;
+}
+
+static unsigned long
+xdiv(unsigned long x, unsigned int denom)
+{
+    switch (denom) {
+    case 16:
+        return x / 16;
+    case 10:
+        return x / 10;
+    default:
+        return 0;
+    }
+}
+
+static unsigned long
+xmod(unsigned long x, unsigned int denom)
+{
+    switch (denom) {
+    case 16:
+        return x % 16;
+    case 10:
+        return x % 10;
+    default:
+        return 0;
+    }
+}
+
+unsigned int
+libsel4_print_unsigned_long(unsigned long x, unsigned int ui_base)
+{
+    char out[11];
+    unsigned int i, j;
+    unsigned int d;
+
+    /*
+     * Only base 10 and 16 supported for now. We want to avoid invoking the
+     * compiler's support libraries through doing arbitrary divisions.
+     */
+    if (ui_base != 10 && ui_base != 16) {
+        return 0;
+    }
+
+    if (x == 0) {
+        libsel4_putchar('0');
+        return 1;
+    }
+
+    for (i = 0; x; x = xdiv(x, ui_base), i++) {
+        d = xmod(x, ui_base);
+
+        if (d >= 10) {
+            out[i] = 'a' + d - 10;
+        } else {
+            out[i] = '0' + d;
+        }
+    }
+
+    for (j = i; j > 0; j--) {
+        libsel4_putchar(out[j - 1]);
+    }
+
+    return i;
+}
+
+
+static unsigned int
+print_unsigned_long_long(unsigned long long x, unsigned int ui_base)
+{
+    unsigned long upper, lower;
+    unsigned int n = 0;
+    unsigned int mask = 0xF0000000u;
+
+    /* only implemented for hex, decimal is harder without 64 bit division */
+    if (ui_base != 16) {
+        return 0;
+    }
+
+    /* we can't do 64 bit division so break it up into two hex numbers */
+    upper = (unsigned long) (x >> 32llu);
+    lower = (unsigned long) x;
+
+    /* print first 32 bits if they exist */
+    if (upper > 0) {
+        n += libsel4_print_unsigned_long(upper, ui_base);
+
+        /* print leading 0s */
+        while (!(mask & lower)) {
+            libsel4_putchar('0');
+            n++;
+            mask = mask >> 4;
+        }
+    }
+
+    /* print last 32 bits */
+    n += libsel4_print_unsigned_long(lower, ui_base);
+
+    return n;
+}
+
+
+static int
+vprintf(const char *format, va_list ap)
+{
+    unsigned int n;
+    unsigned int formatting;
+
+    if (!format) {
+        return 0;
+    }
+
+    n = 0;
+    formatting = 0;
+    while (*format) {
+        if (formatting) {
+            switch (*format) {
+            case '%':
+                libsel4_putchar('%');
+                n++;
+                format++;
+                break;
+
+            case 'd': {
+                int x = va_arg(ap, int);
+
+                if (x < 0) {
+                    libsel4_putchar('-');
+                    n++;
+                    x = -x;
+                }
+
+                n += libsel4_print_unsigned_long((unsigned long)x, 10);
+                format++;
+                break;
+            }
+
+            case 'u':
+                n += libsel4_print_unsigned_long(va_arg(ap, unsigned long), 10);
+                format++;
+                break;
+
+            case 'x':
+                n += libsel4_print_unsigned_long(va_arg(ap, unsigned long), 16);
+                format++;
+                break;
+
+            case 'p': {
+                unsigned long p = va_arg(ap, unsigned long);
+                if (p == 0) {
+                    n += print_string("(nil)");
+                } else {
+                    n += print_string("0x");
+                    n += libsel4_print_unsigned_long(p, 16);
+                }
+                format++;
+                break;
+            }
+
+            case 's':
+                n += print_string(va_arg(ap, char *));
+                format++;
+                break;
+
+            case 'l':
+		// Support llx only
+                if (*(format + 1) == 'l' && *(format + 2) == 'x') {
+                    uint64_t arg = va_arg(ap, unsigned long long);
+                    n += print_unsigned_long_long(arg, 16);
+                    format += 3;
+                }
+                break;
+            default:
+                format++;
+                break;
+            }
+
+            formatting = 0;
+        } else {
+            switch (*format) {
+            case '%':
+                formatting = 1;
+                format++;
+                break;
+
+            default:
+                libsel4_putchar(*format);
+                n++;
+                format++;
+                break;
+            }
+        }
+    }
+
+    return n;
+}
+
+unsigned int
+libsel4_printf(const char *format, ...)
+{
+    va_list args;
+    unsigned int i;
+
+    va_start(args, format);
+    i = vprintf(format, args);
+    va_end(args);
+    return i;
+}
+
+void libsel4_putchar(const char c)
+{
+    seL4_DebugPutChar(c);
+}
+
+unsigned int libsel4_puts(const char *s)
+{
+    for (; *s; s++) {
+        libsel4_putchar(*s);
+    }
+    libsel4_putchar('\n');
+    return 0;
+}
+
+#endif

--- a/libsel4/src/x86/libsel4_start.S
+++ b/libsel4/src/x86/libsel4_start.S
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2014, NICTA
+ *
+ * This software may be distributed and modified according to the terms of
+ * the BSD 2-Clause license. Note that NO WARRANTY is provided.
+ * See "LICENSE_BSD2.txt" for details.
+ *
+ * @TAG(NICTA_BSD)
+ */
+/*
+ * A default _libsel4_start. It initalizes sel4_BootInfo and invokes
+ * int main(void). The return value is ignored and then this hangs.
+ */
+
+#define __ASM__
+#include <autoconf.h>
+
+#include <sel4/arch/constants.h>
+
+
+    .global _libsel4_start
+
+    .text
+
+#ifdef X86_64
+
+.align 0x1000
+_libsel4_start:
+    leaq    _stack_top, %esp
+
+    /* Setup segment selector for IPC buffer access. */
+    movw    $IPCBUF_GDT_SELECTOR, %ax
+    movw    %ax, %gs
+
+    /* Setup the global "bootinfo" structure. */
+    /* Invoke 'seL4_BootInfo* seL4_GetBootInfo();' to get address */
+    movq    %rbx, %rdi
+    call    seL4_InitBootInfo
+
+#else
+
+_libsel4_start:
+    leal    _stack_top, %esp
+
+    /* Setup segment selector for IPC buffer access. */
+    movw    $IPCBUF_GDT_SELECTOR, %ax
+    movw    %ax, %gs
+
+    /* Setup the global "bootinfo" structure. */
+    /* Invoke 'seL4_BootInfo* seL4_GetBootInfo();' to get address */
+    pushl   %ebx
+    call    seL4_InitBootInfo
+
+#endif
+
+    /* Invoke 'int main(void);' */
+    call    main
+
+    /* If main returns ignore result and die */
+1:  jmp     1b
+
+
+    .bss
+    .align  8
+
+_stack_bottom:
+    .space  16384
+_stack_top:
+

--- a/libsel4/tools/syscall_stub_gen.py
+++ b/libsel4/tools/syscall_stub_gen.py
@@ -671,9 +671,9 @@ def generate_stub_file(arch, input_files, output_file, use_only_ipc_buffer):
 #ifndef __LIBSEL4_SEL4_CLIENT_H
 #define __LIBSEL4_SEL4_CLIENT_H
 
-#include <stddef.h>
-#include <stdbool.h>
-#include <stdint.h>
+#include <libsel4_stddef.h>
+#include <libsel4_stdbool.h>
+#include <libsel4_stdint.h>
 #include "sel4/types.h"
 #include "sel4/invocation.h"
 #include "sel4/arch/functions.h"

--- a/tools/bitfield_gen.py
+++ b/tools/bitfield_gen.py
@@ -33,7 +33,7 @@ DEBUG = False
 # Headers to include depending on which environment we are generating code for.
 INCLUDES = {
     'sel4':['assert.h', 'config.h', 'stdint.h', 'util.h'],
-    'libsel4':['assert.h', 'autoconf.h', 'sel4/macros.h', 'stdint.h'],
+    'libsel4':['libsel4_assert.h', 'autoconf.h', 'sel4/macros.h', 'libsel4_stdint.h'],
 }
 
 ### Parser


### PR DESCRIPTION
This is accomplished by modifying several files:
Kbuild, Kconfig, Makefile, syscalls.h, benchmark.h.

Porting code already implemented in the seL4:
 stdint.h becomes libsel4_stdint.h
 stdarg.h becomes libsel4_stdarg.h
 assert.[hc] becomes libsel4_assert.[hc]
 machine_io.[hc] which becomes libsel4_io.[hc]

Porting sel4_crt0.S from libsel4platsupport which becomes libsel4_start.S

And creating a few new files:
 libsel4_halt.[hc], libsel4_stdbool.h, libsel4_stddef.h,
 libsel4_stdint.h which includes the sel4/arch/stdint.h