### PR TITLE
Minor fixes from quick proof read of 4.0 manual

### DIFF
--- a/manual/parts/bootup.tex
+++ b/manual/parts/bootup.tex
@@ -38,7 +38,7 @@ The first 12 slots contain specific capabilities as listed in
       0x0 & \texttt{seL4\_CapNull}                & null \\
       0x1 & \texttt{seL4\_CapInitThreadTCB}       & initial thread's TCB \\
       0x2 & \texttt{seL4\_CapInitThreadCNode}     & initial thread's CNode \\
-      0x3 & \texttt{seL4\_CapInitThreadPD}        & initial thread's page directory \\
+      0x3 & \texttt{seL4\_CapInitThreadVSpace}    & initial thread's VSpace \\
       0x4 & \texttt{seL4\_CapIRQControl}          & global IRQ controller (see \autoref{sec:interrupts}) \\
       0x5 & \texttt{seL4\_CapASIDControl}         & global ASID controller (see \autoref{ch:vspace}) \\
       0x6 & \texttt{seL4\_CapInitThreadASIDPool}  & initial thread's ASID pool (see \autoref{ch:vspace}) \\

--- a/manual/parts/cspace.tex
+++ b/manual/parts/cspace.tex
@@ -234,7 +234,7 @@ an original capability (the ``original badged endpoint capability'')
 and supports one level of derived children like other capabilities.
 
 
-\section{Deletion, Revocation, and Recycling}
+\section{Deletion and Revocation}
 \label{s:cspace-revoke}
 
 Capabilities in seL4 can be deleted and revoked. Both methods

--- a/manual/parts/ipc.tex
+++ b/manual/parts/ipc.tex
@@ -13,7 +13,7 @@
 The seL4 microkernel provides a message-passing IPC mechanism for communication
 between threads. The same mechanism is also used for communication with
 kernel-provided services. Messages are sent by invoking a capability to a
-kernel object. Messages sent to \obj{Endpoint} are destined for other
+kernel object. Messages sent to \obj{Endpoint}s are destined for other
 threads, while messages sent to other objects are processed by the kernel. This
 chapter describes the common message format, endpoints,
 and how they can be used for communication between applications.


### PR DESCRIPTION
Notes:

- In Faults 6.2.3, IA-32 appears under the table in the PDF… not sure how to fix.

- Is there something wrong with the `_service` descriptions in 10.3.x?

- Some of the functions in the manual are `LIBSEL4_INLINE_FUNC`, some are `static inline`.

- My understanding is that a VSpace capability represents the highest level paging structure, e.g. PML4 on x86_64. If that's correct, it'd be worth mentioning it. If not, clarifying the documentation. :-)

Hmm, but oh:

```c
/* Legacy code will have assumptions on the vspace root being a Page Directory
 * type, so for now we define one to the other */
#define seL4_CapInitThreadPD seL4_CapInitThreadVSpace
```

So, there's a second commit to make the manual reflect the current init cap list, but clearly my understanding of what's going on with VSpaces and paging structures is warped.