### PR TITLE
Fix bug in invocation_header_gen.py due to cf8be66

### DIFF
--- a/tools/invocation_header_gen.py
+++ b/tools/invocation_header_gen.py
@@ -85,7 +85,11 @@ enum sel4_arch_invocation_label {
 #endif
     {{endif}}
     {{endfor}}
+    {{if len(invocations) == 0}}
+    nSeL4ArchInvocationLabels = nInvocationLabels,
+    {{else}}
     nSeL4ArchInvocationLabels
+    {{endif}}
 };
 
 #endif /* __{{header_title}}_SEL4_ARCH_INVOCATION_H */
@@ -118,7 +122,11 @@ enum arch_invocation_label {
 #endif
     {{endif}}
     {{endfor}}
+    {{if len(invocations) == 0}}
+    nArchInvocationLabels = nSeL4ArchInvocationLabels,
+    {{else}}
     nArchInvocationLabels
+    {{endif}}
 };
 
 #endif /* __{{header_title}}_ARCH_INVOCATION_H */


### PR DESCRIPTION
This fixes the incorrect invocation header generation due to cf8be66 which causes `nSeL4ArchInvocationLabels` to be declared as 0 rather than `nInvocationLabels` when `seL4_arch_invocations` is an empty list (on ia32).