### PR TITLE
Change PIT_HZ to 1193182

### DIFF
--- a/src/plat/pc99/machine/pit.c
+++ b/src/plat/pc99/machine/pit.c
@@ -17,7 +17,7 @@
 #define PIT_CH0  0x40
 
 /* Count frequency in Hz */
-#define PIT_HZ 1193180
+#define PIT_HZ 1193182
 
 BOOT_CODE void
 pit_init(void)


### PR DESCRIPTION
This value is taken from the Linux kernel. I've been unable to find
a canonical source specifying this value. The PIT isn't even
acknowledged to exist in the Intel SDM or AMD BKDG. There are some
numbers about the *input* to the circuit that emulates the PIT on
modern Intel PCH's, 14.31818MHz, but nothing about the output. Doing
some math on the NTSC subcarrier frequency as mentioned in the
wikipedia article arrives at 1193181.6Hz, which rounds up to
1193182.

This value influences the measured frequency of the TSC, which is
later used in the RT kernel and elsewhere for determining how to
program the deadline timer, or other time-sensitive things.