### PR TITLE
Optional inlining of functions and syscalls

### DIFF
--- a/libsel4/Kconfig
+++ b/libsel4/Kconfig
@@ -16,15 +16,34 @@ menu "libsel4"
         help
             seL4 API library
 
+choice
+    prompt "Function attributes"
+    default LIB_SEL4_INLINE_INVOCATIONS
+
+config LIB_SEL4_DEFAULT_FUNCTION_ATTRIBUTES
+    bool "Default"
+    depends on LIB_SEL4
+    help
+        Verification friendly default configuration. syscalls will be inlined,
+        but generated functions will not.
+
 config LIB_SEL4_INLINE_INVOCATIONS
     bool "Inline generated syscall invocations"
     depends on LIB_SEL4
-    default y
     help
         When set to true will mark generated functions as 'inline', allowing
         them to be inlined by the callee user code. This may be undesirable
-        for verification, so setting to 'n' will forcively prevent the function
-        from being inlined
+        for verification, so setting to 'n' will forcibly prevent the function
+        from being inlined.
+
+config LIB_SEL4_PUBLIC_SYMBOLS
+    bool "Public symbols for all external interfaces"
+    depends on LIB_SEL4
+    help
+        When set to true will make all user facing functions available as
+        public symbols, which can be convenient for some language bindings.
+
+endchoice
 
 config LIB_SEL4_STUBS_USE_IPC_BUFFER_ONLY
     bool "use only IPC buffer for syscalls"

--- a/libsel4/arch_include/arm/sel4/arch/functions.h
+++ b/libsel4/arch_include/arm/sel4/arch/functions.h
@@ -15,7 +15,7 @@
 #include <sel4/types.h>
 #include <sel4/sel4_arch/functions.h>
 
-static inline seL4_IPCBuffer*
+LIBSEL4_INLINE_FUNC seL4_IPCBuffer*
 seL4_GetIPCBuffer(void)
 {
 #if defined(CONFIG_IPC_BUF_GLOBALS_FRAME)
@@ -29,31 +29,31 @@ seL4_GetIPCBuffer(void)
 #endif
 }
 
