### PR TITLE
More RISC-V Changes

### DIFF
--- a/include/arch/riscv/arch/machine.h
+++ b/include/arch/riscv/arch/machine.h
@@ -117,13 +117,13 @@ static inline void setVSpaceRoot(paddr_t addr, asid_t asid)
                            asid,                         /* asid */
                            addr >> seL4_PageBits); /* PPN */
 
-    /* Order read/write operations */
-    sfence();
-
     /* Current toolchain still uses sptbr register name although it got renamed in priv-1.10.
      * This will most likely need to change with newer toolchains
      */
     write_sptbr(satp.words[0]);
+
+    /* Order read/write operations */
+    sfence();
 }
 
 static inline void Arch_finaliseInterrupt(void)

--- a/src/plat/spike/config.cmake
+++ b/src/plat/spike/config.cmake
@@ -24,6 +24,12 @@ config_option(KernelPlatformSpikeRocketChip BUILD_ROCKET_CHIP_ZEDBOARD "Build ap
     DEPENDS "KernelSel4ArchRiscV64;KernelPlatformSpike"
 )
 
+config_string(KernelPlatformSpikeClockFrequency SPIKE_CLOCK_FREQ
+    "Frequency of Clock used for Scheduler"
+    DEFAULT 10000000
+    UNQUOTE
+)
+
 add_sources(
     DEP "KernelPlatformSpike"
     CFILES

--- a/src/plat/spike/config.cmake
+++ b/src/plat/spike/config.cmake
@@ -21,6 +21,7 @@ endif()
 config_choice(KernelSpikeInstance RISCV_SPIKE_INSTANCE "Select the instance for Spike to run on"
     "qemu;KernelPlatformSpikeQemu;BUILD_SPIKE_QEMU;KernelArchRiscV"
     "rocket-chip-zedboard;KernelPlatformSpikeRocketChip;BUILD_ROCKET_CHIP_ZEDBOARD;KernelSel4ArchRiscV64"
+    "hi-five-unleashed;KernelPlatformSpikeSiFiveFreedom;BUILD_HI_FIVE_UNLEASHED;KernelSel4ArchRiscV64"
 )
 
 config_string(KernelPlatformSpikeClockFrequency SPIKE_CLOCK_FREQ
@@ -32,6 +33,7 @@ config_string(KernelPlatformSpikeClockFrequency SPIKE_CLOCK_FREQ
 # Include all of the different instances of the Spike platform
 include(src/plat/spike/instance/qemu/config.cmake)
 include(src/plat/spike/instance/rocket-chip/config.cmake)
+include(src/plat/spike/instance/freedom/config.cmake)
 
 add_sources(
     DEP "KernelPlatformSpike"

--- a/src/plat/spike/config.cmake
+++ b/src/plat/spike/config.cmake
@@ -18,10 +18,9 @@ if(KernelPlatformSpike)
     config_set(KernelPlatform PLAT "spike")
 endif()
 
-config_option(KernelPlatformSpikeRocketChip BUILD_ROCKET_CHIP_ZEDBOARD "Build application to \
-    run on the Rocket-Chip for the zedboard."
-    DEFAULT OFF
-    DEPENDS "KernelSel4ArchRiscV64;KernelPlatformSpike"
+config_choice(KernelSpikeInstance RISCV_SPIKE_INSTANCE "Select the instance for Spike to run on"
+    "qemu;KernelPlatformSpikeQemu;BUILD_SPIKE_QEMU;KernelArchRiscV"
+    "rocket-chip-zedboard;KernelPlatformSpikeRocketChip;BUILD_ROCKET_CHIP_ZEDBOARD;KernelSel4ArchRiscV64"
 )
 
 config_string(KernelPlatformSpikeClockFrequency SPIKE_CLOCK_FREQ
@@ -29,6 +28,10 @@ config_string(KernelPlatformSpikeClockFrequency SPIKE_CLOCK_FREQ
     DEFAULT 10000000
     UNQUOTE
 )
+
+# Include all of the different instances of the Spike platform
+include(src/plat/spike/instance/qemu/config.cmake)
+include(src/plat/spike/instance/rocket-chip/config.cmake)
 
 add_sources(
     DEP "KernelPlatformSpike"

--- a/src/plat/spike/instance/freedom/config.cmake
+++ b/src/plat/spike/instance/freedom/config.cmake
@@ -1,0 +1,13 @@
+#
+# Copyright 2018, DornerWorks
+#
+# This software may be distributed and modified according to the terms of
+# the GNU General Public License version 2. Note that NO WARRANTY is provided.
+# See "LICENSE_GPLv2.txt" for details.
+#
+# @TAG(DORNERWORKS_GPL)
+#
+
+if(KernelPlatformSpikeSiFiveFreedom)
+  set(KernelPlatformSpikeClockFrequency 1000000)
+endif()

--- a/src/plat/spike/instance/qemu/config.cmake
+++ b/src/plat/spike/instance/qemu/config.cmake
@@ -1,0 +1,13 @@
+#
+# Copyright 2018, DornerWorks
+#
+# This software may be distributed and modified according to the terms of
+# the GNU General Public License version 2. Note that NO WARRANTY is provided.
+# See "LICENSE_GPLv2.txt" for details.
+#
+# @TAG(DORNERWORKS_GPL)
+#
+
+if(KernelPlatformSpikeQemu)
+  set(KernelPlatformSpikeClockFrequency 10000000)
+endif()

--- a/src/plat/spike/instance/rocket-chip/config.cmake
+++ b/src/plat/spike/instance/rocket-chip/config.cmake
@@ -1,0 +1,13 @@
+#
+# Copyright 2018, DornerWorks
+#
+# This software may be distributed and modified according to the terms of
+# the GNU General Public License version 2. Note that NO WARRANTY is provided.
+# See "LICENSE_GPLv2.txt" for details.
+#
+# @TAG(DORNERWORKS_GPL)
+#
+
+if(KernelPlatformSpikeRocketChip)
+  set(KernelPlatformSpikeClockFrequency 250000)
+endif()

--- a/src/plat/spike/machine/hardware.c
+++ b/src/plat/spike/machine/hardware.c
@@ -29,6 +29,9 @@
 
 #define MAX_AVAIL_P_REGS 2
 
+#define MS_PER_S     1000
+#define RESET_CYCLES ((CONFIG_SPIKE_CLOCK_FREQ / MS_PER_S) * CONFIG_TIMER_TICK_MS)
+
 /* Available physical memory regions on platform (RAM minus kernel image). */
 /* NOTE: Regions are not allowed to be adjacent! */
 
@@ -166,8 +169,7 @@ resetTimer(void)
     // repeatedly try and set the timer in a loop as otherwise there is a race and we
     // may set a timeout in the past, resulting in it never getting triggered
     do {
-        /* This should be set properly relying on the frequency (on real HW) */
-        target = get_cycles() + 0x1fff;
+        target = get_cycles() + RESET_CYCLES;
         sbi_set_timer(target);
     } while (get_cycles() > target);
 }
@@ -178,7 +180,7 @@ resetTimer(void)
 BOOT_CODE void
 initTimer(void)
 {
-    sbi_set_timer(get_cycles() + 0xfffff);
+    sbi_set_timer(get_cycles() + RESET_CYCLES);
 }
 
 void plat_cleanL2Range(paddr_t start, paddr_t end)


### PR DESCRIPTION
During the last pull request, there were some comments about the Rocket-Chip sharing a bunch of code with the Spike platform. We updated cmake a little bit to allow for different instances of Spike, since platforms will have hardware specific options, like the timebase clock used for the scheduling tick. 

The other big change is moving the `sfence` call after `sptbr` has been updated. This wasn't an issue while running seL4test on the zedboard, but it became an issue when developing other applications, since there would be VM faults on context switches. This order is also how Linux does it, so it is either an ISA issue or a Rocket-Chip issue.