### PR TITLE
aarch64: fix fpsimd_HWCapTest

### DIFF
--- a/src/arch/arm/64/machine/fpu.c
+++ b/src/arch/arm/64/machine/fpu.c
@@ -36,8 +36,8 @@ BOOT_CODE bool_t fpsimd_HWCapTest(void)
 
     /* Check if the hardware has FP and ASIMD support... */
     MRS("id_aa64pfr0_el1", id_aa64pfr0);
-    if ((id_aa64pfr0 >> ID_AA64PFR0_EL1_FP) & MASK(4) ||
-        (id_aa64pfr0 >> ID_AA64PFR0_EL1_ASIMD) & MASK(4)) {
+    if (((id_aa64pfr0 >> ID_AA64PFR0_EL1_FP) & MASK(4)) == MASK(4) ||
+        ((id_aa64pfr0 >> ID_AA64PFR0_EL1_ASIMD) & MASK(4)) == MASK(4)) {
         return false;
     }
 


### PR DESCRIPTION
Prior to this commit this check was invalid for aarch64.

On aarch64 a value the values of the AdvSIMD/FP bits in ID_AA64PFR0_EL1
are as follows:

- 0b1111 means FPU/SIMD is not supported.
- 0b0000 means FPU/SIMD is supported except for half-precision floating
point arithmetic.
- 0b0001 means FPU/SIMD is supported including half-precision floating
point arithmetic.

See the ARMv8 manual for more detail.