### PR TITLE
Clang warnings

### DIFF
--- a/include/api/debug.h
+++ b/include/api/debug.h
@@ -46,9 +46,9 @@ debug_printKernelEntryReason(void)
 #endif
     case Entry_Syscall:
         printf("Syscall, number: %ld, %s\n", (long) ksKernelEntry.syscall_no, syscall_names[ksKernelEntry.syscall_no]);
-        if (ksKernelEntry.syscall_no == SysSend ||
-                ksKernelEntry.syscall_no == SysNBSend ||
-                ksKernelEntry.syscall_no == SysCall) {
+        if (ksKernelEntry.syscall_no == -SysSend ||
+                ksKernelEntry.syscall_no == -SysNBSend ||
+                ksKernelEntry.syscall_no == -SysCall) {
 
             printf("Cap type: %lu, Invocation tag: %lu\n", (unsigned long) ksKernelEntry.cap_type,
                    (unsigned long) ksKernelEntry.invocation_tag);

--- a/include/plat/pc99/plat/machine/interrupt.h
+++ b/include/plat/pc99/plat/machine/interrupt.h
@@ -110,9 +110,9 @@ handleSpuriousIRQ(void)
 }
 
 static void inline
-updateIRQState(word_t irq, x86_irq_state_t state)
+updateIRQState(irq_t irq, x86_irq_state_t state)
 {
-    assert(irq >= 0 && irq <= maxIRQ);
+    assert(irq <= maxIRQ);
     x86KSIRQState[irq] = state;
 }
 

--- a/src/plat/pc99/machine/intel-vtd.c
+++ b/src/plat/pc99/machine/intel-vtd.c
@@ -113,11 +113,6 @@ static inline uint32_t get_ivo(drhu_id_t drhu_id)
     return ((vtd_read32(drhu_id, ECAP_REG) >> 8) & IVO_MASK) * 16;
 }
 
-static inline int supports_passthrough(drhu_id_t drhu_id)
-{
-    return (vtd_read32(drhu_id, ECAP_REG) >> 6) & 1;
-}
-
 static uint32_t get_fro_offset(drhu_id_t drhu_id)
 {
     uint32_t fro_offset;


### PR DESCRIPTION
As far as I can see this does not touch any verified code.

Passes all tests in sel4test with configuration x64_simulation_debug_xml_defconfig.
Compiles all targets in the compile-all make target, except kzm_simulation_debug_xml_defconfig which fails for me without patches.