### PR TITLE
Expand and fix arm architecture-specific object method documentation

### DIFF
--- a/libsel4/arch_include/arm/interfaces/sel4arch.xml
+++ b/libsel4/arch_include/arm/interfaces/sel4arch.xml
@@ -21,9 +21,15 @@
                 Takes a VSpace capability as an argument,
                 and installs a reference to the invoked
                 <texttt text='PageTable'/> in the VSpace according to the provided virtual address.
+                If higher-level paging structures do not exist for the virtual address
+                this operation will fail, returning a seL4_FailedLookup error. If the page table
+                is already mapped this operation will fail, returning a seL4_InvalidCapability error. If
+                another object is already mapped at this level for the virtual address
+                this operation will fail, returning a seL4_DeleteFirst error.
             </description>
             <param dir="in" name="vspace" type="seL4_CPtr"
-            description="Capability to the VSpace which will contain the mapping."/>
+            description="Capability to the VSpace which will contain the mapping.
+                Must be assigned to an ASID pool."/>
             <param dir="in" name="vaddr" type="seL4_Word"
             description="Virtual address to map the page into."/>
             <param dir="in" name="attr" type="seL4_ARM_VMAttributes">
@@ -42,7 +48,8 @@
             </description>
         </method>
     </interface>
-    <interface name="seL4_ARM_IOPageTable" manual_name="I/O Page Table">
+    <interface name="seL4_ARM_IOPageTable" manual_name="I/O Page Table"
+        cap_description="Capability to the I/O page table being operated on.">
         <method id="ARMIOPageTableMap" name="Map" condition="defined(CONFIG_ARM_SMMU)">
             <param dir="in" name="iospace" type="seL4_ARM_IOSpace"/>
             <param dir="in" name="ioaddr" type="seL4_Word"/>
@@ -60,11 +67,15 @@
                 Takes a VSpace capability, as an
                 argument and installs a reference
                 to the given <texttt text="Page"/> in the lowest-level unmapped paging structure
-                corresponding to the given address, or updates the mapping attributes if the page is already mapped at this address. If the required paging structures are not present
-                this operation will fail, returning a seL4_FailedLookup error.
+		corresponding to the given address, or updates the mapping attributes if the page is
+		already mapped at this address. If the required paging structures are not present
+                this operation will fail, returning a seL4_FailedLookup error. The page must not
+		already be mapped through this capability in a different VSpace or at a different
+		address; the page may be mapped in multiple VSpaces by copying the capability.
             </description>
             <param dir="in" name="vspace" type="seL4_CPtr"
-            description="Capability to the VSpace which will contain the mapping."/>
+            description="Capability to the VSpace which will contain the mapping.
+                Must be assigned to an ASID pool."/>
             <param dir="in" name="vaddr" type="seL4_Word"
             description="Virtual address to map the page into."/>
             <param dir="in" name="rights" type="seL4_CapRights_t">
@@ -204,7 +215,8 @@
             description="The VSpace that is being assigned to an ASID pool. Must not already be assigned to an ASID pool."/>
         </method>
     </interface>
-    <interface name="seL4_ARM_VCPU" manual_name="VCPU">
+    <interface name="seL4_ARM_VCPU" manual_name="VCPU"
+        cap_description="Capability to the VCPU being operated on.">
         <method id="ARMVCPUSetTCB" name="SetTCB" condition="defined(CONFIG_ARM_HYPERVISOR_SUPPORT)"
             manual_name="Set TCB">
                 <brief>

--- a/libsel4/sel4_arch_include/aarch32/interfaces/sel4arch.xml
+++ b/libsel4/sel4_arch_include/aarch32/interfaces/sel4arch.xml
@@ -31,7 +31,8 @@
         <member name="r14"/>
         <member name="tpidrurw"/>
     </struct>
-    <interface name="seL4_ARM_PageDirectory" manual_name="Page Directory">
+    <interface name="seL4_ARM_PageDirectory" manual_name="Page Directory"
+        cap_description="Capability to the page directory being operated on.">
         <method id="ARMPDClean_Data" name="Clean_Data" manual_name="Clean Data" manual_label="pd_clean">
                 <brief>
                     Clean cached pages within a page directory

--- a/libsel4/sel4_arch_include/aarch64/interfaces/sel4arch.xml
+++ b/libsel4/sel4_arch_include/aarch64/interfaces/sel4arch.xml
@@ -49,7 +49,8 @@
         <member name="tpidr_el0"/>
         <member name="tpidrro_el0"/>
     </struct>
-    <interface name="seL4_ARM_VSpace" manual_name="Page Global Directory">
+    <interface name="seL4_ARM_VSpace" manual_name="Page Global Directory"
+        cap_description="Capability to the top level translation table being operated on.">
         <method id="ARMVSpaceClean_Data" name="Clean_Data" manual_label="vspace_clean"
             manual_name="Clean Data">
                 <brief>
