### PR TITLE
x86: Aligned memory map to page boundaries to fix allocation issue

### DIFF
--- a/src/arch/x86/kernel/boot_sys.c
+++ b/src/arch/x86/kernel/boot_sys.c
@@ -291,7 +291,7 @@ parse_mem_map(uint32_t mmap_length, uint32_t mmap_addr)
             printf("\tPhysical Memory Region from %lx size %lx type %d\n", (long)mem_start, (long)mem_length, type);
             if (type == MULTIBOOT_MMAP_USEABLE_TYPE && mem_start >= HIGHMEM_PADDR) {
                 if (!add_mem_p_regs((p_region_t) {
-                mem_start, mem_start + mem_length
+                mem_start, ROUND_UP(mem_start + mem_length, PAGE_BITS),
             })) {
                     return false;
                 }


### PR DESCRIPTION
When running sel4test on x86 hardware a single page of memory (size of 12 bits) was trying to be allocated within a space that was mapped to be only a size of 10 bits. The modification made seems to fix this issue by aligning the mapped memory to the size of a full page.