### PR TITLE
RISCV: Added stdout-path to hifive dts

### DIFF
--- a/tools/dts/hifive.dts
+++ b/tools/dts/hifive.dts
@@ -16,6 +16,7 @@
     serial1 = <0x2f736f63 0x2f736572 0x69616c40 0x31303031 0x31303030>;
   };
   chosen {
+    stdout-path = "/soc/serial@10010000";
   };
   firmware {
     sifive,fsbl = "2018-03-20";


### PR DESCRIPTION
This sets the first UART as the stdout-path dts setting in the
"chosen" node in the HiFive device tree.

Change-Id: Icb6b9abf999bdd8a278df5a2ba73ad492af06a24