### PR TITLE
Remove extraneous quotes from PATH setting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ default: all
 ### Tool setup
 ############################################################
 
-PATH := "${SOURCE_ROOT}/tools:${PATH}"
+PATH := ${SOURCE_ROOT}/tools:${PATH}
 export PATH
 
 PARSER = c-parser


### PR DESCRIPTION
This causes the first (and last) component of PATH to include a quote
character. This is obviously wrong. It manifested on my system as not
being able to find mkdir or anything else in /usr/bin since that was
the last entry in my own PATH