### PR TITLE
riscv: Enable seL4 to run in Machine Mode (Highest Privilege)

### DIFF
--- a/include/arch/riscv/arch/encoding.h
+++ b/include/arch/riscv/arch/encoding.h
@@ -304,6 +304,9 @@
 #define rdcycle() read_csr(cycle)
 #define rdinstret() read_csr(instret)
 
+#define get_cycles() (uint64_t) (rdcycle() | (config_set(CONFIG_ARCH_RISCV_RV32)? (uint64_t) (read_csr(cycleh) << 32) : 0))
+#define get_time() (uint64_t) (rdtime() | (config_set(CONFIG_ARCH_RISCV_RV32)? (uint64_t) (read_csr(timeh) << 32) : 0))
+
 #endif
 
 #endif

--- a/include/arch/riscv/arch/encoding.h
+++ b/include/arch/riscv/arch/encoding.h
@@ -24,11 +24,23 @@
  * MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
  */
 
+/*
+ * Copyright (c) 2018, Hesham Almatary <Hesham.Almatary@cl.cam.ac.uk>
+ * All rights reserved.
+ *
+ * This software was was developed in part by SRI International and the University of
+ * Cambridge Computer Laboratory (Department of Computer Science and
+ * Technology) under DARPA contract HR0011-18-C-0016 ("ECATS"), as part of the
+ * DARPA SSITH research programme.
+ */
+
 /* This file is copied from RISC-V tools, it might change for
  * new spec releases.
  */
 #ifndef RISCV_CSR_ENCODING_H
 #define RISCV_CSR_ENCODING_H
+
+#include <config.h>
 
 #define MSTATUS_UIE         0x00000001
 #define MSTATUS_SIE         0x00000002
@@ -215,9 +227,59 @@
 #define RISCV_PGSHIFT 12
 #define RISCV_PGSIZE (1 << RISCV_PGSHIFT)
 
+/* Similar to ecall instruction (environment call), pre-fix registers according to
+ * the RISC-V mode seL4 is working in (Machine or Supervisor)
+ */
+#ifdef CONFIG_SEL4_RV_MACHINE
+#define PREFIX_ENV(token) m ## token
+#define ENV_STRING "m"
+#else
+#define PREFIX_ENV(token) s ## token
+#define ENV_STRING "s"
+#endif
+
+#define EPC_REG     PREFIX_ENV(epc)
+#define TVEC_REG    PREFIX_ENV(tvec)
+#define STATUS_REG  PREFIX_ENV(status)
+#define SCRATCH_REG PREFIX_ENV(scratch)
+#define BADADDR_REG PREFIX_ENV(badaddr)
+#define CAUSE_REG   PREFIX_ENV(cause)
+#define IE_REG      PREFIX_ENV(ie)
+#define IP_REG      PREFIX_ENV(ip)
+#define RET_INSN    PREFIX_ENV(ret)
+
 #ifndef __ASSEMBLER__
 
 #ifdef __GNUC__
