### PR TITLE
Unused functions found by clang

### DIFF
--- a/src/arch/arm/armv/armv7-a/cache.c
+++ b/src/arch/arm/armv/armv7-a/cache.c
@@ -10,11 +10,6 @@
 
 #include <arch/machine/hardware.h>
 
-static inline void invalidateByWSL(word_t wsl)
-{
-    asm volatile("mcr p15, 0, %0, c7, c6, 2" : : "r"(wsl));
-}
-
 static inline void cleanByWSL(word_t wsl)
 {
     asm volatile("mcr p15, 0, %0, c7, c10, 2" : : "r"(wsl));

--- a/src/arch/arm/machine/gic_pl390.c
+++ b/src/arch/arm/machine/gic_pl390.c
@@ -39,13 +39,6 @@ volatile struct gic_cpu_iface_map * const gic_cpuiface =
     (volatile struct gic_cpu_iface_map*)(GIC_PL390_CONTROLLER_PPTR);
 #endif /* GIC_CONTROLLER_PPTR */
 
-static inline void
-set_irq_active(irq_t irq)
-{
-    int word = irq >> 5;
-    int bit = irq & 0x1f;
-    gic_dist->active[word] = BIT(bit);
-}
 uint32_t active_irq[CONFIG_MAX_NUM_NODES] = {IRQ_NONE};
 
 BOOT_CODE static void


### PR DESCRIPTION
Clang found some unused static functions. I think this touches verified code, but removing functions that aren't used is invisible to the proof? Currently I do not know how to update the proof, so if that is needed you could ignore these patches.

make compile-all passed all targets.

All tests passed running:
make mrproper ; make zynq_simulation_debug_xml_defconfig ; make ; make simulate-zynq
