### PR TITLE
should enable print in debug build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -266,6 +266,8 @@ DEFINES += ${CONFIG_DEFS:%=-D%}
 ifdef DEBUG
 DEFINES += -DDEBUG
 DEFINES += -DCONFIG_DEBUG_BUILD
+DEFINES += -DCONFIG_PRINTING
+DEFINES += -DCONFIG_USER_STACK_TRACE_LENGTH=1
 CFLAGS  += -ggdb -g3
 endif
 
@@ -382,7 +384,7 @@ endif
 WARNINGS = all error strict-prototypes missing-prototypes nested-externs \
 	missing-declarations undef pointer-arith no-nonnull declaration-after-statement
 
-CFLAGS += --std=c99 -nostdlib -nostdinc -ffreestanding \
+CFLAGS += --std=c99 -nostdlib -nostdinc -ffreestanding -fms-extensions \
 	${WARNINGS:%=-W%} ${INCLUDES}
 LDFLAGS += -nostdlib -nostdinc
 LDFLAGS += -Wl,--build-id=none

--- a/src/plat/pc99/machine/acpi.c
+++ b/src/plat/pc99/machine/acpi.c
@@ -320,7 +320,7 @@ acpi_madt_scan(
                     }
                     break;
                 case MADT_ISO:
-                    printf("ACIP: MADT_ISO bus=%d source=%d gsi=%d flags=0x%x\n",
+                    printf("ACPI: MADT_ISO bus=%d source=%d gsi=%d flags=0x%x\n",
                            ((acpi_madt_iso_t*)acpi_madt_header)->bus,
                            ((acpi_madt_iso_t*)acpi_madt_header)->source,
                            ((acpi_madt_iso_t*)acpi_madt_header)->gsi,


### PR DESCRIPTION
add CONFIG_PRINTING to DEBUG build
fix `Unnamed Structure and Union Fields' defined for old gcc (add -fms-extensions)
fix typo