### PR TITLE
Riscv32 Boot Fixes

### DIFF
--- a/include/plat/spike/plat/machine/hardware.h
+++ b/include/plat/spike/plat/machine/hardware.h
@@ -22,9 +22,15 @@
 #include <config.h>
 #include <plat_mode/machine/hardware.h>
 
+#if __riscv_xlen == 32
+/* Contain the typical location of memory */
+#define PADDR_BASE 0x80000000lu
+#else
 /* The main kernel window will start at the 0 physical address so that it can contain
  * any potential memory that may exist */
 #define PADDR_BASE 0x0lu
+#endif
+
 /* This represents the physical address that the kernel image will be linked to. This needs to
  * be on a 1gb boundary as we currently require being able to creating a mapping to this address
  * as the largest frame size */
@@ -43,7 +49,7 @@
 #define kernelBase KERNEL_BASE
 #define PPTR_TOP KERNEL_BASE
 #define PPTR_USER_TOP PPTR_BASE
-#define BASE_OFFSET PPTR_BASE
+#define BASE_OFFSET (PPTR_BASE - PADDR_BASE)
 
 #ifndef __ASSEMBLER__
 

--- a/src/arch/riscv/Kconfig
+++ b/src/arch/riscv/Kconfig
@@ -27,9 +27,3 @@ config PT_LEVELS
         Number of page tables levels for RISC-V depends on the mode. For
         example there are: 2, 3 and 4 levels on Sv32, Sv39, Sv48 RISC-V paging
         modes respectively.
-
-config KERNEL_WINDOW_SIZE_BIT
-    int "Desired kernel window size in bits"
-    default 30
-    help
-        Configure the desired kernel window size

--- a/src/arch/riscv/config.cmake
+++ b/src/arch/riscv/config.cmake
@@ -48,14 +48,6 @@ if (KernelSel4ArchRiscV32)
     set(KernelPTLevels 2 CACHE STRING "" FORCE)
 endif()
 
-config_string(KernelWindowSizeBit KERNEL_WINDOW_SIZE_BIT "Configure the \
-    desired kernel window size"
-    DEFAULT 30
-    UNDEF_DISABLED
-    UNQUOTE
-    DEPENDS "KernelArchRiscV"
-)
-
 add_sources(
     DEP "KernelArchRiscV"
     PREFIX src/arch/riscv


### PR DESCRIPTION
Small changes to get sel4test to boot on riscv32.  Not completely sure if this is the right way to do this, but it works.