+
+#define EEPC      STRINGIFY(EPC_REG)
+#define ECAUSE    STRINGIFY(CAUSE_REG)
+#define EBADADDR  STRINGIFY(BADADDR_REG)
+#define ESTATUS   STRINGIFY(STATUS_REG)
+#define ESCRATCH  STRINGIFY(SCRATCH_REG)
+#define ETVEC     STRINGIFY(TVEC_REG)
+#define EIE       STRINGIFY(IE_REG)
+#define EIP       STRINGIFY(IP_REG)
+#define ERET      STRINGIFY(RET_INSN)
+
+#define read_csr_env(reg) ({ unsigned long __tmp; \
+  asm volatile ("csrr %0, " ENV_STRING#reg : "=r"(__tmp)); \
+  __tmp; })
+
+#define clear_csr_env(reg, bit) ({ unsigned long __tmp; \
+  asm volatile ("csrrc %0, " ENV_STRING#reg ", %1" : "=r"(__tmp) : "rK"(bit)); \
+  __tmp; })
+
+#define write_csr_env(reg, val) ({ \
+  asm volatile ("csrw " ENV_STRING#reg ", %0" :: "rK"(val)); })
+
+#define swap_csr_env(reg, val) ({ unsigned long __tmp; \
+  asm volatile ("csrrw %0, " ENV_STRING#reg ", %1" : "=r"(__tmp) : "rK"(val)); \
+  __tmp; })
+
+#define set_csr_env(reg, bit) ({ unsigned long __tmp; \
+  asm volatile ("csrrs %0, " ENV_STRING#reg ", %1" : "=r"(__tmp) : "rK"(bit)); \
+  __tmp; })
 
 #define read_csr(reg) ({ unsigned long __tmp; \
   asm volatile ("csrr %0, " #reg : "=r"(__tmp)); \

--- a/include/arch/riscv/arch/fastpath/fastpath.h
+++ b/include/arch/riscv/arch/fastpath/fastpath.h
@@ -151,19 +151,19 @@ fastpath_restore(word_t badge, word_t msgInfo, tcb_t *cur_thread)
         LOAD_S "  t1, 3*%[REGSIZE](t0)  \n"
         /* get restored tp */
         "add tp, t1, x0  \n"
-        /* get sepc */
+        /* get eepc */
         LOAD_S "  t1, 34*%[REGSIZE](t0)\n"
-        "csrw sepc, t1  \n"
+        "csrw "  EEPC ", t1  \n"
 
         /* Write back sscratch with cur_thread_reg to get it back on the next trap entry */
         "csrw sscratch, t0\n"
 
         LOAD_S "  t1, 32*%[REGSIZE](t0) \n"
-        "csrw sstatus, t1\n"
+        "csrw " ESTATUS ", t1\n"
 
         LOAD_S "  t1, (5*%[REGSIZE])(t0) \n"
         LOAD_S "  t0, (4*%[REGSIZE])(t0) \n"
-        "sret"
+        ERET
         : /* no output */
         : "r" (cur_thread_reg),
         [REGSIZE] "i" (sizeof(word_t)),

--- a/include/arch/riscv/arch/machine/hardware.h
+++ b/include/arch/riscv/arch/machine/hardware.h
@@ -44,17 +44,20 @@
 #define RISCV_GET_LVL_PGSIZE(n)      BIT(RISCV_GET_LVL_PGSIZE_BITS((n)))
 /*
  * These values are defined in RISC-V priv-1.10 manual, they represent the
- * exception codes saved in scause register (by the hardware) on traps.
+ * exception codes saved in cause register (by the hardware) on traps.
  */
 enum vm_fault_type {
     RISCVInstructionMisaligned = 0,
     RISCVInstructionAccessFault = 1,
     RISCVInstructionIllegal = 2,
     RISCVBreakpoint = 3,
+    RISCVLoadAddressMisaligned = 4,
     RISCVLoadAccessFault = 5,
     RISCVAddressMisaligned = 6,
     RISCVStoreAccessFault = 7,
     RISCVEnvCall = 8,
+    RISCVSEnvCall = 9,
+    RISCVMEnvCall = 11,
     RISCVInstructionPageFault = 12,
     RISCVLoadPageFault = 13,
     RISCVStorePageFault = 15

--- a/include/arch/riscv/arch/machine/registerset.h
+++ b/include/arch/riscv/arch/machine/registerset.h
@@ -11,6 +11,16 @@
  */
 
 /*
+ * Copyright (c) 2018, Hesham Almatary <Hesham.Almatary@cl.cam.ac.uk>
+ * All rights reserved.
+ *
+ * This software was was developed in part by SRI International and the University of
+ * Cambridge Computer Laboratory (Department of Computer Science and
+ * Technology) under DARPA contract HR0011-18-C-0016 ("ECATS"), as part of the
+ * DARPA SSITH research programme.
+ */
+
+/*
  *
  * Copyright 2016, 2017 Hesham Almatary, Data61/CSIRO <hesham.almatary@data61.csiro.au>
  * Copyright 2015, 2016 Hesham Almatary <heshamelmatary@gmail.com>
@@ -69,9 +79,9 @@ enum _register {
     t6 = 30,
 
     /* End of GP registers, the following are additional kernel-saved state. */
-    SCAUSE,
-    SSTATUS,
-    SEPC,
+    CAUSE,
+    STATUS,
+    EPC,
     NEXTPC,
 
     /* TODO: add other user-level CSRs if needed (i.e. to avoid channels) */
@@ -102,8 +112,8 @@ typedef struct user_context user_context_t;
 
 static inline void Arch_initContext(user_context_t* context)
 {
-    /* Enable supervisor interrupts (when going to user-mode) */
-    context->registers[SSTATUS] = SSTATUS_SPIE;
+    /* Enable interrupts (when going to user-mode) */
+    context->registers[STATUS] = config_set(CONFIG_SEL4_RV_MACHINE) ? MSTATUS_MPIE : SSTATUS_SPIE;
 }
 
 static inline word_t CONST
@@ -115,14 +125,14 @@ sanitiseRegister(register_t reg, word_t v, bool_t archInfo)
 
 #define EXCEPTION_MESSAGE \
  {\
-    [seL4_UserException_FaultIP] = SEPC,\
+    [seL4_UserException_FaultIP] = EPC,\
     [seL4_UserException_SP] = SP,\
     [seL4_UserException_Number] = a7,\
  }
 
 #define SYSCALL_MESSAGE \
 {\
-    [seL4_UnknownSyscall_FaultIP] = SEPC,\
+    [seL4_UnknownSyscall_FaultIP] = EPC,\
     [seL4_UnknownSyscall_SP] = SP,\
     [seL4_UnknownSyscall_RA] = LR,\
     [seL4_UnknownSyscall_A0] = a0,\

--- a/include/arch/riscv/arch/model/statedata.h
+++ b/include/arch/riscv/arch/model/statedata.h
@@ -39,4 +39,8 @@ extern asid_pool_t *riscvKSASIDTable[BIT(asidHighBits)];
  * each of which is 4KiB, PTEs are of word_t size
   */
 extern pte_t kernel_pageTables[CONFIG_PT_LEVELS][BIT(PT_INDEX_BITS)] ALIGN(BIT(seL4_PageTableBits));
+
+/* Address of pk trap address */
+extern word_t pk_trap_addr;
+
 #endif

--- a/include/plat/spike/plat/32/plat_mode/machine/hardware.h
+++ b/include/plat/spike/plat/32/plat_mode/machine/hardware.h
@@ -9,12 +9,27 @@
  *
  * @TAG(DATA61_GPL)
  */
+
+/*
+ * Copyright (c) 2018, Hesham Almatary <Hesham.Almatary@cl.cam.ac.uk>
+ * All rights reserved.
+ *
+ * This software was was developed in part by SRI International and the University of
+ * Cambridge Computer Laboratory (Department of Computer Science and
+ * Technology) under DARPA contract HR0011-18-C-0016 ("ECATS"), as part of the
+ * DARPA SSITH research programme.
+ */
 #ifndef __PLAT_MODE_MACHINE_HARDWARE_H
 #define __PLAT_MODE_MACHINE_HARDWARE_H
 
 #include <config.h>
 
 #define PPTR_BASE  0x80000000lu
+
+#ifdef CONFIG_SEL4_RV_MACHINE
+#define KERNEL_BASE 0xC0000000lu
+#else
 #define KERNEL_BASE 0xFFC00000lu
+#endif
 
 #endif

--- a/include/plat/spike/plat/64/plat_mode/machine/hardware.h
+++ b/include/plat/spike/plat/64/plat_mode/machine/hardware.h
@@ -9,6 +9,16 @@
  *
  * @TAG(DATA61_GPL)
  */
+
+/*
+ * Copyright (c) 2018, Hesham Almatary <Hesham.Almatary@cl.cam.ac.uk>
+ * All rights reserved.
+ *
+ * This software was was developed in part by SRI International and the University of
+ * Cambridge Computer Laboratory (Department of Computer Science and
+ * Technology) under DARPA contract HR0011-18-C-0016 ("ECATS"), as part of the
+ * DARPA SSITH research programme.
+ */
 #ifndef __PLAT_MODE_MACHINE_HARDWARE_H
 #define __PLAT_MODE_MACHINE_HARDWARE_H
 
@@ -23,7 +33,11 @@
 /* We steal the top 2 gb entries for the kernel, this means that between PPTR_BASE and
  * KERNEL_BASE there are 254 entries remaining, which represents how much physical memory
  * can be used */
+#ifdef CONFIG_SEL4_RV_MACHINE
+#define KERNEL_BASE      0x00000000C0000000lu
+#else
 #define KERNEL_BASE      0xFFFFFFFF80000000lu
+#endif
 #else
 #error Only PT_LEVELS == 3 is supported
 #endif

--- a/include/plat/spike/plat/machine.h
+++ b/include/plat/spike/plat/machine.h
@@ -11,6 +11,16 @@
  */
 
 /*
+ * Copyright (c) 2018, Hesham Almatary <Hesham.Almatary@cl.cam.ac.uk>
+ * All rights reserved.
+ *
+ * This software was was developed in part by SRI International and the University of
+ * Cambridge Computer Laboratory (Department of Computer Science and
+ * Technology) under DARPA contract HR0011-18-C-0016 ("ECATS"), as part of the
+ * DARPA SSITH research programme.
+ */
+
+/*
  *
  * Copyright 2016, 2017 Hesham Almatary, Data61/CSIRO <hesham.almatary@data61.csiro.au>
  * Copyright 2015, 2016 Hesham Almatary <heshamelmatary@gmail.com>
@@ -19,22 +29,29 @@
 #ifndef __PLAT_MACHINE_H
 #define __PLAT_MACHINE_H
 
+#include <config.h>
 
-#define N_INTERRUPTS 6
+#define N_INTERRUPTS 7
 
 #ifndef __ASSEMBLER__
 enum IRQConstants {
     INTERRUPT_SW = 0,
-    INTERRUPT_TIMER = 5,
+    INTERRUPT_STIMER = 5,
+    INTERRUPT_MTIMER = 7,
     /* TODO: Handle PLIC and add external IRQs upon needed */
-    maxIRQ = 5
+    maxIRQ = 7
 } platform_interrupt_t;
 
 #define IRQ_CNODE_BITS 12
-#define KERNEL_TIMER_IRQ INTERRUPT_TIMER
+
+#ifdef CONFIG_SEL4_RV_MACHINE
+#define KERNEL_TIMER_IRQ INTERRUPT_MTIMER
+#else
+#define KERNEL_TIMER_IRQ INTERRUPT_STIMER
+#endif
 
 enum irqNumbers {
-    irqInvalid = 6
+    irqInvalid = 8
 };
 
 typedef uint32_t interrupt_t;

--- a/include/plat/spike/plat/machine/hardware.h
+++ b/include/plat/spike/plat/machine/hardware.h
@@ -11,6 +11,16 @@
  */
 
 /*
+ * Copyright (c) 2018, Hesham Almatary <Hesham.Almatary@cl.cam.ac.uk>
+ * All rights reserved.
+ *
+ * This software was was developed in part by SRI International and the University of
+ * Cambridge Computer Laboratory (Department of Computer Science and
+ * Technology) under DARPA contract HR0011-18-C-0016 ("ECATS"), as part of the
+ * DARPA SSITH research programme.
+ */
+
+/*
  *
  * Copyright 2016, 2017 Hesham Almatary, Data61/CSIRO <hesham.almatary@data61.csiro.au>
  * Copyright 2015, 2016 Hesham Almatary <heshamelmatary@gmail.com>
@@ -36,20 +46,33 @@
  * as the largest frame size */
 #define PADDR_LOAD 0xC0000000lu
 
+#ifdef CONFIG_SEL4_RV_MACHINE
+#define PADDR_TOP -1UL
+#else
 /* The highest valid physical address that can be indexed in the kernel window */
 #define PADDR_TOP (KERNEL_BASE - PPTR_BASE + PADDR_BASE)
+#endif
+
 /* The highest valid physical address that can be used for the kernel image. We offset by
  * PADDR_LOAD as the window for the kernel image is mapped started at PADDR_LOAD */
 #define PADDR_HIGH_TOP (-KERNEL_BASE + PADDR_LOAD)
 
-/* Translates from a physical address and a value in the kernel image */
-#define KERNEL_BASE_OFFSET (KERNEL_BASE - PADDR_LOAD)
-
 /* Convert our values into general values expected by the common code */
 #define kernelBase KERNEL_BASE
+
+#ifdef CONFIG_SEL4_RV_MACHINE
+#define BASE_OFFSET 0
+#define KERNEL_BASE_OFFSET 0
+#define PPTR_TOP PADDR_TOP
+#define PPTR_USER_TOP PADDR_TOP
+#else
 #define PPTR_TOP KERNEL_BASE
 #define PPTR_USER_TOP PPTR_BASE
 #define BASE_OFFSET (PPTR_BASE - PADDR_BASE)
+/* Translates from a physical address and a value in the kernel image */
+#define KERNEL_BASE_OFFSET (KERNEL_BASE - PADDR_LOAD)
+
+#endif /* CONFIG_SEL4_RV_MACHINE */
 
 #ifndef __ASSEMBLER__
 

--- a/src/arch/riscv/c_traps.c
+++ b/src/arch/riscv/c_traps.c
@@ -11,6 +11,16 @@
  */
 
 /*
+ * Copyright (c) 2018, Hesham Almatary <Hesham.Almatary@cl.cam.ac.uk>
+ * All rights reserved.
+ *
+ * This software was was developed in part by SRI International and the University of
+ * Cambridge Computer Laboratory (Department of Computer Science and
+ * Technology) under DARPA contract HR0011-18-C-0016 ("ECATS"), as part of the
+ * DARPA SSITH research programme.
+ */
+
+/*
  *
  * Copyright 2016, 2017 Hesham Almatary, Data61/CSIRO <hesham.almatary@data61.csiro.au>
  * Copyright 2015, 2016 Hesham Almatary <heshamelmatary@gmail.com>
@@ -73,19 +83,19 @@ void VISIBLE NORETURN restore_user_context(void)
         LOAD_S "  t1, (3*%[REGSIZE])(t0)  \n"
         /* get restored tp */
         "add tp, t1, x0  \n"
-        /* get sepc */
+        /* get eepc */
         LOAD_S "  t1, (34*%[REGSIZE])(t0)\n"
-        "csrw sepc, t1  \n"
+        "csrw " EEPC ", t1  \n"
 
         /* Write back sscratch with cur_thread_reg to get it back on the next trap entry */
         "csrw sscratch, t0         \n"
 
         LOAD_S "  t1, (32*%[REGSIZE])(t0) \n"
-        "csrw sstatus, t1\n"
+        "csrw " ESTATUS ", t1\n"
 
         LOAD_S "  t1, (5*%[REGSIZE])(t0) \n"
         LOAD_S "  t0, (4*%[REGSIZE])(t0) \n"
-        "sret"
+        ERET
         : /* no output */
         : [REGSIZE] "i" (sizeof(word_t)),
         [cur_thread] "r" (cur_thread_reg)

--- a/src/arch/riscv/kernel/boot.c
+++ b/src/arch/riscv/kernel/boot.c
@@ -11,6 +11,16 @@
  */
 
 /*
+ * Copyright (c) 2018, Hesham Almatary <Hesham.Almatary@cl.cam.ac.uk>
+ * All rights reserved.
+ *
+ * This software was was developed in part by SRI International and the University of
+ * Cambridge Computer Laboratory (Department of Computer Science and
+ * Technology) under DARPA contract HR0011-18-C-0016 ("ECATS"), as part of the
+ * DARPA SSITH research programme.
+ */
+
+/*
  *
  * Copyright 2016, 2017 Hesham Almatary, Data61/CSIRO <hesham.almatary@data61.csiro.au>
  * Copyright 2015, 2016 Hesham Almatary <heshamelmatary@gmail.com>
@@ -206,7 +216,7 @@ init_cpu(void)
 {
 
     /* Write trap entry address to stvec */
-    write_csr(stvec, trap_entry);
+    write_csr_env(tvec, trap_entry);
 
     activate_kernel_vspace();
 }

--- a/src/arch/riscv/kernel/boot.c
+++ b/src/arch/riscv/kernel/boot.c
@@ -214,13 +214,15 @@ extern char trap_entry[];
 BOOT_CODE static void
 init_cpu(void)
 {
-    /* Write trap entry address to stvec */
-    write_csr_env(tvec, trap_entry);
-
     if (!config_set(CONFIG_SEL4_RV_MACHINE)) {
         activate_kernel_vspace();
+    } else {
+        /* Save the trap address entry of riscv-pk before overwritting it */
+        pk_trap_addr = read_csr(mtvec);
     }
 
+    /* Write trap entry address to stvec */
+    write_csr_env(tvec, trap_entry);
 }
 
 /* This and only this function initialises the platform. It does NOT initialise any kernel state. */

--- a/src/arch/riscv/kernel/boot.c
+++ b/src/arch/riscv/kernel/boot.c
@@ -214,11 +214,13 @@ extern char trap_entry[];
 BOOT_CODE static void
 init_cpu(void)
 {
-
     /* Write trap entry address to stvec */
     write_csr_env(tvec, trap_entry);
 
-    activate_kernel_vspace();
+    if (!config_set(CONFIG_SEL4_RV_MACHINE)) {
+        activate_kernel_vspace();
+    }
+
 }
 
 /* This and only this function initialises the platform. It does NOT initialise any kernel state. */
@@ -275,7 +277,9 @@ try_init_kernel(
     it_v_reg.start = ui_v_reg.start;
     it_v_reg.end = bi_frame_vptr + BIT(PAGE_BITS);
 
-    map_kernel_window();
+    if (!config_set(CONFIG_SEL4_RV_MACHINE)) {
+        map_kernel_window();
+    }
 
     /* initialise the CPU */
     init_cpu();

--- a/src/arch/riscv/kernel/thread.c
+++ b/src/arch/riscv/kernel/thread.c
@@ -11,6 +11,16 @@
  */
 
 /*
+ * Copyright (c) 2018, Hesham Almatary <Hesham.Almatary@cl.cam.ac.uk>
+ * All rights reserved.
+ *
+ * This software was was developed in part by SRI International and the University of
+ * Cambridge Computer Laboratory (Department of Computer Science and
+ * Technology) under DARPA contract HR0011-18-C-0016 ("ECATS"), as part of the
+ * DARPA SSITH research programme.
+ */
+
+/*
  *
  * Copyright 2016, 2017 Hesham Almatary, Data61/CSIRO <hesham.almatary@data61.csiro.au>
  * Copyright 2015, 2016 Hesham Almatary <heshamelmatary@gmail.com>
@@ -37,8 +47,13 @@ Arch_configureIdleThread(tcb_t *tcb)
 {
     setRegister(tcb, NEXTPC, (word_t)idleThreadStart);
 
-    /* Enable interrupts and keep working in supervisor mode */
-    setRegister(tcb, SSTATUS, (word_t) SSTATUS_SPP | SSTATUS_SPIE | SSTATUS_SIE);
+    /* Enable interrupts and keep working in X privilege mode */
+    if (config_set(CONFIG_SEL4_RV_MACHINE)) {
+        setRegister(tcb, STATUS, (word_t) MSTATUS_MPP | MSTATUS_MPIE | MSTATUS_MIE);
+    } else {
+        setRegister(tcb, STATUS, (word_t) SSTATUS_SPP | SSTATUS_SPIE | SSTATUS_SIE);
+    }
+
     setRegister(tcb, SP, (word_t)kernel_stack_alloc + BIT(CONFIG_KERNEL_STACK_BITS));
 }
 

--- a/src/arch/riscv/kernel/vspace.c
+++ b/src/arch/riscv/kernel/vspace.c
@@ -11,6 +11,16 @@
  */
 
 /*
+ * Copyright (c) 2018, Hesham Almatary <Hesham.Almatary@cl.cam.ac.uk>
+ * All rights reserved.
+ *
+ * This software was was developed in part by SRI International and the University of
+ * Cambridge Computer Laboratory (Department of Computer Science and
+ * Technology) under DARPA contract HR0011-18-C-0016 ("ECATS"), as part of the
+ * DARPA SSITH research programme.
+ */
+
+/*
  *
  * Copyright 2016, 2017 Hesham Almatary, Data61/CSIRO <hesham.almatary@data61.csiro.au>
  * Copyright 2015, 2016 Hesham Almatary <heshamelmatary@gmail.com>
@@ -397,9 +407,7 @@ lookupPTSlot(pte_t *lvl1pt, vptr_t vptr)
 exception_t
 handleVMFault(tcb_t *thread, vm_fault_type_t vm_faultType)
 {
-    uint64_t addr;
-
-    addr = read_csr(sbadaddr);
+    word_t addr = read_csr_env(badaddr);
 
     switch (vm_faultType) {
     case RISCVLoadPageFault:
@@ -412,7 +420,7 @@ handleVMFault(tcb_t *thread, vm_fault_type_t vm_faultType)
         return EXCEPTION_FAULT;
     case RISCVInstructionPageFault:
     case RISCVInstructionAccessFault:
-        setRegister(thread, NEXTPC, getRegister(thread, SEPC));
+        setRegister(thread, NEXTPC, getRegister(thread, EPC));
         current_fault = seL4_Fault_VMFault_new(addr, RISCVInstructionAccessFault, true);
         return EXCEPTION_FAULT;
 

--- a/src/arch/riscv/kernel/vspace.c
+++ b/src/arch/riscv/kernel/vspace.c
@@ -238,7 +238,9 @@ create_it_address_space(cap_t root_cnode_cap, v_region_t it_v_reg)
     }
     memzero(PTE_PTR(lvl1pt_pptr), 1 << PT_SIZE_BITS);
 
-    copyGlobalMappings(PTE_PTR(lvl1pt_pptr));
+    if (!config_set(CONFIG_SEL4_RV_MACHINE)) {
+        copyGlobalMappings(PTE_PTR(lvl1pt_pptr));
+    }
 
     lvl1pt_cap =
         cap_page_table_cap_new(
@@ -469,7 +471,9 @@ static exception_t performASIDPoolInvocation(asid_t asid, asid_pool_t* poolPtr, 
     cap = cap_page_table_cap_set_capPTIsMapped(cap, 1);
     vspaceCapSlot->cap = cap;
 
-    copyGlobalMappings(regionBase);
+    if (!config_set(CONFIG_SEL4_RV_MACHINE)) {
+        copyGlobalMappings(regionBase);
+    }
 
     poolPtr->array[asid & MASK(asidLowBits)] = regionBase;
 

--- a/src/arch/riscv/machine/hardware.c
+++ b/src/arch/riscv/machine/hardware.c
@@ -11,6 +11,16 @@
  */
 
 /*
+ * Copyright (c) 2018, Hesham Almatary <Hesham.Almatary@cl.cam.ac.uk>
+ * All rights reserved.
+ *
+ * This software was was developed in part by SRI International and the University of
+ * Cambridge Computer Laboratory (Department of Computer Science and
+ * Technology) under DARPA contract HR0011-18-C-0016 ("ECATS"), as part of the
+ * DARPA SSITH research programme.
+ */
+
+/*
  *
  * Copyright 2016, 2017 Hesham Almatary, Data61/CSIRO <hesham.almatary@data61.csiro.au>
  * Copyright 2015, 2016 Hesham Almatary <heshamelmatary@gmail.com>
@@ -22,7 +32,7 @@
 word_t PURE
 getRestartPC(tcb_t *thread)
 {
-    return getRegister(thread, SEPC);
+    return getRegister(thread, EPC);
 }
 
 void

--- a/src/arch/riscv/machine/io.c
+++ b/src/arch/riscv/machine/io.c
@@ -11,6 +11,16 @@
  */
 
 /*
+ * Copyright (c) 2018, Hesham Almatary <Hesham.Almatary@cl.cam.ac.uk>
+ * All rights reserved.
+ *
+ * This software was was developed in part by SRI International and the University of
+ * Cambridge Computer Laboratory (Department of Computer Science and
+ * Technology) under DARPA contract HR0011-18-C-0016 ("ECATS"), as part of the
+ * DARPA SSITH research programme.
+ */
+
+/*
  *
  * Copyright 2016, 2017 Hesham Almatary, Data61/CSIRO <hesham.almatary@data61.csiro.au>
  * Copyright 2015, 2016 Hesham Almatary <heshamelmatary@gmail.com>
@@ -22,6 +32,7 @@
 #include <plat/machine/devices.h>
 #include <arch/machine.h>
 #include <arch/sbi.h>
+#include <arch/encoding.h>
 #include <arch/kernel/traps.h>
 
 static inline void print_format_cause(int cause_num)
@@ -68,28 +79,28 @@ static inline void print_format_cause(int cause_num)
 
 void handle_exception(void)
 {
-    word_t scause = read_csr(scause);
+    word_t cause = read_csr_env(cause);
 
     /* handleVMFaultEvent
      * */
-    switch (scause) {
+    switch (cause) {
     case RISCVInstructionAccessFault:
     case RISCVLoadAccessFault:
     case RISCVStoreAccessFault:
     case RISCVInstructionPageFault:
     case RISCVLoadPageFault:
     case RISCVStorePageFault:
-        handleVMFaultEvent(scause);
+        handleVMFaultEvent(cause);
         break;
     case RISCVInstructionIllegal:
         handleUserLevelFault(0, 0);
 
         break;
     default:
-        print_format_cause(read_csr(scause));
-        printf("sepc = %p\n", (void*)(word_t)read_csr(sepc));
-        printf("sbadaddr = %p\n", (void*)(word_t)read_csr(sbadaddr));
-        printf("sstatus = %p\n", (void*)(word_t)read_csr(sstatus));
+        print_format_cause(read_csr_env(cause));
+        printf("epc = %p\n", (void*)(word_t)read_csr_env(epc));
+        printf("badaddr = %p\n", (void*)(word_t)read_csr_env(badaddr));
+        printf("status = %p\n", (void*)(word_t)read_csr_env(status));
         printf("Halt!\n");
 
         printf("Register Context Dump \n");

--- a/src/arch/riscv/machine/registerset.c
+++ b/src/arch/riscv/machine/registerset.c
@@ -11,6 +11,16 @@
  */
 
 /*
+ * Copyright (c) 2018, Hesham Almatary <Hesham.Almatary@cl.cam.ac.uk>
+ * All rights reserved.
+ *
+ * This software was was developed in part by SRI International and the University of
+ * Cambridge Computer Laboratory (Department of Computer Science and
+ * Technology) under DARPA contract HR0011-18-C-0016 ("ECATS"), as part of the
+ * DARPA SSITH research programme.
+ */
+
+/*
  *
  * Copyright 2016, 2017 Hesham Almatary, Data61/CSIRO <hesham.almatary@data61.csiro.au>
  * Copyright 2015, 2016 Hesham Almatary <heshamelmatary@gmail.com>
@@ -23,7 +33,7 @@ const register_t msgRegisters[] = {
 };
 
 const register_t frameRegisters[] = {
-    SEPC, ra, sp, gp, tp, t0, t1, t2, s0, s1, a0, a1, a2, a3, a4, a5, a6
+    EPC, ra, sp, gp, tp, t0, t1, t2, s0, s1, a0, a1, a2, a3, a4, a5, a6
 };
 
 const register_t gpRegisters[] = {

--- a/src/arch/riscv/model/statedata.c
+++ b/src/arch/riscv/model/statedata.c
@@ -17,6 +17,7 @@
  */
 
 #include <util.h>
+#include <config.h>
 #include <api/types.h>
 #include <arch/types.h>
 #include <arch/model/statedata.h>
@@ -28,3 +29,6 @@
 asid_pool_t *riscvKSASIDTable[BIT(asidHighBits)];
 
 pte_t kernel_pageTables[CONFIG_PT_LEVELS][BIT(PT_INDEX_BITS)] ALIGN(BIT(seL4_PageTableBits));
+
+/* Address of pk trap address */
+UNUSED word_t pk_trap_addr;

--- a/src/arch/riscv/traps.S
+++ b/src/arch/riscv/traps.S
@@ -11,6 +11,16 @@
  */
 
 /*
+ * Copyright (c) 2018, Hesham Almatary <Hesham.Almatary@cl.cam.ac.uk>
+ * All rights reserved.
+ *
+ * This software was was developed in part by SRI International and the University of
+ * Cambridge Computer Laboratory (Department of Computer Science and
+ * Technology) under DARPA contract HR0011-18-C-0016 ("ECATS"), as part of the
+ * DARPA SSITH research programme.
+ */
+
+/*
  *
  * Copyright 2016, 2017 Hesham Almatary, Data61/CSIRO <hesham.almatary@data61.csiro.au>
  * Copyright 2015, 2016 Hesham Almatary <heshamelmatary@gmail.com>
@@ -22,6 +32,7 @@
 #include <arch/api/syscall.h>
 #include <arch/machine/registerset.h>
 #include <util.h>
+#include <arch/encoding.h>
 
 #define REGBYTES (CONFIG_WORD_SIZE / 8)
 
@@ -72,14 +83,14 @@ trap_entry:
   csrr  x1, sscratch
   STORE    x1, (4*REGBYTES)(t0)
 
-  csrr x1, sstatus
+  csrr x1, STATUS_REG
   STORE x1, (32*REGBYTES)(t0)
 
-  csrr s0, scause
+  csrr s0, CAUSE_REG
   STORE s0, (31*REGBYTES)(t0)
 
   /* Save exception PC */
-  csrr x1,  sepc
+  csrr x1, EPC_REG
   STORE   x1, (33*REGBYTES)(t0)
 
   la gp, __global_pointer$

--- a/src/plat/spike/linker.lds
+++ b/src/plat/spike/linker.lds
@@ -11,6 +11,16 @@
  */
 
 /*
+ * Copyright (c) 2018, Hesham Almatary <Hesham.Almatary@cl.cam.ac.uk>
+ * All rights reserved.
+ *
+ * This software was was developed in part by SRI International and the University of
+ * Cambridge Computer Laboratory (Department of Computer Science and
+ * Technology) under DARPA contract HR0011-18-C-0016 ("ECATS"), as part of the
+ * DARPA SSITH research programme.
+ */
+
+/*
  *
  * Copyright 2016, 2017 Hesham Almatary, Data61/CSIRO <hesham.almatary@data61.csiro.au>
  * Copyright 2015, 2016 Hesham Almatary <heshamelmatary@gmail.com>
@@ -22,16 +32,29 @@ ENTRY(_start)
 #include <config.h>
 
 #if CONFIG_PT_LEVELS == 2
+#ifdef CONFIG_SEL4_RV_MACHINE
+KERNEL_BASE  = 0xC0000000;
+#else
 KERNEL_BASE  = 0xFFC00000;
+#endif
 #elif CONFIG_PT_LEVELS == 3
+#ifdef CONFIG_SEL4_RV_MACHINE
+KERNEL_BASE  = 0x00000000C0000000;
+#else
 KERNEL_BASE  = 0xFFFFFFFF80000000;
+#endif
 #elif CONFIG_PT_LEVELS == 4
 #error PT_LEVELS == 4 is not supported yet
 #endif
 
 /* WARNING: constants also defined in plat/machine/hardware.h */
 PADDR_LOAD     = 0x00000000C0000000;
+
+#ifdef CONFIG_SEL4_RV_MACHINE
+KERNEL_OFFSET = 0;
+#else
 KERNEL_OFFSET = KERNEL_BASE - PADDR_LOAD;
+#endif
 
 SECTIONS
 {

--- a/src/plat/spike/machine/hardware.c
+++ b/src/plat/spike/machine/hardware.c
@@ -11,6 +11,16 @@
  */
 
 /*
+ * Copyright (c) 2018, Hesham Almatary <Hesham.Almatary@cl.cam.ac.uk>
+ * All rights reserved.
+ *
+ * This software was was developed in part by SRI International and the University of
+ * Cambridge Computer Laboratory (Department of Computer Science and
+ * Technology) under DARPA contract HR0011-18-C-0016 ("ECATS"), as part of the
+ * DARPA SSITH research programme.
+ */
+
+/*
  *
  * Copyright 2016, 2017 Hesham Almatary, Data61/CSIRO <hesham.almatary@data61.csiro.au>
  * Copyright 2015, 2016 Hesham Almatary <heshamelmatary@gmail.com>
@@ -26,6 +36,7 @@
 #include <plat/machine/devices.h>
 #include <plat/machine/hardware.h>
 #include <arch/sbi.h>
+#include <arch/encoding.h>
 
 #define MAX_AVAIL_P_REGS 2
 
@@ -62,8 +73,7 @@ interrupt_t
 getActiveIRQ(void)
 {
 
-    uint64_t temp = 0;
-    asm volatile ("csrr %0, scause":"=r" (temp)::);
+    word_t temp = read_csr_env(cause);
 
     if (!(temp & BIT(CONFIG_WORD_SIZE - 1))) {
         return irqInvalid;
@@ -90,9 +100,9 @@ maskInterrupt(bool_t disable, interrupt_t irq)
             clear_csr(sie, BIT(irq));
         }
     } else {
-        /* FIXME: currently only account for user/supervisor and timer interrupts */
-        if (irq == 4 /* user timer */ || irq == 5 /* supervisor timer */) {
-            set_csr(sie, BIT(irq));
+        /* FIXME: currently only account for timer interrupts */
+        if (irq == KERNEL_TIMER_IRQ) {
+            set_csr_env(ie, BIT(irq));
         } else {
             /* TODO: account for external and PLIC interrupts */
         }
@@ -120,7 +130,7 @@ ackInterrupt(irq_t irq)
     // don't ack the kernel timer interrupt, see the comment in resetTimer
     // to understand why
     if (irq != KERNEL_TIMER_IRQ) {
-        clear_csr(sip, BIT(irq));
+        clear_csr_env(ip, BIT(irq));
     }
     //set_csr(scause, 0);
 
@@ -162,7 +172,7 @@ resetTimer(void)
     // ack the timer interrupt. we do this here as due to slow simulation platform there
     // is a race between us setting the new interrupt here, and the ackInterrupt call in
     // handleInterrupt that will happen at some point after this call to resetTimer
-    clear_csr(sip, KERNEL_TIMER_IRQ);
+    clear_csr_env(ie, KERNEL_TIMER_IRQ);
     // repeatedly try and set the timer in a loop as otherwise there is a race and we
     // may set a timeout in the past, resulting in it never getting triggered
     do {


### PR DESCRIPTION
* This allows for future virtualization efforts (e.g. running Linux in S-Mode)
* User level is not affected by this change
* Kernel works in physical memory (doesn't use MMU or TLBs)
* No "global" kernel mappings in this mode
* User can use the entire virtual address space
* In the future, this allows the seL4 to use and/or export devices (like UART) without the need to trap to riscv-pk