### PR TITLE
Use autoconf definition for `RetypeMaxObjects` def

### DIFF
--- a/libsel4/include/sel4/types.h
+++ b/libsel4/include/sel4/types.h
@@ -31,7 +31,11 @@
 #include <sel4/shared_types.h>
 #include <sel4/mode/types.h>
 
-#define seL4_UntypedRetypeMaxObjects 256
+#ifdef CONFIG_RETYPE_FAN_OUT_LIMIT
+#  define seL4_UntypedRetypeMaxObjects CONFIG_RETYPE_FAN_OUT_LIMIT
+#else
+#  define seL4_UntypedRetypeMaxObjects 256
+#endif
 
 typedef seL4_CPtr seL4_CNode;
 typedef seL4_CPtr seL4_IRQHandler;


### PR DESCRIPTION
Relates to #168. The definition for `seL4_UntypedRetypeMaxObjects` lives
in the UAPI `types.h` but appears to have no link to the value actually
used by the kernel, which is configurable. This change sets the UAPI
definition to the generated definition from the kernel config steps and
defaults to the previous fixed value if, for some reason, the configured
definition is not available.