### PR TITLE
mcs: ensure that all checks are performed on ticks

### DIFF
--- a/src/object/schedcontrol.c
+++ b/src/object/schedcontrol.c
@@ -103,7 +103,9 @@ static exception_t decodeSchedControl_Configure(word_t length, cap_t cap, extra_
     }
 
     time_t budget_us = mode_parseTimeArg(0, buffer);
+    ticks_t budget = usToTicks(budget_us);
     time_t period_us = mode_parseTimeArg(TIME_ARG_SIZE, buffer);
+    ticks_t period = usToTicks(period_us);
     word_t extra_refills = getSyscallArg(TIME_ARG_SIZE * 2, buffer);
     word_t badge = getSyscallArg(TIME_ARG_SIZE * 2 + 1, buffer);
 
@@ -115,7 +117,7 @@ static exception_t decodeSchedControl_Configure(word_t length, cap_t cap, extra_
         return EXCEPTION_SYSCALL_ERROR;
     }
 
-    if (budget_us > getMaxUsToTicks() || budget_us < MIN_BUDGET_US) {
+    if (budget_us > getMaxUsToTicks() || budget < MIN_BUDGET) {
         userError("SchedControl_Configure: budget out of range.");
         current_syscall_error.type = seL4_RangeError;
         current_syscall_error.rangeErrorMin = MIN_BUDGET_US;
@@ -123,7 +125,7 @@ static exception_t decodeSchedControl_Configure(word_t length, cap_t cap, extra_
         return EXCEPTION_SYSCALL_ERROR;
     }
 
-    if (period_us > getMaxUsToTicks() || period_us < MIN_BUDGET_US) {
+    if (period_us > getMaxUsToTicks() || period < MIN_BUDGET) {
         userError("SchedControl_Configure: period out of range.");
         current_syscall_error.type = seL4_RangeError;
         current_syscall_error.rangeErrorMin = MIN_BUDGET_US;
@@ -131,7 +133,7 @@ static exception_t decodeSchedControl_Configure(word_t length, cap_t cap, extra_
         return EXCEPTION_SYSCALL_ERROR;
     }
 
-    if (budget_us > period_us) {
+    if (budget > period) {
         userError("SchedControl_Configure: budget must be <= period");
         current_syscall_error.type = seL4_RangeError;
         current_syscall_error.rangeErrorMin = MIN_BUDGET_US;
@@ -152,8 +154,8 @@ static exception_t decodeSchedControl_Configure(word_t length, cap_t cap, extra_
     setThreadState(NODE_STATE(ksCurThread), ThreadState_Restart);
     return invokeSchedControl_Configure(SC_PTR(cap_sched_context_cap_get_capSCPtr(targetCap)),
                                         cap_sched_control_cap_get_core(cap),
-                                        usToTicks(budget_us),
-                                        usToTicks(period_us),
+                                        budget,
+                                        period,
                                         extra_refills + MIN_REFILLS,
                                         badge);
 }


### PR DESCRIPTION
Although the configuration of WCET, domain time, and scheduling
contexts are provided in milliseconds or microseconds, all of the
comparisons must occur after the values have been converted to timer
ticks.

This is needed as the conversion is not guaranteed to preserve the
properties of the checks due to possible truncation.