### PR TITLE
add stub Arch_userStackTrace for x86 PAE

### DIFF
--- a/src/arch/x86/32/kernel/vspace_pae.c
+++ b/src/arch/x86/32/kernel/vspace_pae.c
@@ -468,4 +468,12 @@ decodeIA32PageDirectoryInvocation(
     return performIA32PageDirectoryInvocationMap(cap, cte, pdpte, pdptSlot, threadRoot, vspaceCap);
 }
 
+#if CONFIG_PRINTING
+/* FIXME implement */
+void
+Arch_userStackTrace(tcb_t *tptr)
+{
+}
+#endif
+
 #endif


### PR DESCRIPTION
When configuring with both CONFIG_PAE and CONFIG_PRINTING,
this needed to be declared (I didn't implement the function however, just added a stub)