### PR TITLE
manual: ipc: clarify sending caps is a copy

### DIFF
--- a/manual/parts/api.tex
+++ b/manual/parts/api.tex
@@ -199,6 +199,19 @@ A capability could not be looked up.
 \end{tabularx}
 \vfill
 
+\subsection{Truncated Message}
+
+Too few message words or capabilities were sent in the message.
+
+\begin{tabularx}{\textwidth}{p{0.25\textwidth}X}
+\toprule
+    Field & Meaning \\
+\midrule
+    \ipcbloc{Label} & \enummem{seL4\_TruncatedMessage} \\
+\bottomrule
+\end{tabularx}
+\vfill
+
 \subsection{Delete First}
 
 A destination slot specified in the syscall arguments is occupied.

--- a/manual/parts/ipc.tex
+++ b/manual/parts/ipc.tex
@@ -143,7 +143,7 @@ silently ignore any usage of the high 4 bits.
 \subsection{Capability Transfer}
 \label{sec:cap-transfer}
 
-Messages may contain capabilities, which will be transferred to the
+Messages may contain capabilities, which will be copied to the
 receiver, provided that the endpoint capability
 invoked by the sending thread has Grant rights. An attempt to send
 capabilities using an endpoint capability without the Grant right will
@@ -173,6 +173,10 @@ position of the receiver's badges array, and the kernel sets the n-th bit (count
 least significant) in the \texttt{capsUnwrapped} field of the message
 tag. The capability itself is not transferred, so the receive slot may be used
 for another capability.
+
+A capability that is not unwrapped is transferred by copying it from the
+sender's CNode slot to the receiver's CNode slot. The sender retains access
+to the sent capability.
 
 If a receiver gets a message whose tag has an \texttt{extraCaps} of 2 and a
 \texttt{capsUnwrapped} of 2, then the first capability in the message was


### PR DESCRIPTION
"Transfer" kind of sounds like it has move semantics.