### PR TITLE
manual: Correct CNode slot size in bytes

### DIFF
--- a/manual/parts/cspace.tex
+++ b/manual/parts/cspace.tex
@@ -63,9 +63,10 @@ individual capabilities within their CSpaces when invoking methods.
 CSpaces are created by creating and manipulating \obj{CNode} objects.
 When creating a \obj{CNode} the user must specify the number of slots
 that it will have, and this determines the amount of memory that it
-will use. Each slot requires 16 bytes of physical memory and has the
-capacity to hold exactly one capability. Like any other object, a
-\obj{CNode} must be created by calling
+will use. Each slot requires $2^\texttt{seL4\_SlotBits}$ bytes of physical
+memory and has the capacity to hold exactly one capability. This is 16
+bytes on 32-bit architectures and 32 bytes on 64-bit architectures.
+Like any other object, a \obj{CNode} must be created by calling
 \apifunc{seL4\_Untyped\_Retype}{untyped_retype} on an appropriate
 amount of untyped memory (see \autoref{sec:object_sizes}).  The caller
 must therefore have a capability to enough untyped memory as well as

--- a/manual/parts/objects.tex
+++ b/manual/parts/objects.tex
@@ -401,7 +401,10 @@ argument to \apifunc{seL4\_Untyped\_Retype}{untyped_retype} is ignored.
     \toprule
     Type & Meaning of \texttt{size\_bits} & Size in Bytes  \\
     \midrule
-    \obj{CNode} & $\log_2$ number of slots & $2^\texttt{size\_bits} \cdot 16$ \\
+    \obj{CNode} & $\log_2$ number of slots & $2^\texttt{size\_bits} \cdot 2^\texttt{seL4\_SlotBits}$
+	  \texttt{seL4\_SlotBits} is: \newline
+	  \emph{on 32-bit architectures:} 4 \newline
+	  \emph{on 64-bit architectures:} 5 \\
     \obj{Untyped} & $\log_2$ size in bytes & $2^\texttt{size\_bits}$ \\
     \bottomrule
   \end{tabularx}


### PR DESCRIPTION
It is 16 bytes on 32-bit systems and 32 bytes on 64-bit systems