### PR TITLE
Add thread name to debug info for SysDebugHalt and SysDebugSnapshot

### DIFF
--- a/src/api/syscall.c
+++ b/src/api/syscall.c
@@ -75,11 +75,13 @@ handleUnknownSyscall(word_t w)
 #endif
 #ifdef CONFIG_DEBUG_BUILD
     if (w == SysDebugHalt) {
-        printf("Debug halt syscall from user thread %p\n", NODE_STATE(ksCurThread));
+        tcb_t *tptr = NODE_STATE(ksCurThread);
+        printf("Debug halt syscall from user thread %p \"%s\"\n", tptr, tptr->tcbName);
         halt();
     }
     if (w == SysDebugSnapshot) {
-        printf("Debug snapshot syscall from user thread %p\n", NODE_STATE(ksCurThread));
+        tcb_t *tptr = NODE_STATE(ksCurThread);
+        printf("Debug snapshot syscall from user thread %p \"%s\"\n", tptr, tptr->tcbName);
         capDL();
         return EXCEPTION_NONE;
     }


### PR DESCRIPTION
This will make it easier to understand which tread that triggered these debugging syscalls. Similar to the print in kernel/src/kernel/faulthandler.c. I've run sel4test on config x64_simulation_debug_xml_defconfig with all tests passing.
```
Starting test 102: Test all tests ran
Test suite passed. 102 tests passed. 46 tests disabled.
All is well in the universe
```