### PR TITLE
Multicore vmm

### DIFF
--- a/include/arch/arm/arch/object/interrupt.h
+++ b/include/arch/arm/arch/object/interrupt.h
@@ -35,7 +35,7 @@ static inline void handleReservedIRQ(irq_t irq)
 #endif /* CONFIG_ARM_ENABLE_PMU_OVERFLOW_INTERRUPT */
 
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
-    if (irq == INTERRUPT_VGIC_MAINTENANCE) {
+    if (IDX_TO_IRQ(irq) == INTERRUPT_VGIC_MAINTENANCE) {
         VGICMaintenance();
         return;
     }

--- a/src/arch/arm/kernel/boot.c
+++ b/src/arch/arm/kernel/boot.c
@@ -264,6 +264,10 @@ BOOT_CODE static bool_t try_init_kernel_secondary_core(void)
     /* Enable per-CPU timer interrupts */
     setIRQState(IRQTimer, CORE_IRQ_TO_IDX(getCurrentCPUIndex(), KERNEL_TIMER_IRQ));
 
+#ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
+    setIRQState(IRQReserved, CORE_IRQ_TO_IDX(getCurrentCPUIndex(), INTERRUPT_VGIC_MAINTENANCE));
+#endif
+
     NODE_LOCK_SYS;
 
     ksNumCPUs++;

--- a/src/object/interrupt.c
+++ b/src/object/interrupt.c
@@ -41,7 +41,7 @@ exception_t decodeIRQControlInvocation(word_t invLabel, word_t length,
             return EXCEPTION_SYSCALL_ERROR;
         }
         irq_w = getSyscallArg(0, buffer);
-        irq = CORE_IRQ_TO_IDX(0, irq_w);
+        irq = CORE_IRQ_TO_IDX(getCurrentCPUIndex(), irq_w);
         index = getSyscallArg(1, buffer);
         depth = getSyscallArg(2, buffer);
 


### PR DESCRIPTION
Just a couple commits that allow VMMs to run on secondary cores. These commits don't address the issue of getting the virtual timer irq to trigger (that needs to happen in userspace), but once the interrupt is turned on, then this allows the vms to function when running on secondary cores.