### PR TITLE
aarch64: fix FAR_EL1 width in writeFAR

### DIFF
--- a/include/arch/arm/armv/armv8-a/64/armv/vcpu.h
+++ b/include/arch/arm/armv/armv8-a/64/armv/vcpu.h
@@ -256,7 +256,7 @@ static inline word_t readFAR(void)
 
 static inline void writeFAR(word_t reg)
 {
-    MSR(REG_FAR_EL1, (uint32_t)reg);
+    MSR(REG_FAR_EL1, reg);
 }
 
 /* ISR is read-only */

--- a/include/arch/arm/armv/armv8-a/64/armv/vcpu.h
+++ b/include/arch/arm/armv/armv8-a/64/armv/vcpu.h
@@ -300,7 +300,7 @@ static inline word_t readELR_EL1(void)
 
 static inline void writeELR_EL1(word_t reg)
 {
-    MRS(REG_ELR_EL1, reg);
+    MSR(REG_ELR_EL1, reg);
 }
 
 static inline word_t readSPSR_EL1(void)


### PR DESCRIPTION
Fixes a bug where `writeFAR` was only writing to the low 32 bits of the 64-bit `FAR_EL1` register.