### PR TITLE
tools: BSD compat for changed.sh

### DIFF
--- a/tools/changed.sh
+++ b/tools/changed.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2017, Data61
 # Commonwealth Scientific and Industrial Research Organisation (CSIRO)


### PR DESCRIPTION
On e.g. FreeBSD, Bash lives at /usr/local/bin/bash. This change makes the script
find Bash wherever it may be hiding.

----

This script is quite handy outside the context of seL4 as well; thanks :) If you decide this change makes sense, it may be more consistent to change the shebang on all the shell scripts in a single commit. On the other hand, maybe it's better to avoid any indications that the build system runs on non-Linux.