@@ -97,43 +98,63 @@
              <description>
                  <docref>See <autoref label="ch:vspace"/>.</docref>
              </description>
-            <param dir="in" name="start" type="seL4_Word"/>
-            <param dir="in" name="end" type="seL4_Word"/>
+             <param dir="in" name="start" type="seL4_Word"
+             description="Start address"/>
+             <param dir="in" name="end" type="seL4_Word"
+	     description="End address"/>
         </method>
     </interface>
-    <interface name="seL4_ARM_PageUpperDirectory" manual_name="Page Upper Directory">
+    <interface name="seL4_ARM_PageUpperDirectory" manual_name="Page Upper Directory"
+        cap_description="Capability to the upper page directory being operated on.">
         <method id="ARMPageUpperDirectoryMap" name="Map" condition="!(defined CONFIG_ARM_HYPERVISOR_SUPPORT &amp;&amp; defined CONFIG_ARM_PA_SIZE_BITS_40)">
                 <brief>
                     Map an upper page directory
                 </brief>
                 <description>
-                    Map an upper page directory (level 1) to a top level translation table (level 0)
+                    Map an upper page directory (level 1) to a top level translation table (level 0).
+                    If the upper page directory is already mapped this operation will fail,
+                    returning a seL4_InvalidCapability error. If another object is already mapped at this
+                    level for the virtual address this operation will fail,
+                    returning a seL4_DeleteFirst error.
                 </description>
             <param dir="in" name="vspace" type="seL4_CPtr"
-            description="top level translation table"/>
+            description="Top level translation table. Must be assigned to an ASID pool."/>
             <param dir="in" name="vaddr" type="seL4_Word"
             description="Virtual address"/>
-            <param dir="in" name="attr" type="seL4_ARM_VMAttributes"
-            description="Memory attributes"/>
+            <param dir="in" name="attr" type="seL4_ARM_VMAttributes">
+                <description>
+                    VM Attributes for the mapping.<docref>Possible values for this type are given in <autoref label="ch:vspace"/>  .</docref>
+                </description>
+            </param>
         </method>
         <method id="ARMPageUpperDirectoryUnmap" name="Unmap"
             condition="!(defined CONFIG_ARM_HYPERVISOR_SUPPORT &amp;&amp; defined CONFIG_ARM_PA_SIZE_BITS_40)">
         </method>
     </interface>
-    <interface name="seL4_ARM_PageDirectory" manual_name="Page Directory">
+    <interface name="seL4_ARM_PageDirectory" manual_name="Page Directory"
+        cap_description="Capability to the page directory being operated on.">
         <method id="ARMPageDirectoryMap" name="Map">
                 <brief>
                     Map a page directory
                 </brief>
                 <description>
-                    Map a page directory (level 2) to an upper page directory (level 1)
+                    Map a page directory (level 2) to an upper page directory (level 1).
+                    If an upper page directory does not exist for the virtual address this
+                    operation will fail, returning a seL4_FailedLookup error. If the page
+                    directory is already mapped this operation will fail,
+                    returning a seL4_InvalidCapability error. If another object is already mapped
+                    at this level for the virtual address this operation will
+                    fail, returning a seL4_DeleteFirst error.
                 </description>
             <param dir="in" name="vspace" type="seL4_CPtr"
             description="Top level translation table. Must be assigned to an ASID pool."/>
             <param dir="in" name="vaddr" type="seL4_Word"
             description="Virtual adress"/>
-            <param dir="in" name="attr" type="seL4_ARM_VMAttributes"
-            description="Memory attributes"/>
+            <param dir="in" name="attr" type="seL4_ARM_VMAttributes">
+                <description>
+                    VM Attributes for the mapping.<docref>Possible values for this type are given in <autoref label="ch:vspace"/>  .</docref>
+                </description>
+            </param>
         </method>
         <method id="ARMPageDirectoryUnmap" name="Unmap">
                 <brief>

--- a/libsel4/sel4_arch_include/aarch64/interfaces/sel4arch.xml
+++ b/libsel4/sel4_arch_include/aarch64/interfaces/sel4arch.xml
@@ -128,8 +128,8 @@
                 <description>
                     Map a page directory (level 2) to an upper page directory (level 1)
                 </description>
-            <param dir="in" name="pud" type="seL4_CPtr"
-            description="Upper page directory"/>
+            <param dir="in" name="vspace" type="seL4_CPtr"
+            description="Top level translation table. Must be assigned to an ASID pool."/>
             <param dir="in" name="vaddr" type="seL4_Word"
             description="Virtual adress"/>
             <param dir="in" name="attr" type="seL4_ARM_VMAttributes"


### PR DESCRIPTION
- Fill in some missing object and parameter descriptions
- Vspace mapping functions always take the vspace root as the argument
- Document more error conditions in vspace mapping functions