### PR TITLE
Removed unused static function set_irq_active

### DIFF
--- a/src/arch/arm/machine/gic_pl390.c
+++ b/src/arch/arm/machine/gic_pl390.c
@@ -39,13 +39,6 @@ volatile struct gic_cpu_iface_map * const gic_cpuiface =
     (volatile struct gic_cpu_iface_map*)(GIC_PL390_CONTROLLER_PPTR);
 #endif /* GIC_CONTROLLER_PPTR */
 
-static inline void
-set_irq_active(irq_t irq)
-{
-    int word = irq >> 5;
-    int bit = irq & 0x1f;
-    gic_dist->active[word] = BIT(bit);
-}
 uint32_t active_irq[CONFIG_MAX_NUM_NODES] = {IRQ_NONE};
 
 BOOT_CODE static void


### PR DESCRIPTION
Removed commit invalidateByWSL, only removing set_irq_active. Reference: https://github.com/seL4/seL4/pull/64

make compile-all passes all targets. make simulate-x86_64 passes all tests in sel4test.