### PR TITLE
Enable SYSCALL (SCE) after entering long mode

### DIFF
--- a/src/arch/x86/64/head.S
+++ b/src/arch/x86/64/head.S
@@ -318,15 +318,16 @@ BEGIN_FUNC(common_init)
     andl $0x7fffffff, %eax
     movl %eax, %cr0
 
-#ifdef CONFIG_SYSCALL
-    call syscall_enable
-#endif
-
     call fsgsbase_enable
     /* Initialize boot PML4 and switch to long mode */
     call setup_pml4
     call enable_x64_mode
     lgdt _gdt64_ptr
+
+#ifdef CONFIG_SYSCALL
+    call syscall_enable
+#endif
+
     ret
 END_FUNC(common_init)
 


### PR DESCRIPTION
It appears to be somewhat more correct to flip SCE after entering long mode, as per other operating systems (including Linux).

c.f. [Linux 4.8's head_64.S](http://lxr.free-electrons.com/source/arch/x86/kernel/head_64.S?v=4.8#L210), which is executed in long mode.