-static inline seL4_Word
+LIBSEL4_INLINE_FUNC seL4_Word
 seL4_GetMR(int i)
 {
     return seL4_GetIPCBuffer()->msg[i];
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_SetMR(int i, seL4_Word mr)
 {
     seL4_GetIPCBuffer()->msg[i] = mr;
 }
 
-static inline seL4_Word
+LIBSEL4_INLINE_FUNC seL4_Word
 seL4_GetUserData(void)
 {
     return seL4_GetIPCBuffer()->userData;
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_SetUserData(seL4_Word data)
 {
     seL4_GetIPCBuffer()->userData = data;
 }
 
-static inline seL4_CapData_t
+LIBSEL4_INLINE_FUNC seL4_CapData_t
 seL4_GetBadge(int i)
 {
     return (seL4_CapData_t) {
@@ -63,19 +63,19 @@ seL4_GetBadge(int i)
     };
 }
 
-static inline seL4_CPtr
+LIBSEL4_INLINE_FUNC seL4_CPtr
 seL4_GetCap(int i)
 {
     return (seL4_CPtr)seL4_GetIPCBuffer()->caps_or_badges[i];
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_SetCap(int i, seL4_CPtr cptr)
 {
     seL4_GetIPCBuffer()->caps_or_badges[i] = (seL4_Word)cptr;
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_GetCapReceivePath(seL4_CPtr* receiveCNode, seL4_CPtr* receiveIndex, seL4_Word* receiveDepth)
 {
     seL4_IPCBuffer* ipcbuffer = seL4_GetIPCBuffer();
@@ -92,7 +92,7 @@ seL4_GetCapReceivePath(seL4_CPtr* receiveCNode, seL4_CPtr* receiveIndex, seL4_Wo
     }
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_SetCapReceivePath(seL4_CPtr receiveCNode, seL4_CPtr receiveIndex, seL4_Word receiveDepth)
 {
     seL4_IPCBuffer* ipcbuffer = seL4_GetIPCBuffer();

--- a/libsel4/arch_include/arm/sel4/arch/syscalls.h
+++ b/libsel4/arch_include/arm/sel4/arch/syscalls.h
@@ -16,13 +16,13 @@
 #include <sel4/sel4_arch/syscalls.h>
 #include <sel4/types.h>
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_Wait(seL4_CPtr src, seL4_Word *sender)
 {
     seL4_Recv(src, sender);
 }
 
-static inline seL4_MessageInfo_t
+LIBSEL4_INLINE_FUNC seL4_MessageInfo_t
 seL4_Poll(seL4_CPtr src, seL4_Word *sender)
 {
     return seL4_NBRecv(src, sender);

--- a/libsel4/arch_include/x86/sel4/arch/functions.h
+++ b/libsel4/arch_include/x86/sel4/arch/functions.h
@@ -14,7 +14,7 @@
 #include <sel4/types.h>
 #include <sel4/sel4_arch/functions.h>
 
-static inline seL4_Word
+LIBSEL4_INLINE_FUNC seL4_Word
 seL4_GetMR(int i)
 {
     seL4_Word mr;
@@ -22,13 +22,13 @@ seL4_GetMR(int i)
     return mr;
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_SetMR(int i, seL4_Word mr)
 {
     SEL4_SET_IPCBUF_SCALE(msg, i, mr);
 }
 
-static inline seL4_Word
+LIBSEL4_INLINE_FUNC seL4_Word
 seL4_GetUserData(void)
 {
     seL4_Word data;
@@ -36,13 +36,13 @@ seL4_GetUserData(void)
     return data;
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_SetUserData(seL4_Word data)
 {
     SEL4_SET_IPCBUF(userData, data);
 }
 
-static inline seL4_CapData_t
+LIBSEL4_INLINE_FUNC seL4_CapData_t
 seL4_GetBadge(int i)
 {
     seL4_CapData_t badge;
@@ -50,7 +50,7 @@ seL4_GetBadge(int i)
     return badge;
 }
 
-static inline seL4_CPtr
+LIBSEL4_INLINE_FUNC seL4_CPtr
 seL4_GetCap(int i)
 {
     seL4_CPtr cap;
@@ -58,13 +58,13 @@ seL4_GetCap(int i)
     return cap;
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_SetCap(int i, seL4_CPtr cptr)
 {
     SEL4_SET_IPCBUF_SCALE(caps_or_badges, i, cptr);
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_GetCapReceivePath(seL4_CPtr* receiveCNode, seL4_CPtr* receiveIndex, seL4_Word* receiveDepth)
 {
     if (receiveCNode != seL4_Null) {
@@ -80,7 +80,7 @@ seL4_GetCapReceivePath(seL4_CPtr* receiveCNode, seL4_CPtr* receiveIndex, seL4_Wo
     }
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_SetCapReceivePath(seL4_CPtr receiveCNode, seL4_CPtr receiveIndex, seL4_Word receiveDepth)
 {
     SEL4_SET_IPCBUF(receiveCNode, receiveCNode);
@@ -88,7 +88,7 @@ seL4_SetCapReceivePath(seL4_CPtr receiveCNode, seL4_CPtr receiveIndex, seL4_Word
     SEL4_SET_IPCBUF(receiveDepth, receiveDepth);
 }
 
-static inline seL4_IPCBuffer*
+LIBSEL4_INLINE_FUNC seL4_IPCBuffer*
 seL4_GetIPCBuffer(void)
 {
     /* Assume that the address of our IPC buffer is in the user data word. Our

--- a/libsel4/arch_include/x86/sel4/arch/syscalls.h
+++ b/libsel4/arch_include/x86/sel4/arch/syscalls.h
@@ -16,13 +16,13 @@
 #include <sel4/sel4_arch/syscalls.h>
 #include <sel4/types.h>
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_Wait(seL4_CPtr src, seL4_Word *sender)
 {
     seL4_Recv(src, sender);
 }
 
-static inline seL4_MessageInfo_t
+LIBSEL4_INLINE_FUNC seL4_MessageInfo_t
 seL4_Poll(seL4_CPtr src, seL4_Word *sender)
 {
     return seL4_NBRecv(src, sender);

--- a/libsel4/include/sel4/faults.h
+++ b/libsel4/include/sel4/faults.h
@@ -15,7 +15,7 @@
 #include <sel4/types.h>
 #include <sel4/sel4_arch/faults.h>
 
-static inline seL4_Fault_t
+LIBSEL4_INLINE_FUNC seL4_Fault_t
 seL4_getFault(seL4_MessageInfo_t tag)
 {
 
@@ -40,38 +40,38 @@ seL4_getFault(seL4_MessageInfo_t tag)
 }
 
 #ifdef CONFIG_HARDWARE_DEBUG_API
-static inline seL4_Bool
+LIBSEL4_INLINE_FUNC seL4_Bool
 seL4_isDebugException_tag(seL4_MessageInfo_t tag)
 {
     return seL4_MessageInfo_get_label(tag) == seL4_Fault_DebugException;
 }
 #endif
 
-static inline seL4_Bool
+LIBSEL4_INLINE_FUNC seL4_Bool
 seL4_isVMFault_tag(seL4_MessageInfo_t tag)
 {
     return seL4_MessageInfo_get_label(tag) == seL4_Fault_VMFault;
 }
 
-static inline seL4_Bool
+LIBSEL4_INLINE_FUNC seL4_Bool
 seL4_isUnknownSyscall_tag(seL4_MessageInfo_t tag)
 {
     return seL4_MessageInfo_get_label(tag) == seL4_Fault_UnknownSyscall;
 }
 
-static inline seL4_Bool
+LIBSEL4_INLINE_FUNC seL4_Bool
 seL4_isUserException_tag(seL4_MessageInfo_t tag)
 {
     return seL4_MessageInfo_get_label(tag) == seL4_Fault_UserException;
 }
 
-static inline seL4_Bool
+LIBSEL4_INLINE_FUNC seL4_Bool
 seL4_isNullFault_tag(seL4_MessageInfo_t tag)
 {
     return seL4_MessageInfo_get_label(tag) == seL4_Fault_NullFault;
 }
 
-static inline seL4_Bool
+LIBSEL4_INLINE_FUNC seL4_Bool
 seL4_isCapFault_tag(seL4_MessageInfo_t tag)
 {
     return seL4_MessageInfo_get_label(tag) == seL4_Fault_CapFault;

--- a/libsel4/include/sel4/macros.h
+++ b/libsel4/include/sel4/macros.h
@@ -33,8 +33,15 @@
 
 #ifdef CONFIG_LIB_SEL4_INLINE_INVOCATIONS
 #define LIBSEL4_INLINE static inline
+#define LIBSEL4_INLINE_FUNC static inline
+
+#elif CONFIG_LIB_SEL4_PUBLIC_SYMBOLS
+#define LIBSEL4_INLINE __attribute__((unused)) __attribute__((weak))
+#define LIBSEL4_INLINE_FUNC __attribute__((unused)) __attribute__((weak))
+
 #else
 #define LIBSEL4_INLINE __attribute__((noinline)) __attribute__((unused)) __attribute__((weak))
+#define LIBSEL4_INLINE_FUNC static inline
 #endif
 
 #define SEL4_DEPRECATED(x) __attribute__((deprecated(x)))

--- a/libsel4/include/sel4/syscalls.h
+++ b/libsel4/include/sel4/syscalls.h
@@ -31,7 +31,7 @@
  * @param[in] dest The capability to be invoked.
  * @param[in] msgInfo The messageinfo structure for the IPC.
  */
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_Send(seL4_CPtr dest, seL4_MessageInfo_t msgInfo);
 
 /**
@@ -55,7 +55,7 @@ seL4_Send(seL4_CPtr dest, seL4_MessageInfo_t msgInfo);
  * as described in <autoref sec="messageinfo"/>
  * @endxmlonly
  */
-static inline seL4_MessageInfo_t
+LIBSEL4_INLINE_FUNC seL4_MessageInfo_t
 seL4_Recv(seL4_CPtr src, seL4_Word* sender);
 
 /**
@@ -74,7 +74,7 @@ seL4_Recv(seL4_CPtr src, seL4_Word* sender);
  * as described in <autoref sec="messageinfo"/>
  * @endxmlonly
  */
-static inline seL4_MessageInfo_t
+LIBSEL4_INLINE_FUNC seL4_MessageInfo_t
 seL4_Call(seL4_CPtr dest, seL4_MessageInfo_t msgInfo);
 
 /**
@@ -88,7 +88,7 @@ seL4_Call(seL4_CPtr dest, seL4_MessageInfo_t msgInfo);
  *
  * @param[in] msgInfo The messageinfo structure for the IPC.
  */
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_Reply(seL4_MessageInfo_t msgInfo);
 
 /**
@@ -102,7 +102,7 @@ seL4_Reply(seL4_MessageInfo_t msgInfo);
  * @param[in] dest The capability to be invoked.
  * @param[in] msgInfo The messageinfo structure for the IPC.
  */
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_NBSend(seL4_CPtr dest, seL4_MessageInfo_t msgInfo);
 
 /**
@@ -127,7 +127,7 @@ seL4_NBSend(seL4_CPtr dest, seL4_MessageInfo_t msgInfo);
  * as described in <autoref sec="messageinfo"/>
  * @endxmlonly
  */
-static inline seL4_MessageInfo_t
+LIBSEL4_INLINE_FUNC seL4_MessageInfo_t
 seL4_ReplyRecv(seL4_CPtr dest, seL4_MessageInfo_t msgInfo, seL4_Word *sender);
 
 /**
@@ -152,7 +152,7 @@ seL4_ReplyRecv(seL4_CPtr dest, seL4_MessageInfo_t msgInfo, seL4_Word *sender);
  * as described in <autoref sec="messageinfo"/>
  * @endxmlonly
  */
-static inline seL4_MessageInfo_t
+LIBSEL4_INLINE_FUNC seL4_MessageInfo_t
 seL4_NBRecv(seL4_CPtr src, seL4_Word* sender);
 
 /**
@@ -163,7 +163,7 @@ seL4_NBRecv(seL4_CPtr src, seL4_Word* sender);
  * See <autoref sec="sys_yield"/>
  * @endxmlonly
  */
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_Yield(void);
 
 /**
@@ -180,7 +180,7 @@ seL4_Yield(void);
  *
  * @param[in] dest The capability to be invoked.
  */
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_Signal(seL4_CPtr dest);
 
 /**
@@ -202,7 +202,7 @@ seL4_Signal(seL4_CPtr dest);
  *               notification object that was signalled.
  *               This parameter is ignored if `NULL`.
  */
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_Wait(seL4_CPtr src, seL4_Word *sender);
 
 /**
@@ -225,7 +225,7 @@ seL4_Wait(seL4_CPtr src, seL4_Word *sender);
  *               notification object that was signalled.
  *               This parameter is ignored if `NULL`.
  */
-static inline seL4_MessageInfo_t
+LIBSEL4_INLINE_FUNC seL4_MessageInfo_t
 seL4_Poll(seL4_CPtr src, seL4_Word *sender);
 
 /** @} */

--- a/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/faults.h
+++ b/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/faults.h
@@ -15,7 +15,7 @@
 #include <sel4/faults.h>
 #include <sel4/sel4_arch/constants.h>
 
-static inline seL4_Fault_t
+LIBSEL4_INLINE_FUNC seL4_Fault_t
 seL4_getArchFault(seL4_MessageInfo_t tag)
 {
     switch (seL4_MessageInfo_get_label(tag)) {
@@ -57,13 +57,13 @@ seL4_getArchFault(seL4_MessageInfo_t tag)
 }
 
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
-static inline seL4_Bool
+LIBSEL4_INLINE_FUNC seL4_Bool
 seL4_isVGICMaintenance_tag(seL4_MessageInfo_t tag)
 {
     return seL4_MessageInfo_get_label(tag) == seL4_Fault_VGICMaintenance;
 }
 
-static inline seL4_Bool
+LIBSEL4_INLINE_FUNC seL4_Bool
 seL4_isVCPUFault_tag(seL4_MessageInfo_t tag)
 {
     return seL4_MessageInfo_get_label(tag) == seL4_Fault_VCPUFault;

--- a/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/mapping.h
+++ b/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/mapping.h
@@ -23,7 +23,7 @@
 #define SEL4_MAPPING_LOOKUP_NO_PT 20
 #endif
 
-static inline seL4_Word seL4_MappingFailedLookupLevel()
+LIBSEL4_INLINE_FUNC seL4_Word seL4_MappingFailedLookupLevel()
 {
     return seL4_GetMR(SEL4_MAPPING_LOOKUP_LEVEL);
 }

--- a/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/syscalls.h
+++ b/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/syscalls.h
@@ -69,7 +69,8 @@ arm_sys_send(seL4_Word sys, seL4_Word dest, seL4_Word info_arg, seL4_Word mr0, s
     );
 }
 
-static inline void arm_sys_reply(seL4_Word sys, seL4_Word info_arg, seL4_Word mr0, seL4_Word mr1, seL4_Word mr2, seL4_Word mr3)
+static inline void
+arm_sys_reply(seL4_Word sys, seL4_Word info_arg, seL4_Word mr0, seL4_Word mr1, seL4_Word mr2, seL4_Word mr3)
 {
     register seL4_Word info asm("r1") = info_arg;
 
@@ -173,13 +174,13 @@ arm_sys_null(seL4_Word sys)
     );
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_Send(seL4_CPtr dest, seL4_MessageInfo_t msgInfo)
 {
     arm_sys_send(seL4_SysSend, dest, msgInfo.words[0], seL4_GetMR(0), seL4_GetMR(1), seL4_GetMR(2), seL4_GetMR(3));
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_SendWithMRs(seL4_CPtr dest, seL4_MessageInfo_t msgInfo,
                  seL4_Word *mr0, seL4_Word *mr1, seL4_Word *mr2, seL4_Word *mr3)
 {
@@ -191,13 +192,13 @@ seL4_SendWithMRs(seL4_CPtr dest, seL4_MessageInfo_t msgInfo,
                 );
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_NBSend(seL4_CPtr dest, seL4_MessageInfo_t msgInfo)
 {
     arm_sys_send(seL4_SysNBSend, dest, msgInfo.words[0], seL4_GetMR(0), seL4_GetMR(1), seL4_GetMR(2), seL4_GetMR(3));
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_NBSendWithMRs(seL4_CPtr dest, seL4_MessageInfo_t msgInfo,
                    seL4_Word *mr0, seL4_Word *mr1, seL4_Word *mr2, seL4_Word *mr3)
 {
@@ -209,13 +210,13 @@ seL4_NBSendWithMRs(seL4_CPtr dest, seL4_MessageInfo_t msgInfo,
                 );
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_Reply(seL4_MessageInfo_t msgInfo)
 {
     arm_sys_reply(seL4_SysReply, msgInfo.words[0], seL4_GetMR(0), seL4_GetMR(1), seL4_GetMR(2), seL4_GetMR(3));
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_ReplyWithMRs(seL4_MessageInfo_t msgInfo,
                   seL4_Word *mr0, seL4_Word *mr1, seL4_Word *mr2, seL4_Word *mr3)
 {
@@ -227,13 +228,13 @@ seL4_ReplyWithMRs(seL4_MessageInfo_t msgInfo,
                  );
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_Signal(seL4_CPtr dest)
 {
     arm_sys_send_null(seL4_SysSend, dest, seL4_MessageInfo_new(0, 0, 0, 0).words[0]);
 }
 
-static inline seL4_MessageInfo_t
+LIBSEL4_INLINE_FUNC seL4_MessageInfo_t
 seL4_Recv(seL4_CPtr src, seL4_Word* sender)
 {
     seL4_MessageInfo_t info;
@@ -257,7 +258,7 @@ seL4_Recv(seL4_CPtr src, seL4_Word* sender)
     return info;
 }
 
-static inline seL4_MessageInfo_t
+LIBSEL4_INLINE_FUNC seL4_MessageInfo_t
 seL4_RecvWithMRs(seL4_CPtr src, seL4_Word* sender,
                  seL4_Word *mr0, seL4_Word *mr1, seL4_Word *mr2, seL4_Word *mr3)
 {
@@ -291,7 +292,7 @@ seL4_RecvWithMRs(seL4_CPtr src, seL4_Word* sender,
     return info;
 }
 
-static inline seL4_MessageInfo_t
+LIBSEL4_INLINE_FUNC seL4_MessageInfo_t
 seL4_NBRecv(seL4_CPtr src, seL4_Word* sender)
 {
     seL4_MessageInfo_t info;
@@ -315,7 +316,7 @@ seL4_NBRecv(seL4_CPtr src, seL4_Word* sender)
     return info;
 }
 
-static inline seL4_MessageInfo_t
+LIBSEL4_INLINE_FUNC seL4_MessageInfo_t
 seL4_Call(seL4_CPtr dest, seL4_MessageInfo_t msgInfo)
 {
     seL4_MessageInfo_t info;
@@ -335,7 +336,7 @@ seL4_Call(seL4_CPtr dest, seL4_MessageInfo_t msgInfo)
     return info;
 }
 
-static inline seL4_MessageInfo_t
+LIBSEL4_INLINE_FUNC seL4_MessageInfo_t
 seL4_CallWithMRs(seL4_CPtr dest, seL4_MessageInfo_t msgInfo,
                  seL4_Word *mr0, seL4_Word *mr1, seL4_Word *mr2, seL4_Word *mr3)
 {
@@ -378,7 +379,7 @@ seL4_CallWithMRs(seL4_CPtr dest, seL4_MessageInfo_t msgInfo,
     return info;
 }
 
-static inline seL4_MessageInfo_t
+LIBSEL4_INLINE_FUNC seL4_MessageInfo_t
 seL4_ReplyRecv(seL4_CPtr src, seL4_MessageInfo_t msgInfo, seL4_Word *sender)
 {
     seL4_MessageInfo_t info;
@@ -410,7 +411,7 @@ seL4_ReplyRecv(seL4_CPtr src, seL4_MessageInfo_t msgInfo, seL4_Word *sender)
     return info;
 }
 
-static inline seL4_MessageInfo_t
+LIBSEL4_INLINE_FUNC seL4_MessageInfo_t
 seL4_ReplyRecvWithMRs(seL4_CPtr src, seL4_MessageInfo_t msgInfo, seL4_Word *sender,
                       seL4_Word *mr0, seL4_Word *mr1, seL4_Word *mr2, seL4_Word *mr3)
 {
@@ -458,7 +459,7 @@ seL4_ReplyRecvWithMRs(seL4_CPtr src, seL4_MessageInfo_t msgInfo, seL4_Word *send
     return info;
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_Yield(void)
 {
     arm_sys_null(seL4_SysYield);
@@ -466,7 +467,7 @@ seL4_Yield(void)
 }
 
 #ifdef CONFIG_DEBUG_BUILD
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_DebugPutChar(char c)
 {
     seL4_Word unused0 = 0;
@@ -479,20 +480,20 @@ seL4_DebugPutChar(char c)
     arm_sys_send_recv(seL4_SysDebugPutChar, c, &unused0, 0, &unused1, &unused2, &unused3, &unused4, &unused5);
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_DebugHalt(void)
 {
     arm_sys_null(seL4_SysDebugHalt);
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_DebugSnapshot(void)
 {
     arm_sys_null(seL4_SysDebugSnapshot);
     asm volatile("" ::: "memory");
 }
 
-static inline seL4_Uint32
+LIBSEL4_INLINE_FUNC seL4_Uint32
 seL4_DebugCapIdentify(seL4_CPtr cap)
 {
     seL4_Word unused0 = 0;
@@ -506,7 +507,7 @@ seL4_DebugCapIdentify(seL4_CPtr cap)
 }
 
 char *strcpy(char *, const char *);
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_DebugNameThread(seL4_CPtr tcb, const char *name)
 {
     strcpy((char*)seL4_GetIPCBuffer()->msg, name);
@@ -523,7 +524,7 @@ seL4_DebugNameThread(seL4_CPtr tcb, const char *name)
 #endif
 
 #ifdef SEL4_DANGEROUS_CODE_INJECTION_KERNEL
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_DebugRun(void (* userfn) (void *), void* userarg)
 {
     arm_sys_send_null(seL4_SysDebugRun, (seL4_Word)userfn, (seL4_Word)userarg);
@@ -533,7 +534,7 @@ seL4_DebugRun(void (* userfn) (void *), void* userarg)
 
 #ifdef CONFIG_ENABLE_BENCHMARKS
 /* set the log index back to 0 */
-static inline seL4_Error
+LIBSEL4_INLINE_FUNC seL4_Error
 seL4_BenchmarkResetLog(void)
 {
     seL4_Word unused0 = 0;
@@ -548,14 +549,14 @@ seL4_BenchmarkResetLog(void)
     return (seL4_Error) ret;
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_BenchmarkFinalizeLog(void)
 {
     arm_sys_null(seL4_SysBenchmarkFinalizeLog);
     asm volatile("" ::: "memory");
 }
 
-static inline seL4_Error
+LIBSEL4_INLINE_FUNC seL4_Error
 seL4_BenchmarkSetLogBuffer(seL4_Word frame_cptr)
 {
     seL4_Word unused0 = 0;
@@ -569,14 +570,14 @@ seL4_BenchmarkSetLogBuffer(seL4_Word frame_cptr)
     return (seL4_Error) frame_cptr;
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_BenchmarkNullSyscall(void)
 {
     arm_sys_null(seL4_SysBenchmarkNullSyscall);
     asm volatile("" ::: "memory");
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_BenchmarkFlushCaches(void)
 {
     arm_sys_null(seL4_SysBenchmarkFlushCaches);
@@ -584,7 +585,7 @@ seL4_BenchmarkFlushCaches(void)
 }
 
 #ifdef CONFIG_BENCHMARK_TRACK_UTILISATION
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_BenchmarkGetThreadUtilisation(seL4_Word tcp_cptr)
 {
     seL4_Word unused0 = 0;
@@ -597,7 +598,7 @@ seL4_BenchmarkGetThreadUtilisation(seL4_Word tcp_cptr)
     arm_sys_send_recv(seL4_BenchmarkGetThreadUtilization, tcb_cptr, &unused0, 0, &unused1, &unused2, &unused3, &unused4, &unused5);
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_BenchmarkResetThreadUtilisation(seL4_Word tcp_cptr)
 {
     seL4_Word unused0 = 0;

--- a/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/faults.h
+++ b/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/faults.h
@@ -15,7 +15,7 @@
 #include <sel4/faults.h>
 #include <sel4/sel4_arch/constants.h>
 
-static inline seL4_Fault_t
+LIBSEL4_INLINE_FUNC seL4_Fault_t
 seL4_getArchFault(seL4_MessageInfo_t tag)
 {
     switch (seL4_MessageInfo_get_label(tag)) {

--- a/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/mapping.h
+++ b/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/mapping.h
@@ -21,7 +21,7 @@
 #define SEL4_MAPPING_LOOKUP_NO_PT 22
 #endif
 
-static inline seL4_Word seL4_MappingFailedLookupLevel()
+LIBSEL4_INLINE_FUNC seL4_Word seL4_MappingFailedLookupLevel()
 {
     return seL4_GetMR(SEL4_MAPPING_LOOKUP_LEVEL);
 }

--- a/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/syscalls.h
+++ b/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/syscalls.h
@@ -290,52 +290,52 @@ x86_sys_null(seL4_Word sys)
 
 #endif /* defined(__pic__) */
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_Send(seL4_CPtr dest, seL4_MessageInfo_t msgInfo)
 {
     x86_sys_send(seL4_SysSend, dest, msgInfo.words[0], seL4_GetMR(0), seL4_GetMR(1));
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_SendWithMRs(seL4_CPtr dest, seL4_MessageInfo_t msgInfo,
                  seL4_Word *mr0, seL4_Word *mr1)
 {
     x86_sys_send(seL4_SysSend, dest, msgInfo.words[0], mr0 != seL4_Null ? *mr0 : 0, mr1 != seL4_Null ? *mr1 : 0);
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_NBSend(seL4_CPtr dest, seL4_MessageInfo_t msgInfo)
 {
     x86_sys_send(seL4_SysNBSend, dest, msgInfo.words[0], seL4_GetMR(0), seL4_GetMR(1));
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_NBSendWithMRs(seL4_CPtr dest, seL4_MessageInfo_t msgInfo,
                    seL4_Word *mr0, seL4_Word *mr1)
 {
     x86_sys_send(seL4_SysNBSend, dest, msgInfo.words[0], mr0 != seL4_Null ? *mr0 : 0, mr1 != seL4_Null ? *mr1 : 0);
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_Reply(seL4_MessageInfo_t msgInfo)
 {
     x86_sys_reply(seL4_SysReply, msgInfo.words[0], seL4_GetMR(0), seL4_GetMR(1));
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_ReplyWithMRs(seL4_MessageInfo_t msgInfo,
                   seL4_Word *mr0, seL4_Word *mr1)
 {
     x86_sys_reply(seL4_SysReply, msgInfo.words[0], mr0 != seL4_Null ? *mr0 : 0, mr1 != seL4_Null ? *mr1 : 0);
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_Signal(seL4_CPtr dest)
 {
     x86_sys_send_null(seL4_SysSend, dest, seL4_MessageInfo_new(0, 0, 0, 0).words[0]);
 }
 
-static inline seL4_MessageInfo_t
+LIBSEL4_INLINE_FUNC seL4_MessageInfo_t
 seL4_Recv(seL4_CPtr src, seL4_Word* sender)
 {
     seL4_MessageInfo_t info;
@@ -355,7 +355,7 @@ seL4_Recv(seL4_CPtr src, seL4_Word* sender)
     return info;
 }
 
-static inline seL4_MessageInfo_t
+LIBSEL4_INLINE_FUNC seL4_MessageInfo_t
 seL4_RecvWithMRs(seL4_CPtr src, seL4_Word* sender,
                  seL4_Word *mr0, seL4_Word *mr1)
 {
@@ -380,7 +380,7 @@ seL4_RecvWithMRs(seL4_CPtr src, seL4_Word* sender,
     return info;
 }
 
-static inline seL4_MessageInfo_t
+LIBSEL4_INLINE_FUNC seL4_MessageInfo_t
 seL4_NBRecv(seL4_CPtr src, seL4_Word* sender)
 {
     seL4_MessageInfo_t info;
@@ -400,7 +400,7 @@ seL4_NBRecv(seL4_CPtr src, seL4_Word* sender)
     return info;
 }
 
-static inline seL4_MessageInfo_t
+LIBSEL4_INLINE_FUNC seL4_MessageInfo_t
 seL4_Call(seL4_CPtr dest, seL4_MessageInfo_t msgInfo)
 {
     seL4_MessageInfo_t info;
@@ -415,7 +415,7 @@ seL4_Call(seL4_CPtr dest, seL4_MessageInfo_t msgInfo)
     return info;
 }
 
-static inline seL4_MessageInfo_t
+LIBSEL4_INLINE_FUNC seL4_MessageInfo_t
 seL4_CallWithMRs(seL4_CPtr dest, seL4_MessageInfo_t msgInfo,
                  seL4_Word *mr0, seL4_Word *mr1)
 {
@@ -442,7 +442,7 @@ seL4_CallWithMRs(seL4_CPtr dest, seL4_MessageInfo_t msgInfo,
     return info;
 }
 
-static inline seL4_MessageInfo_t
+LIBSEL4_INLINE_FUNC seL4_MessageInfo_t
 seL4_ReplyRecv(seL4_CPtr dest, seL4_MessageInfo_t msgInfo, seL4_Word *sender)
 {
     seL4_MessageInfo_t info;
@@ -462,7 +462,7 @@ seL4_ReplyRecv(seL4_CPtr dest, seL4_MessageInfo_t msgInfo, seL4_Word *sender)
     return info;
 }
 
-static inline seL4_MessageInfo_t
+LIBSEL4_INLINE_FUNC seL4_MessageInfo_t
 seL4_ReplyRecvWithMRs(seL4_CPtr dest, seL4_MessageInfo_t msgInfo, seL4_Word *sender,
                       seL4_Word *mr0, seL4_Word *mr1)
 {
@@ -494,7 +494,7 @@ seL4_ReplyRecvWithMRs(seL4_CPtr dest, seL4_MessageInfo_t msgInfo, seL4_Word *sen
     return info;
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_Yield(void)
 {
     x86_sys_null(seL4_SysYield);
@@ -502,7 +502,7 @@ seL4_Yield(void)
 }
 
 #ifdef CONFIG_VTX
-static inline seL4_Word
+LIBSEL4_INLINE_FUNC seL4_Word
 seL4_VMEnter(seL4_CPtr vcpu, seL4_Word *sender)
 {
     seL4_Word fault;
@@ -522,7 +522,7 @@ seL4_VMEnter(seL4_CPtr vcpu, seL4_Word *sender)
 #endif
 
 #if defined(CONFIG_DEBUG_BUILD)
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_DebugPutChar(char c)
 {
     seL4_Word unused0 = 0;
@@ -535,7 +535,7 @@ seL4_DebugPutChar(char c)
 #endif
 
 #ifdef CONFIG_DEBUG_BUILD
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_DebugHalt(void)
 {
     x86_sys_null(seL4_SysDebugHalt);
@@ -544,7 +544,7 @@ seL4_DebugHalt(void)
 #endif
 
 #if defined(CONFIG_DEBUG_BUILD)
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_DebugSnapshot(void)
 {
     x86_sys_null(seL4_SysDebugSnapshot);
@@ -553,7 +553,7 @@ seL4_DebugSnapshot(void)
 #endif
 
 #ifdef CONFIG_DEBUG_BUILD
-static inline seL4_Uint32
+LIBSEL4_INLINE_FUNC seL4_Uint32
 seL4_DebugCapIdentify(seL4_CPtr cap)
 {
     seL4_Word unused0 = 0;
@@ -565,7 +565,7 @@ seL4_DebugCapIdentify(seL4_CPtr cap)
 }
 
 char *strcpy(char *, const char *);
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_DebugNameThread(seL4_CPtr tcb, const char *name)
 {
     strcpy((char*)seL4_GetIPCBuffer()->msg, name);
@@ -580,7 +580,7 @@ seL4_DebugNameThread(seL4_CPtr tcb, const char *name)
 #endif
 
 #if defined(SEL4_DANGEROUS_CODE_INJECTION_KERNEL)
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_DebugRun(void (*userfn) (void *), void* userarg)
 {
     x86_sys_send_null(seL4_SysDebugRun, (seL4_Word)userfn, (seL4_Word)userarg);
@@ -589,7 +589,7 @@ seL4_DebugRun(void (*userfn) (void *), void* userarg)
 #endif
 
 #ifdef CONFIG_ENABLE_BENCHMARKS
-static inline seL4_Error
+LIBSEL4_INLINE_FUNC seL4_Error
 seL4_BenchmarkResetLog(void)
 {
     seL4_Word unused0 = 0;
@@ -603,14 +603,14 @@ seL4_BenchmarkResetLog(void)
     return (seL4_Error)ret;
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_BenchmarkFinalizeLog(void)
 {
     x86_sys_null(seL4_SysBenchmarkFinalizeLog);
     asm volatile("" :::"%esi", "%edi", "memory");
 }
 
-static inline seL4_Error
+LIBSEL4_INLINE_FUNC seL4_Error
 seL4_BenchmarkSetLogBuffer(seL4_Word frame_cptr)
 {
     seL4_Word unused0 = 0;
@@ -623,14 +623,14 @@ seL4_BenchmarkSetLogBuffer(seL4_Word frame_cptr)
 }
 
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_BenchmarkNullSyscall(void)
 {
     x86_sys_null(seL4_SysBenchmarkNullSyscall);
     asm volatile("" :::"%esi", "%edi", "memory");
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_BenchmarkFlushCaches(void)
 {
     x86_sys_null(seL4_SysBenchmarkFlushCaches);
@@ -638,7 +638,7 @@ seL4_BenchmarkFlushCaches(void)
 }
 
 #ifdef CONFIG_BENCHMARK_TRACK_UTILISATION
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_BenchmarkGetThreadUtilisation(seL4_Word tcb_cptr)
 {
     seL4_Word unused0 = 0;
@@ -649,7 +649,7 @@ seL4_BenchmarkGetThreadUtilisation(seL4_Word tcb_cptr)
     x86_sys_send_recv(seL4_SysBenchmarkGetThreadUtilisation, tcb_cptr, &unused0, 0, &unused1, &unused2, &unused3);
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_BenchmarkResetThreadUtilisation(seL4_Word tcb_cptr)
 {
     seL4_Word unused0 = 0;

--- a/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/faults.h
+++ b/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/faults.h
@@ -17,7 +17,7 @@
 #include <sel4/faults.h>
 #include <sel4/sel4_arch/constants.h>
 
-static inline seL4_Fault_t
+LIBSEL4_INLINE_FUNC seL4_Fault_t
 seL4_getArchFault(seL4_MessageInfo_t tag)
 {
     switch (seL4_MessageInfo_get_label(tag)) {

--- a/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/mapping.h
+++ b/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/mapping.h
@@ -18,7 +18,7 @@
 #define SEL4_MAPPING_LOOKUP_NO_PD 30
 #define SEL4_MAPPING_LOOKUP_NO_PDPT 39
 
-static inline seL4_Word seL4_MappingFailedLookupLevel()
+LIBSEL4_INLINE_FUNC seL4_Word seL4_MappingFailedLookupLevel()
 {
     return seL4_GetMR(SEL4_MAPPING_LOOKUP_LEVEL);
 }

--- a/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/syscalls.h
+++ b/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/syscalls.h
@@ -23,13 +23,13 @@
 #error Unknown method for kernel syscalls
 #endif
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_Send(seL4_CPtr dest, seL4_MessageInfo_t msgInfo)
 {
     x64_sys_send(seL4_SysSend, dest, msgInfo.words[0], seL4_GetMR(0), seL4_GetMR(1), seL4_GetMR(2), seL4_GetMR(3));
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_SendWithMRs(seL4_CPtr dest, seL4_MessageInfo_t msgInfo,
                  seL4_Word *mr0, seL4_Word *mr1, seL4_Word *mr2, seL4_Word *mr3)
 {
@@ -41,13 +41,13 @@ seL4_SendWithMRs(seL4_CPtr dest, seL4_MessageInfo_t msgInfo,
                 );
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_NBSend(seL4_CPtr dest, seL4_MessageInfo_t msgInfo)
 {
     x64_sys_send(seL4_SysNBSend, dest, msgInfo.words[0], seL4_GetMR(0), seL4_GetMR(1), seL4_GetMR(2), seL4_GetMR(3));
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_NBSendWithMRs(seL4_CPtr dest, seL4_MessageInfo_t msgInfo,
                    seL4_Word *mr0, seL4_Word *mr1, seL4_Word *mr2, seL4_Word *mr3)
 {
@@ -59,13 +59,13 @@ seL4_NBSendWithMRs(seL4_CPtr dest, seL4_MessageInfo_t msgInfo,
                 );
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_Reply(seL4_MessageInfo_t msgInfo)
 {
     x64_sys_reply(seL4_SysReply, msgInfo.words[0], seL4_GetMR(0), seL4_GetMR(1), seL4_GetMR(2), seL4_GetMR(3));
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_ReplyWithMRs(seL4_MessageInfo_t msgInfo,
                   seL4_Word *mr0, seL4_Word *mr1, seL4_Word *mr2, seL4_Word *mr3)
 {
@@ -77,13 +77,13 @@ seL4_ReplyWithMRs(seL4_MessageInfo_t msgInfo,
                  );
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_Signal(seL4_CPtr dest)
 {
     x64_sys_send_null(seL4_SysSend, dest, seL4_MessageInfo_new(0, 0, 0, 1).words[0]);
 }
 
-static inline seL4_MessageInfo_t
+LIBSEL4_INLINE_FUNC seL4_MessageInfo_t
 seL4_Recv(seL4_CPtr src, seL4_Word* sender)
 {
     seL4_MessageInfo_t info;
@@ -107,7 +107,7 @@ seL4_Recv(seL4_CPtr src, seL4_Word* sender)
     return info;
 }
 
-static inline seL4_MessageInfo_t
+LIBSEL4_INLINE_FUNC seL4_MessageInfo_t
 seL4_RecvWithMRs(seL4_CPtr src, seL4_Word* sender,
                  seL4_Word *mr0, seL4_Word *mr1, seL4_Word *mr2, seL4_Word *mr3)
 {
@@ -140,7 +140,7 @@ seL4_RecvWithMRs(seL4_CPtr src, seL4_Word* sender,
     return info;
 }
 
-static inline seL4_MessageInfo_t
+LIBSEL4_INLINE_FUNC seL4_MessageInfo_t
 seL4_NBRecv(seL4_CPtr src, seL4_Word* sender)
 {
     seL4_MessageInfo_t info;
@@ -164,7 +164,7 @@ seL4_NBRecv(seL4_CPtr src, seL4_Word* sender)
     return info;
 }
 
-static inline seL4_MessageInfo_t
+LIBSEL4_INLINE_FUNC seL4_MessageInfo_t
 seL4_Call(seL4_CPtr dest, seL4_MessageInfo_t msgInfo)
 {
 
@@ -184,7 +184,7 @@ seL4_Call(seL4_CPtr dest, seL4_MessageInfo_t msgInfo)
     return info;
 }
 
-static inline seL4_MessageInfo_t
+LIBSEL4_INLINE_FUNC seL4_MessageInfo_t
 seL4_CallWithMRs(seL4_CPtr dest, seL4_MessageInfo_t msgInfo,
                  seL4_Word *mr0, seL4_Word *mr1, seL4_Word *mr2, seL4_Word *mr3)
 {
@@ -225,7 +225,7 @@ seL4_CallWithMRs(seL4_CPtr dest, seL4_MessageInfo_t msgInfo,
     return info;
 }
 
-static inline seL4_MessageInfo_t
+LIBSEL4_INLINE_FUNC seL4_MessageInfo_t
 seL4_ReplyRecv(seL4_CPtr dest, seL4_MessageInfo_t msgInfo, seL4_Word *sender)
 {
     seL4_MessageInfo_t info;
@@ -249,7 +249,7 @@ seL4_ReplyRecv(seL4_CPtr dest, seL4_MessageInfo_t msgInfo, seL4_Word *sender)
     return info;
 }
 
-static inline seL4_MessageInfo_t
+LIBSEL4_INLINE_FUNC seL4_MessageInfo_t
 seL4_ReplyRecvWithMRs(seL4_CPtr dest, seL4_MessageInfo_t msgInfo, seL4_Word *sender,
                       seL4_Word *mr0, seL4_Word *mr1, seL4_Word *mr2, seL4_Word *mr3)
 {
@@ -295,7 +295,7 @@ seL4_ReplyRecvWithMRs(seL4_CPtr dest, seL4_MessageInfo_t msgInfo, seL4_Word *sen
     return info;
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_Yield(void)
 {
     x64_sys_null(seL4_SysYield);
@@ -303,7 +303,7 @@ seL4_Yield(void)
 }
 
 #if defined(SEL4_DEBUG_KERNEL)
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_DebugPutChar(char c)
 {
     seL4_Word unused0 = 0;
@@ -318,7 +318,7 @@ seL4_DebugPutChar(char c)
 #endif
 
 #ifdef SEL4_DEBUG_KERNEL
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_DebugHalt(void)
 {
     x64_sys_null(seL4_SysDebugHalt);
@@ -327,7 +327,7 @@ seL4_DebugHalt(void)
 #endif
 
 #if defined(SEL4_DEBUG_KERNEL)
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_DebugSnapshot(void)
 {
     x64_sys_null(seL4_SysDebugSnapshot);
@@ -336,7 +336,7 @@ seL4_DebugSnapshot(void)
 #endif
 
 #ifdef SEL4_DEBUG_KERNEL
-static inline seL4_Uint32
+LIBSEL4_INLINE_FUNC seL4_Uint32
 seL4_DebugCapIdentify(seL4_CPtr cap)
 {
     seL4_Word unused0 = 0;
@@ -352,7 +352,7 @@ seL4_DebugCapIdentify(seL4_CPtr cap)
 
 #ifdef SEL4_DEBUG_KERNEL
 char *strcpy(char *, const char *);
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_DebugNameThread(seL4_CPtr tcb, const char *name)
 {
 
@@ -370,7 +370,7 @@ seL4_DebugNameThread(seL4_CPtr tcb, const char *name)
 #endif
 
 #if defined(SEL4_DANGEROUS_CODE_INJECTION_KERNEL)
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_DebugRun(void (*userfn) (void *), void* userarg)
 {
     x64_sys_send_null(seL4_SysDebugRun, (seL4_Word)userfn, (seL4_Word)userarg);
@@ -379,7 +379,7 @@ seL4_DebugRun(void (*userfn) (void *), void* userarg)
 #endif
 
 #if CONFIG_ENABLE_BENCHMARKS
-static inline seL4_Error
+LIBSEL4_INLINE_FUNC seL4_Error
 seL4_BenchmarkResetLog(void)
 {
     seL4_Word unused0 = 0;
@@ -395,14 +395,14 @@ seL4_BenchmarkResetLog(void)
     return (seL4_Error)ret;
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_BenchmarkFinalizeLog(void)
 {
     x64_sys_null(seL4_SysBenchmarkFinalizeLog);
     asm volatile("" ::: "memory");
 }
 
-static inline seL4_Error
+LIBSEL4_INLINE_FUNC seL4_Error
 seL4_BenchmarkSetLogBuffer(seL4_Word frame_cptr)
 {
     seL4_Word unused0 = 0;
@@ -416,7 +416,7 @@ seL4_BenchmarkSetLogBuffer(seL4_Word frame_cptr)
     return (seL4_Error) frame_cptr;
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_BenchmarkNullSyscall(void)
 {
     x64_sys_null(seL4_SysBenchmarkNullSyscall);
@@ -424,7 +424,7 @@ seL4_BenchmarkNullSyscall(void)
 }
 
 #ifdef CONFIG_BENCHMARK_TRACK_UTILISATION
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_BenchmarkGetThreadUtilisation(seL4_Word tcb_cptr)
 {
     seL4_Word unused0 = 0;
@@ -437,7 +437,7 @@ seL4_BenchmarkGetThreadUtilisation(seL4_Word tcb_cptr)
     x64_sys_send_recv(seL4_SysBenchmarkGetThreadUtilisation, tcb_cptr, &unused0, 0, &unused1, &unused2, &unused3, &unused4, &unused5);
 }
 
-static inline void
+LIBSEL4_INLINE_FUNC void
 seL4_BenchmarkResetThreadUtilisation(seL4_Word tcb_cptr)
 {
     seL4_Word unused0 = 0;

--- a/tools/bitfield_gen.py
+++ b/tools/bitfield_gen.py
@@ -48,6 +48,11 @@ ASSERTS = {
     'libsel4': 'seL4_DebugAssert'
 }
 
+INLINE = {
+    'sel4': 'static inline',
+    'libsel4': 'LIBSEL4_INLINE_FUNC'
+}
+
 TYPES = {
     "sel4": {
         8:  "uint8_t",
@@ -218,7 +223,7 @@ typedef_template = \
 typedef struct %(name)s %(name)s_t;"""
 
 generator_template = \
-"""static inline %(block)s_t CONST
+"""%(inline)s %(block)s_t CONST
 %(block)s_new(%(args)s) {
     %(block)s_t %(block)s;
 
@@ -230,7 +235,7 @@ generator_template = \
 }"""
 
 ptr_generator_template = \
-"""static inline void
+"""%(inline)s void
 %(block)s_ptr_new(%(args)s) {
 %(word_inits)s
 
@@ -238,7 +243,7 @@ ptr_generator_template = \
 }"""
 
 reader_template = \
-"""static inline %(type)s CONST
+"""%(inline)s %(type)s CONST
 %(block)s_get_%(field)s(%(block)s_t %(block)s) {
     %(type)s ret;
     ret = (%(block)s.words[%(index)d] & 0x%(mask)x%(suf)s) %(r_shift_op)s %(shift)d;
@@ -250,7 +255,7 @@ reader_template = \
 }"""
 
 ptr_reader_template = \
-"""static inline %(type)s PURE
+"""%(inline)s %(type)s PURE
 %(block)s_ptr_get_%(field)s(%(block)s_t *%(block)s_ptr) {
     %(type)s ret;
     ret = (%(block)s_ptr->words[%(index)d] & 0x%(mask)x%(suf)s) """ \
@@ -263,7 +268,7 @@ ptr_reader_template = \
 }"""
 
 writer_template = \
-"""static inline %(block)s_t CONST
+"""%(inline)s %(block)s_t CONST
 %(block)s_set_%(field)s(%(block)s_t %(block)s, %(type)s v) {
     /* fail if user has passed bits that we will override */
     %(assert)s((((~0x%(mask)x %(r_shift_op)s %(shift)d ) | 0x%(high_bits)x) & v) == ((%(sign_extend)d && (v & (1%(suf)s << (%(extend_bit)d)))) ? 0x%(high_bits)x : 0));
@@ -273,7 +278,7 @@ writer_template = \
 }"""
 
 ptr_writer_template = \
-"""static inline void
+"""%(inline)s void
 %(block)s_ptr_set_%(field)s(%(block)s_t *%(block)s_ptr, %(type)s v) {
     /* fail if user has passed bits that we will override */
     %(assert)s((((~0x%(mask)x %(r_shift_op)s %(shift)d) | 0x%(high_bits)x) & v) == ((%(sign_extend)d && (v & (1%(suf)s << (%(extend_bit)d)))) ? 0x%(high_bits)x : 0));
@@ -283,7 +288,7 @@ ptr_writer_template = \
 }"""
 
 union_generator_template = \
-"""static inline %(union)s_t CONST
+"""%(inline)s %(union)s_t CONST
 %(union)s_%(block)s_new(%(args)s) {
     %(union)s_t %(union)s;
 
@@ -295,7 +300,7 @@ union_generator_template = \
 }"""
 
 ptr_union_generator_template = \
-"""static inline void
+"""%(inline)s void
 %(union)s_%(block)s_ptr_new(%(args)s) {
 %(word_inits)s
 
@@ -303,7 +308,7 @@ ptr_union_generator_template = \
 }"""
 
 union_reader_template = \
-"""static inline %(type)s CONST
+"""%(inline)s %(type)s CONST
 %(union)s_%(block)s_get_%(field)s(%(union)s_t %(union)s) {
     %(type)s ret;
     %(assert)s(((%(union)s.words[%(tagindex)d] >> %(tagshift)d) & 0x%(tagmask)x) ==
@@ -318,7 +323,7 @@ union_reader_template = \
 }"""
 
 ptr_union_reader_template = \
-"""static inline %(type)s PURE
+"""%(inline)s %(type)s PURE
 %(union)s_%(block)s_ptr_get_%(field)s(%(union)s_t *%(union)s_ptr) {
     %(type)s ret;
     %(assert)s(((%(union)s_ptr->words[%(tagindex)d] >> """ \
@@ -335,7 +340,7 @@ ptr_union_reader_template = \
 }"""
 
 union_writer_template = \
-"""static inline %(union)s_t CONST
+"""%(inline)s %(union)s_t CONST
 %(union)s_%(block)s_set_%(field)s(%(union)s_t %(union)s, %(type)s v) {
     %(assert)s(((%(union)s.words[%(tagindex)d] >> %(tagshift)d) & 0x%(tagmask)x) ==
            %(union)s_%(block)s);
@@ -348,7 +353,7 @@ union_writer_template = \
 }"""
 
 ptr_union_writer_template = \
-"""static inline void
+"""%(inline)s void
 %(union)s_%(block)s_ptr_set_%(field)s(%(union)s_t *%(union)s_ptr,
                                       %(type)s v) {
     %(assert)s(((%(union)s_ptr->words[%(tagindex)d] >> """ \
@@ -364,7 +369,7 @@ ptr_union_writer_template = \
 }"""
 
 tag_reader_header_template = \
-"""static inline %(type)s CONST
+"""%(inline)s %(type)s CONST
 %(union)s_get_%(tagname)s(%(union)s_t %(union)s) {
 """
 
@@ -381,7 +386,7 @@ tag_reader_footer_template = \
 }"""
 
 tag_eq_reader_header_template = \
-"""static inline int CONST
+"""%(inline)s int CONST
 %(union)s_%(tagname)s_equals(%(union)s_t %(union)s, %(type)s %(union)s_type_tag) {
 """
 
@@ -398,7 +403,7 @@ tag_eq_reader_footer_template = \
 }"""
 
 ptr_tag_reader_header_template = \
-"""static inline %(type)s PURE
+"""%(inline)s %(type)s PURE
 %(union)s_ptr_get_%(tagname)s(%(union)s_t *%(union)s_ptr) {
 """
 
@@ -415,7 +420,7 @@ ptr_tag_reader_footer_template = \
 }"""
 
 tag_writer_template = \
-"""static inline %(union)s_t CONST
+"""%(inline)s %(union)s_t CONST
 %(union)s_set_%(tagname)s(%(union)s_t %(union)s, %(type)s v) {
     /* fail if user has passed bits that we will override */
     %(assert)s((((~0x%(mask)x%(suf)s %(r_shift_op)s %(shift)d) | 0x%(high_bits)x) & v) == ((%(sign_extend)d && (v & (1%(suf)s << (%(extend_bit)d)))) ? 0x%(high_bits)x : 0));
@@ -426,7 +431,7 @@ tag_writer_template = \
 }"""
 
 ptr_tag_writer_template = \
-"""static inline void
+"""%(inline)s void
 %(union)s_ptr_set_%(tagname)s(%(union)s_t *%(union)s_ptr, %(type)s v) {
     /* fail if user has passed bits that we will override */
     %(assert)s((((~0x%(mask)x%(suf)s %(r_shift_op)s %(shift)d) | 0x%(high_bits)x) & v) == ((%(sign_extend)d && (v & (1%(suf)s << (%(extend_bit)d)))) ? 0x%(high_bits)x : 0));
@@ -1681,6 +1686,7 @@ class TaggedUnion:
         print(file=output)
 
         subs = {\
+            'inline': INLINE[options.environment], \
             'union': self.name, \
             'type':  TYPES[options.environment][self.union_base], \
             'tagname': self.tagname, \
@@ -1812,14 +1818,16 @@ class TaggedUnion:
                         (self.name, index, f_value, shift_op, shift))
 
             generator = union_generator_template % \
-                {"block":        name, \
+                {"inline":       INLINE[options.environment], \
+                 "block":        name, \
                  "union":        self.name, \
                  "args":         args, \
                  "word_inits":   '\n'.join(word_inits), \
                  "field_inits":  '\n'.join(field_inits)}
 
             ptr_generator = ptr_union_generator_template % \
-                {"block":        name, \
+                {"inline":       INLINE[options.environment], \
+                 "block":        name, \
                  "union":        self.name, \
                  "args":         ptr_args, \
                  "word_inits":   '\n'.join(ptr_word_inits), \
@@ -1857,6 +1865,7 @@ class TaggedUnion:
                 mask = ((1 << size) - 1) << (offset % self.base)
 
                 subs = {\
+                    "inline": INLINE[options.environment], \
                     "block": ref.name, \
                     "field": field, \
                     "type": TYPES[options.environment][ref.base], \
@@ -2429,13 +2438,15 @@ class Block:
                     (self.name, index, field, shift_op, shift))
 
         generator = generator_template % \
-            {"block":        self.name, \
+            {"inline":       INLINE[options.environment], \
+             "block":        self.name, \
              "args":         args, \
              "word_inits":   '\n'.join(word_inits), \
              "field_inits":  '\n'.join(field_inits)}
 
         ptr_generator = ptr_generator_template % \
-            {"block":        self.name, \
+            {"inline":       INLINE[options.environment], \
+             "block":        self.name, \
              "args":         ptr_args, \
              "word_inits":   '\n'.join(ptr_word_inits), \
              "field_inits":  '\n'.join(ptr_field_inits)}
@@ -2466,6 +2477,7 @@ class Block:
             mask = ((1 << size) - 1) << (offset % self.base)
 
             subs = {\
+                "inline": INLINE[options.environment], \
                 "block": self.name, \
                 "field": field, \
                 "type": TYPES[options.environment][self.base], \


### PR DESCRIPTION
`CONFIG_LIB_SEL4_INLINE_INVOCATIONS=n` will now disable inlining for all external interfaces (except deprecated functions).