### PR TITLE
python2 --> python3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ include(tools/internal.cmake)
 
 # Define tools used by the kernel
 set(PYTHON "python" CACHE INTERNAL "")
+set(PYTHON3 "python3" CACHE INTERNAL "")
 RequireTool(CPP_GEN_PATH cpp_gen.sh)
 RequireTool(CIRCULAR_INCLUDES circular_includes.py)
 RequireTool(BF_GEN_PATH bitfield_gen.py)
@@ -319,7 +320,7 @@ add_custom_command(
     COMMAND
         ${CMAKE_COMMAND} -E remove -f "${syscall_dest}"
     COMMAND
-        ${PYTHON} "${SYSCALL_ID_GEN_PATH}"
+        ${PYTHON3} "${SYSCALL_ID_GEN_PATH}"
         --xml "${syscall_xml_base}/syscall.xml"
         --kernel_header "${syscall_dest}"
     DEPENDS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ endif()
 include(tools/internal.cmake)
 
 # Define tools used by the kernel
-set(PYTHON "python" CACHE INTERNAL "")
+set(PYTHON "python2" CACHE INTERNAL "")
 set(PYTHON3 "python3" CACHE INTERNAL "")
 RequireTool(CPP_GEN_PATH cpp_gen.sh)
 RequireTool(CIRCULAR_INCLUDES circular_includes.py)

--- a/config.cmake
+++ b/config.cmake
@@ -160,7 +160,7 @@ if(DEFINED KernelDTSList AND (NOT "${KernelDTSList}" STREQUAL ""))
         file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/gen_headers/plat/machine/")
         execute_process(
             COMMAND
-                ${PYTHON} "${HARDWARE_GEN_PATH}" --dtb "${KernelDTBPath}" --compatibility-strings
+                ${PYTHON3} "${HARDWARE_GEN_PATH}" --dtb "${KernelDTBPath}" --compatibility-strings
                 "${compatibility_outfile}" --output "${device_dest}" --config "${config_file}"
                 --schema "${config_schema}" --yaml "${platform_yaml}" --arch "${KernelArch}"
             INPUT_FILE /dev/stdin

--- a/libsel4/CMakeLists.txt
+++ b/libsel4/CMakeLists.txt
@@ -126,7 +126,7 @@ add_custom_command(
             "${CMAKE_CURRENT_SOURCE_DIR}/include/api/syscall.xsd"
             "${CMAKE_CURRENT_SOURCE_DIR}/include/api/syscall.xml"
     COMMAND
-        ${PYTHON} "${SYSCALL_ID_GEN_PATH}"
+        ${PYTHON3} "${SYSCALL_ID_GEN_PATH}"
         --xml "${CMAKE_CURRENT_SOURCE_DIR}/include/api/syscall.xml"
         --libsel4_header include/sel4/syscall.h
     DEPENDS
@@ -148,7 +148,7 @@ add_custom_command(
     COMMAND
         echo "CONFIG_WORD_SIZE=${KernelWordSize}" > config
     COMMAND
-        "${PYTHON}" "${SYSCALL_STUB_GEN_PATH}" ${buffer} -a "${KernelSel4Arch}" -c config -o
+        "${PYTHON3}" "${SYSCALL_STUB_GEN_PATH}" ${buffer} -a "${KernelSel4Arch}" -c config -o
         include/interfaces/sel4_client.h ${interface_xmls}
     DEPENDS
         "${SYSCALL_STUB_GEN_PATH}"

--- a/libsel4/tools/__init__.py
+++ b/libsel4/tools/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2017, Data61
 # Commonwealth Scientific and Industrial Research Organisation (CSIRO)

--- a/libsel4/tools/syscall_stub_gen.py
+++ b/libsel4/tools/syscall_stub_gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2017, Data61
 # Commonwealth Scientific and Industrial Research Organisation (CSIRO)

--- a/manual/Makefile
+++ b/manual/Makefile
@@ -40,7 +40,7 @@ mv	   = mv
 awk	   = awk
 R	   = R
 doxygen = doxygen
-PYTHON ?= python
+PYTHON ?= python3
 
 # To add a second target, simply append the basename of the .tex file here
 Targets    = manual

--- a/manual/tools/gen_env.py
+++ b/manual/tools/gen_env.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2017, Data61
 # Commonwealth Scientific and Industrial Research Organisation (CSIRO)

--- a/manual/tools/gen_invocations.py
+++ b/manual/tools/gen_invocations.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2017, Data61
 # Commonwealth Scientific and Industrial Research Organisation (CSIRO)

--- a/manual/tools/parse_doxygen_xml.py
+++ b/manual/tools/parse_doxygen_xml.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2017, Data61
 # Commonwealth Scientific and Industrial Research Organisation (CSIRO)
@@ -417,7 +417,7 @@ class MarkdownGenerator(Generator):
     def generate_enumerate_list(self, para, ref_dict, output):
         """ Returns a Markdown number list """
 
-        for num, item in zip(xrange(sys.maxint), para.contents):
+        for num, item in zip(range(sys.maxsize), para.contents):
             parsed_item = self.parse_para(item, ref_dict)
             output += "%d. %s" % (num, parsed_item) if parsed_item.rstrip() else ""
         return output

--- a/tools/bitfield_gen.py
+++ b/tools/bitfield_gen.py
@@ -1248,6 +1248,13 @@ def sign_extend_proof(high, base_bits, base_sign_extend):
         return ""
 
 
+def det_values(*dicts):
+    """Deterministically iterate over the values of each dict in `dicts`."""
+    def values(d):
+        return (d[key] for key in sorted(d.keys()))
+    return itertools.chain(*(values(d) for d in dicts))
+
+
 class TaggedUnion:
     def __init__(self, name, tagname, classes, tags):
         self.name = name
@@ -2750,7 +2757,7 @@ if __name__ == '__main__':
 
     # Prune list of names to generate
     name_list = []
-    for e in itertools.chain(blocks.values(), unions.values()):
+    for e in det_values(blocks, unions):
         name_list += e.make_names()
 
     name_list = set(name_list)
@@ -2783,7 +2790,7 @@ if __name__ == '__main__':
             print(defs_global_lemmas, file=out_file)
             print(file=out_file)
 
-            for e in blocks.values() + unions.values():
+            for e in det_values(blocks, unions):
                 e.generate_hol_defs(options)
 
             print("end", file=out_file)
@@ -2793,13 +2800,13 @@ if __name__ == '__main__':
             print("  \"%s/KernelState_C\"" % (
                 os.path.relpath(options.cspec_dir,
                                 os.path.dirname(out_file.filename))), file=out_file)
-            for e in blocks.values() + unions.values():
+            for e in det_values(blocks, unions):
                 print("  %s_%s_defs" % (module_name, e.name),
                       file=out_file)
             print("begin", file=out_file)
             print("end", file=out_file)
 
-            for e in blocks.values() + unions.values():
+            for e in det_values(blocks, unions):
                 base_filename = \
                     os.path.basename(options.multifile_base).split('.')[0]
                 submodule_name = base_filename + "_" + \
@@ -2819,7 +2826,8 @@ if __name__ == '__main__':
                 print("end", file=out_file)
     elif options.hol_proofs:
         def is_bit_type(tp):
-            return (umm.is_base(tp) & (umm.base_name(tp) in map(lambda e: e.name + '_C', blocks.values() + unions.values())))
+            return umm.is_base(tp) & (umm.base_name(tp) in
+                                      map(lambda e: e.name + '_C', det_values(blocks, unions)))
 
         tps = umm.build_types(options.umm_types_file)
         type_map = {}
@@ -2843,7 +2851,7 @@ if __name__ == '__main__':
             print(file=out_file)
             print(file=out_file)
 
-            for e in blocks.values() + unions.values():
+            for e in det_values(blocks, unions):
                 e.generate_hol_proofs(options, type_map)
 
             print("end", file=out_file)
@@ -2851,13 +2859,13 @@ if __name__ == '__main__':
             # top types are broken here.
             print("theory %s_proofs" % module_name, file=out_file)
             print("imports", file=out_file)
-            for e in blocks.values() + unions.values():
+            for e in det_values(blocks, unions):
                 print("  %s_%s_proofs" % (module_name, e.name),
                       file=out_file)
             print("begin", file=out_file)
             print("end", file=out_file)
 
-            for e in blocks.values() + unions.values():
+            for e in det_values(blocks, unions):
                 base_filename = \
                     os.path.basename(options.multifile_base).split('.')[0]
                 submodule_name = base_filename + "_" + \
@@ -2881,7 +2889,7 @@ if __name__ == '__main__':
               {'guard': guard}, file=out_file)
         print('\n'.join(map(lambda x: '#include <%s>' % x,
                             INCLUDES[options.environment])), file=out_file)
-        for e in itertools.chain(blocks.values(), unions.values()):
+        for e in det_values(blocks, unions):
             e.generate(options)
         print("#endif", file=out_file)
 

--- a/tools/bitfield_gen.py
+++ b/tools/bitfield_gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # Copyright 2017, Data61

--- a/tools/circular_includes.py
+++ b/tools/circular_includes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2017, Data61
 # Commonwealth Scientific and Industrial Research Organisation (CSIRO)

--- a/tools/hardware_gen.py
+++ b/tools/hardware_gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2018, Data61
 # Commonwealth Scientific and Industrial Research Organisation (CSIRO)

--- a/tools/helpers.cmake
+++ b/tools/helpers.cmake
@@ -117,7 +117,7 @@ function(GenBFCommand args target_name pbf_path pbf_target deps)
     add_custom_command(
         OUTPUT "${target_name_absolute}"
         COMMAND
-            "${PYTHON}" "${BF_GEN_PATH}" "${args}" "${pbf_path_absolute}" "${target_name_absolute}"
+            "${PYTHON3}" "${BF_GEN_PATH}" "${args}" "${pbf_path_absolute}" "${target_name_absolute}"
         DEPENDS
             "${BF_GEN_PATH}"
             "${pbf_path_absolute}"

--- a/tools/internal.cmake
+++ b/tools/internal.cmake
@@ -44,7 +44,7 @@ function(gen_invocation_header)
         OUTPUT "${GEN_OUTPUT}"
         COMMAND rm -f "${GEN_OUTPUT}"
         COMMAND
-            "${PYTHON}" "${INVOCATION_ID_GEN_PATH}"
+            "${PYTHON3}" "${INVOCATION_ID_GEN_PATH}"
             --xml "${xml_absolute}" ${libsel4_setting} ${arch_setting}
             --dest "${GEN_OUTPUT}"
         DEPENDS "${xml_absolute}" "${INVOCATION_ID_GEN_PATH}"

--- a/tools/invocation_header_gen.py
+++ b/tools/invocation_header_gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2017, Data61
 # Commonwealth Scientific and Industrial Research Organisation (CSIRO)

--- a/tools/python-deps/setup.py
+++ b/tools/python-deps/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2017, Data61
 # Commonwealth Scientific and Industrial Research Organisation (CSIRO)

--- a/tools/syscall_header_gen.py
+++ b/tools/syscall_header_gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2017, Data61
 # Commonwealth Scientific and Industrial Research Organisation (CSIRO)

--- a/tools/umm.py
+++ b/tools/umm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # Copyright 2017, Data61


### PR DESCRIPTION
Update all scripts and build system to call python3, given python2's
upcoming doom. Use sys.maxsize instead of sys.maxint in one script
(maxint does not exist in python3).