### PR TITLE
mcs: Donate scheduling context from bound ntfn

### DIFF
--- a/include/object/schedcontext.h
+++ b/include/object/schedcontext.h
@@ -74,6 +74,10 @@ void schedContext_bindNtfn(sched_context_t *sc, notification_t *ntfn);
 /* unbind scheduling context from a notification */
 void schedContext_unbindNtfn(sched_context_t *sc);
 
+/* Return a donated scheduling context to the notification to which it
+ * was bound if any is bound */
+void schedContext_maybeReturnToNtfn(sched_context_t *sc);
+
 time_t schedContext_updateConsumed(sched_context_t *sc);
 void schedContext_completeYieldTo(tcb_t *yielder);
 void schedContext_cancelYieldTo(tcb_t *yielder);

--- a/src/api/syscall.c
+++ b/src/api/syscall.c
@@ -23,6 +23,9 @@
 #include <machine/io.h>
 #include <plat/machine/hardware.h>
 #include <object/interrupt.h>
+#ifdef CONFIG_KERNEL_MCS
+#include <object/schedcontext.h>
+#endif
 #include <model/statedata.h>
 #include <string.h>
 #include <kernel/traps.h>
@@ -464,6 +467,13 @@ static void handleRecv(bool_t isBlocking)
         handleFault(NODE_STATE(ksCurThread));
         return;
     }
+
+#ifdef CONFIG_KERNEL_MCS
+    if (isBlocking) {
+        /* Return any SC donated from a notification object */
+        schedContext_maybeReturnToNtfn(NODE_STATE(ksCurThread)->tcbSchedContext, NODE_STATE(ksCurThread));
+    }
+#endif
 
     switch (cap_get_capType(lu_ret.cap)) {
     case cap_endpoint_cap:

--- a/src/object/notification.c
+++ b/src/object/notification.c
@@ -263,6 +263,9 @@ void completeSignal(notification_t *ntfnPtr, tcb_t *tcb)
         badge = notification_ptr_get_ntfnMsgIdentifier(ntfnPtr);
         setRegister(tcb, badgeRegister, badge);
         notification_ptr_set_state(ntfnPtr, NtfnState_Idle);
+#ifdef CONFIG_KERNEL_MCS
+        maybeDonateSchedContext(tcb, ntfnPtr);
+#endif
     } else {
         fail("tried to complete signal with inactive notification object");
     }

--- a/src/object/notification.c
+++ b/src/object/notification.c
@@ -54,16 +54,6 @@ static inline void maybeDonateSchedContext(tcb_t *tcb, notification_t *ntfnPtr)
         }
     }
 }
-
-static inline void maybeReturnSchedContext(notification_t *ntfnPtr, tcb_t *tcb)
-{
-
-    sched_context_t *sc = SC_PTR(notification_ptr_get_ntfnSchedContext(ntfnPtr));
-    if (sc == tcb->tcbSchedContext) {
-        tcb->tcbSchedContext = NULL;
-        sc->scTcb = NULL;
-    }
-}
 #endif
 
 #ifdef CONFIG_KERNEL_MCS
@@ -182,9 +172,6 @@ void receiveSignal(tcb_t *thread, cap_t cap, bool_t isBlocking)
                                         ThreadState_BlockedOnNotification);
             thread_state_ptr_set_blockingObject(&thread->tcbState,
                                                 NTFN_REF(ntfnPtr));
-#ifdef CONFIG_KERNEL_MCS
-            maybeReturnSchedContext(ntfnPtr, thread);
-#endif
             scheduleTCB(thread);
 
             /* Enqueue TCB */

--- a/src/object/schedcontext.c
+++ b/src/object/schedcontext.c
@@ -354,6 +354,17 @@ void schedContext_unbindNtfn(sched_context_t *sc)
     }
 }
 
+void schedContext_maybeReturnToNtfn(sched_context_t *sc, tcb_t *tcb)
+{
+    assert(sc->scTcb == tcb);
+    assert(tcb->tcbSchedContext == sc);
+    if (sc->scNotification != NULL) {
+        assert(SC_PTR(notification_ptr_get_ntfnSchedContext(sc->scNotification)) == sc);
+        sc->scTcb == NULL;
+        tcb->tcbSchedContext == NULL;
+    }
+}
+
 time_t schedContext_updateConsumed(sched_context_t *sc)
 {
     ticks_t consumed = sc->scConsumed;


### PR DESCRIPTION
When a passive server receives a signal from a bound notification object
the SC from the bound notification object should be donated to the TCB
in order to handle the notification.