### PR TITLE
zynqmp: add Ultra96 platform

### DIFF
--- a/include/plat/zynqmp/plat/machine/devices.h
+++ b/include/plat/zynqmp/plat/machine/devices.h
@@ -27,7 +27,11 @@
 #define GIC_PL390_DISTRIBUTOR_PPTR  GIC_DISTRIBUTOR_PPTR
 
 /* These devices are used by the seL4 kernel. */
+#ifdef CONFIG_PLAT_ZYNQMP_ULTRA96
+#define UART_PADDR                  UART1_PADDR
+#else
 #define UART_PADDR                  UART0_PADDR
+#endif
 
 #define ACPU_GIC_PADDR              0xF9000000
 #define ACPU_GIC_DISTRIBUTOR_PADDR  0xF9010000

--- a/src/arch/arm/config.cmake
+++ b/src/arch/arm/config.cmake
@@ -32,6 +32,7 @@ config_choice(KernelARMPlatform ARM_PLAT "Select the platform for the architectu
     "imx7sabre;KernelPlatformImx7Sabre;PLAT_IMX7_SABRE;KernelSel4ArchAarch32"
     "zynq7000;KernelPlatformZynq7000;PLAT_ZYNQ7000;KernelSel4ArchAarch32"
     "zynqmp;KernelPlatformZynqmp;PLAT_ZYNQMP;KernelArchARM"
+    "ultra96;KernelPlatformUltra96;PLAT_ULTRA96;KernelArchARM"
     "allwinnera20;KernelPlatformAllwinnerA20;PLAT_ALLWINNERA20;KernelSel4ArchAarch32"
     "tk1;KernelPlatformTK1;PLAT_TK1;KernelSel4ArchAarch32 OR KernelSel4ArchArmHyp"
     "hikey;KernelPlatformHikey;PLAT_HIKEY;KernelArchARM"

--- a/src/plat/zynqmp/config.cmake
+++ b/src/plat/zynqmp/config.cmake
@@ -12,6 +12,12 @@
 
 cmake_minimum_required(VERSION 3.7.2)
 
+if(KernelPlatformUltra96)
+    # Ultra96 is is basically Zynqmp
+    config_set(KernelPlatformZynqmp PLAT_ZYNQMP ON)
+    config_set(KernelPlatformZynqmpUltra96 PLAT_ZYNQMP_ULTRA96 ON)
+endif()
+
 if(KernelPlatformZynqmp)
     set(KernelArmCortexA53 ON)
     set(KernelArchArmV8a ON)


### PR DESCRIPTION
Add Ultra96 platform, which is based on the zynqmp SoC