### PR TITLE
Let aarch32 CallWithMRs

### DIFF
--- a/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/syscalls.h
+++ b/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/syscalls.h
@@ -263,10 +263,10 @@ seL4_RecvWithMRs(seL4_CPtr src, seL4_Word* sender,
 {
     seL4_MessageInfo_t info;
     seL4_Word badge;
-    seL4_Word msg0;
-    seL4_Word msg1;
-    seL4_Word msg2;
-    seL4_Word msg3;
+    seL4_Word msg0 = 0;
+    seL4_Word msg1 = 0;
+    seL4_Word msg2 = 0;
+    seL4_Word msg3 = 0;
 
     arm_sys_recv(seL4_SysRecv, src, &badge, &info.words[0], &msg0, &msg1, &msg2, &msg3);
 
@@ -416,10 +416,10 @@ seL4_ReplyRecvWithMRs(seL4_CPtr src, seL4_MessageInfo_t msgInfo, seL4_Word *send
 {
     seL4_MessageInfo_t info;
     seL4_Word badge;
-    seL4_Word msg0;
-    seL4_Word msg1;
-    seL4_Word msg2;
-    seL4_Word msg3;
+    seL4_Word msg0 = 0;
+    seL4_Word msg1 = 0;
+    seL4_Word msg2 = 0;
+    seL4_Word msg3 = 0;
 
     if (mr0 != seL4_Null && seL4_MessageInfo_get_length(msgInfo) > 0) {
         msg0 = *mr0;

--- a/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/syscalls.h
+++ b/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/syscalls.h
@@ -340,10 +340,10 @@ seL4_CallWithMRs(seL4_CPtr dest, seL4_MessageInfo_t msgInfo,
                  seL4_Word *mr0, seL4_Word *mr1, seL4_Word *mr2, seL4_Word *mr3)
 {
     seL4_MessageInfo_t info;
-    seL4_Word msg0;
-    seL4_Word msg1;
-    seL4_Word msg2;
-    seL4_Word msg3;
+    seL4_Word msg0 = 0;
+    seL4_Word msg1 = 0;
+    seL4_Word msg2 = 0;
+    seL4_Word msg3 = 0;
 
     /* Load beginning of the message into registers. */
     if (mr0 != seL4_Null && seL4_MessageInfo_get_length(msgInfo) > 0) {


### PR DESCRIPTION
* Initialise the message variables (as per ia32 and x86_64)
* `libsel4` now builds when `syscall_stub_gen.py` is run without `--buffer`
* While simple things appear to work, `sel4test` with aarch32 in qemu is *not* happy:

```
Bootstrapping kernel

Warning: using printf before serial is set up. This only works as your
printf is backed by seL4_Debug_PutChar()
sel4utils_create_object_at_level@mapping.h:22 Should not be called
Ignoring call to sys_rt_sigprocmask
Ignoring call to sys_gettid
sys_tkill assuming self kill
```