### PR TITLE
boot: on arm, expose all pptrs as device memory

### DIFF
--- a/include/kernel/boot.h
+++ b/include/kernel/boot.h
@@ -62,6 +62,7 @@ void write_it_pd_pts(cap_t root_cnode_cap, cap_t it_pd_cap);
 bool_t create_idle_thread(void);
 bool_t create_untypeds_for_region(cap_t root_cnode_cap, bool_t device_memory, region_t reg,
                                   seL4_SlotPos first_untyped_slot);
+bool_t create_device_untypeds(cap_t root_cnode_cap, seL4_SlotPos first_untyped_slot);
 bool_t create_kernel_untypeds(cap_t root_cnode_cap, region_t boot_mem_reuse_reg, seL4_SlotPos first_untyped_slot);
 void bi_finalise(void);
 void create_domain_cap(cap_t root_cnode_cap);

--- a/src/arch/arm/kernel/boot.c
+++ b/src/arch/arm/kernel/boot.c
@@ -128,29 +128,11 @@ BOOT_CODE static void init_irqs(cap_t root_cnode_cap)
 
 BOOT_CODE static bool_t create_untypeds(cap_t root_cnode_cap, region_t boot_mem_reuse_reg)
 {
-    seL4_SlotPos   slot_pos_before;
-    seL4_SlotPos   slot_pos_after;
-    region_t       dev_reg;
-    word_t         i;
-
-    slot_pos_before = ndks_boot.slot_pos_cur;
+    seL4_SlotPos slot_pos_before = ndks_boot.slot_pos_cur;
+    /* create device untypeds for all non-ram addresses */
+    create_device_untypeds(root_cnode_cap, slot_pos_before);
     create_kernel_untypeds(root_cnode_cap, boot_mem_reuse_reg, slot_pos_before);
-    UNUSED paddr_t current_region_pos = 0;
-    for (i = 0; i < get_num_dev_p_regs(); i++) {
-        /* It is required that untyped regions are non-overlapping.
-         * We assume that hardware regions are defined in ascending order to make
-         * overlapping checks simpler
-         */
-        assert(get_dev_p_reg(i).start >= current_region_pos);
-        current_region_pos = get_dev_p_reg(i).end;
-        dev_reg = paddr_to_pptr_reg(get_dev_p_reg(i));
-        if (!create_untypeds_for_region(root_cnode_cap, true,
-                                        dev_reg, slot_pos_before)) {
-            return false;
-        }
-    }
-
-    slot_pos_after = ndks_boot.slot_pos_cur;
+    seL4_SlotPos slot_pos_after = ndks_boot.slot_pos_cur;
     ndks_boot.bi_frame->untyped = (seL4_SlotRegion) {
         slot_pos_before, slot_pos_after
     };

--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -472,6 +472,35 @@ BOOT_CODE bool_t create_untypeds_for_region(
     return true;
 }
 
+BOOT_CODE bool_t create_device_untypeds(cap_t root_cnode_cap, seL4_SlotPos first_untyped_slot)
+{
+    /* convert remaining freemem into UT objects and provide the caps */
+    pptr_t start = BASE_OFFSET;
+    for (word_t i = 0; i < MAX_NUM_FREEMEM_REG; i++) {
+        if (start < ndks_boot.freemem[i].start) {
+            region_t notram = {
+                .start = start,
+                .end = MIN(ndks_boot.freemem[i].start, PPTR_TOP)
+            };
+            if (!create_untypeds_for_region(root_cnode_cap, true, notram, first_untyped_slot)) {
+                return false;
+            }
+            start = notram.end;
+        }
+    }
+
+    if (start < PPTR_TOP) {
+        region_t notram = {
+            .start = start,
+            .end = PPTR_TOP
+        };
+        if (!create_untypeds_for_region(root_cnode_cap, true, notram, first_untyped_slot)) {
+            return false;
+        }
+    }
+    return true;
+}
+
 BOOT_CODE bool_t create_kernel_untypeds(cap_t root_cnode_cap, region_t boot_mem_reuse_reg,
                                         seL4_SlotPos first_untyped_slot)
 {


### PR DESCRIPTION
Some platforms have large amounts of devices which end up creating too
many untypeds to fit into boot info. Consequently we change the approach
on arm, and bring it in line with x86 to expose all non-kernel memory as
device untyped.

There's more to be done as a result of this PR: hardware_gen should stop generating the now-unused device list. You could also use the same approach on RISC-V, and it should be possible to make the x86 code more consistent with the arm code. However, I don't have time for this currently. My preference is to merge this now (assuming it doesn't break any platforms/projects), but am just putting it up to share/build-on. 