### PR TITLE
add missing include for config.h

### DIFF
--- a/include/plat/exynos5/plat/machine/devices.h
+++ b/include/plat/exynos5/plat/machine/devices.h
@@ -11,6 +11,8 @@
 #ifndef __PLAT_MACHINE_DEVICES_H
 #define __PLAT_MACHINE_DEVICES_H
 
+#include <config.h>
+
 /* These devices are used by the seL4 kernel. */
 #define UART_PPTR                   0xfff01000
 #define MCT_PPTR                    0xfff02000

--- a/include/plat/imx6/plat/machine/devices.h
+++ b/include/plat/imx6/plat/machine/devices.h
@@ -11,6 +11,8 @@
 #ifndef __PLAT_MACHINE_DEVICES_H
 #define __PLAT_MACHINE_DEVICES_H
 
+#include <config.h>
+
 /* These devices are used by the seL4 kernel. */
 #ifdef CONFIG_PLAT_SABRE
 #define UART_PADDR                  UART2_PADDR

--- a/include/plat/zynqmp/plat/machine/devices.h
+++ b/include/plat/zynqmp/plat/machine/devices.h
@@ -21,6 +21,7 @@
 #ifndef __PLAT_MACHINE_DEVICES_H
 #define __PLAT_MACHINE_DEVICES_H
 
+#include <config.h>
 #include <plat_mode/machine/devices.h>
 
 #define GIC_PL390_CONTROLLER_PPTR   GIC_CONTROLLER_PPTR


### PR DESCRIPTION
These files contain conditional parts which depends on `CONFIG_PLAT_xxx` being set, thus they must include `config.h`. Currently it works, because the files including these headers already have included `config.h` before. 