### PR TITLE
mcs: Maintain IPC invariants

### DIFF
--- a/include/kernel/faulthandler.h
+++ b/include/kernel/faulthandler.h
@@ -21,7 +21,7 @@ static inline bool_t validTimeoutHandler(tcb_t *tptr)
 
 void handleTimeout(tcb_t *tptr);
 void handleNoFaultHandler(tcb_t *tptr);
-bool_t sendFaultIPC(tcb_t *tptr, cap_t handlerCap, bool_t can_donate);
+bool_t sendFaultIPC(tcb_t *tptr, cap_t handlerCap);
 #else
 exception_t sendFaultIPC(tcb_t *tptr);
 void handleDoubleFault(tcb_t *tptr, seL4_Fault_t ex1);

--- a/include/kernel/sporadic.h
+++ b/include/kernel/sporadic.h
@@ -108,11 +108,11 @@ static inline bool_t refill_sufficient(sched_context_t *sc, ticks_t usage)
  */
 static inline bool_t refill_ready(sched_context_t *sc)
 {
-    return REFILL_HEAD(sc).rTime <= (NODE_STATE(ksCurTime) + getKernelWcetTicks());
+    return REFILL_HEAD(sc).rTime <= (NODE_STATE_ON_CORE(ksCurTime, sc->scCore) + getKernelWcetTicks());
 }
 
 /* Create a new refill in a non-active sc */
-void refill_new(sched_context_t *sc, word_t max_refills, ticks_t budget, ticks_t period);
+void refill_new(sched_context_t *sc, word_t max_refills, ticks_t budget, ticks_t period, word_t core);
 
 /* Update refills in an active sc without violating bandwidth constraints */
 void refill_update(sched_context_t *sc, ticks_t new_period, ticks_t new_budget, word_t new_max_refills);

--- a/include/kernel/thread.h
+++ b/include/kernel/thread.h
@@ -97,6 +97,16 @@ static inline bool_t isCurDomainExpired(void)
            ksDomainTime < (NODE_STATE(ksConsumed) + MIN_BUDGET);
 }
 
+static inline bool_t threadFaulted(tcb_t *thread)
+{
+    return seL4_Fault_get_seL4_FaultType(thread->tcbFault) != seL4_Fault_NullFault;
+}
+
+static inline bool_t threadTimeoutFaulted(tcb_t *thread)
+{
+    return seL4_Fault_get_seL4_FaultType(thread->tcbFault) == seL4_Fault_Timeout;
+}
+
 static inline void commitTime(void)
 {
     if (NODE_STATE(ksCurSC)->scRefillMax) {

--- a/include/object/endpoint.h
+++ b/include/object/endpoint.h
@@ -24,16 +24,13 @@ static inline tcb_queue_t PURE ep_ptr_get_queue(endpoint_t *epptr)
     return queue;
 }
 
-#ifdef CONFIG_KERNEL_MCS
-void sendIPC(bool_t blocking, bool_t do_call, word_t badge,
-             bool_t canGrant, bool_t canGrantReply, bool_t canDonate, tcb_t *thread,
-             endpoint_t *epptr);
-void receiveIPC(tcb_t *thread, cap_t cap, bool_t isBlocking, cap_t replyCPtr);
-void reorderEP(endpoint_t *epptr, tcb_t *thread);
-#else
 void sendIPC(bool_t blocking, bool_t do_call, word_t badge,
              bool_t canGrant, bool_t canGrantReply, tcb_t *thread,
              endpoint_t *epptr);
+#ifdef CONFIG_KERNEL_MCS
+void receiveIPC(tcb_t *thread, cap_t cap, bool_t isBlocking, cap_t replyCPtr);
+void reorderEP(endpoint_t *epptr, tcb_t *thread);
+#else
 void receiveIPC(tcb_t *thread, cap_t cap, bool_t isBlocking);
 #endif
 void cancelIPC(tcb_t *tptr);

--- a/include/object/objecttype.h
+++ b/include/object/objecttype.h
@@ -34,10 +34,7 @@ void createNewObjects(object_t t, cte_t *parent, slot_range_t slots,
 exception_t decodeInvocation(word_t invLabel, word_t length,
                              cptr_t capIndex, cte_t *slot, cap_t cap,
                              extra_caps_t excaps, bool_t block, bool_t call,
-                             bool_t canDonate, bool_t firstPhase, word_t *buffer);
-exception_t performInvocation_Endpoint(endpoint_t *ep, word_t badge,
-                                       bool_t canGrant, bool_t canGrantReply,
-                                       bool_t block, bool_t call, bool_t canDonate);
+                             bool_t firstPhase, word_t *buffer);
 exception_t performInvocation_Notification(notification_t *ntfn,
                                            word_t badge);
 exception_t performInvocation_Reply(tcb_t *thread, reply_t *reply, bool_t canGrant);
@@ -46,13 +43,13 @@ exception_t decodeInvocation(word_t invLabel, word_t length,
                              cptr_t capIndex, cte_t *slot, cap_t cap,
                              extra_caps_t excaps, bool_t block, bool_t call,
                              word_t *buffer);
-exception_t performInvocation_Endpoint(endpoint_t *ep, word_t badge,
-                                       bool_t canGrant, bool_t canGrantReply,
-                                       bool_t block, bool_t call);
 exception_t performInvocation_Notification(notification_t *ntfn,
                                            word_t badge);
 exception_t performInvocation_Reply(tcb_t *thread, cte_t *slot, bool_t canGrant);
 #endif
+exception_t performInvocation_Endpoint(endpoint_t *ep, word_t badge,
+                                       bool_t canGrant, bool_t canGrantReply,
+                                       bool_t block, bool_t call);
 word_t getObjectSize(word_t t, word_t userObjSize);
 
 static inline void postCapDeletion(cap_t cap)

--- a/include/object/reply.h
+++ b/include/object/reply.h
@@ -29,7 +29,7 @@ static inline void reply_unlink(reply_t *reply)
 }
 
 /* Push a reply object onto the call stack */
-void reply_push(tcb_t *tcb_caller, tcb_t *tcb_callee, reply_t *reply, bool_t canDonate);
+void reply_push(tcb_t *tcb_caller, tcb_t *tcb_callee, reply_t *reply, bool_t isTimeout);
 /* Pop the head reply from the call stack */
 void reply_pop(reply_t *reply);
 /* Remove a reply from the call stack - replyTCB must be in ThreadState_BlockedOnReply */

--- a/src/api/syscall.c
+++ b/src/api/syscall.c
@@ -302,7 +302,7 @@ exception_t handleVMFaultEvent(vm_fault_type_t vm_faultType)
 }
 
 #ifdef CONFIG_KERNEL_MCS
-static exception_t handleInvocation(bool_t isCall, bool_t isBlocking, bool_t canDonate, bool_t firstPhase, cptr_t cptr)
+static exception_t handleInvocation(bool_t isCall, bool_t isBlocking, bool_t firstPhase, cptr_t cptr)
 #else
 static exception_t handleInvocation(bool_t isCall, bool_t isBlocking)
 #endif
@@ -356,7 +356,7 @@ static exception_t handleInvocation(bool_t isCall, bool_t isBlocking)
     status = decodeInvocation(seL4_MessageInfo_get_label(info), length,
                               cptr, lu_ret.slot, lu_ret.cap,
                               current_extra_caps, isBlocking, isCall,
-                              canDonate, firstPhase, buffer);
+                              firstPhase, buffer);
 #else
     status = decodeInvocation(seL4_MessageInfo_get_label(info), length,
                               cptr, lu_ret.slot, lu_ret.cap,
@@ -541,7 +541,7 @@ static inline void mcsIRQ(irq_t irq)
 #else
 #define handleRecv(isBlocking, canReply) handleRecv(isBlocking)
 #define mcsIRQ(irq)
-#define handleInvocation(isCall, isBlocking, canDonate, firstPhase, cptr) handleInvocation(isCall, isBlocking)
+#define handleInvocation(isCall, isBlocking, firstPhase, cptr) handleInvocation(isCall, isBlocking)
 #endif
 
 static void handleYield(void)
@@ -566,7 +566,7 @@ exception_t handleSyscall(syscall_t syscall)
         switch (syscall)
         {
         case SysSend:
-            ret = handleInvocation(false, true, false, false, getRegister(NODE_STATE(ksCurThread), capRegister));
+            ret = handleInvocation(false, true, false, getRegister(NODE_STATE(ksCurThread), capRegister));
             if (unlikely(ret != EXCEPTION_NONE)) {
                 irq = getActiveIRQ();
                 if (irq != irqInvalid) {
@@ -579,7 +579,7 @@ exception_t handleSyscall(syscall_t syscall)
             break;
 
         case SysNBSend:
-            ret = handleInvocation(false, false, false, false, getRegister(NODE_STATE(ksCurThread), capRegister));
+            ret = handleInvocation(false, false, false, getRegister(NODE_STATE(ksCurThread), capRegister));
             if (unlikely(ret != EXCEPTION_NONE)) {
                 irq = getActiveIRQ();
                 if (irq != irqInvalid) {
@@ -591,7 +591,7 @@ exception_t handleSyscall(syscall_t syscall)
             break;
 
         case SysCall:
-            ret = handleInvocation(true, true, true, false, getRegister(NODE_STATE(ksCurThread), capRegister));
+            ret = handleInvocation(true, true, false, getRegister(NODE_STATE(ksCurThread), capRegister));
             if (unlikely(ret != EXCEPTION_NONE)) {
                 irq = getActiveIRQ();
                 if (irq != irqInvalid) {
@@ -625,7 +625,7 @@ exception_t handleSyscall(syscall_t syscall)
             break;
         case SysReplyRecv: {
             cptr_t reply = getRegister(NODE_STATE(ksCurThread), replyRegister);
-            ret = handleInvocation(false, false, true, true, reply);
+            ret = handleInvocation(false, false, true, reply);
             /* reply cannot error and is not preemptible */
             assert(ret == EXCEPTION_NONE);
             handleRecv(true, true);
@@ -634,7 +634,7 @@ exception_t handleSyscall(syscall_t syscall)
 
         case SysNBSendRecv: {
             cptr_t dest = getNBSendRecvDest();
-            ret = handleInvocation(false, false, true, true, dest);
+            ret = handleInvocation(false, false, true, dest);
             if (unlikely(ret != EXCEPTION_NONE)) {
                 irq = getActiveIRQ();
                 if (irq != irqInvalid) {
@@ -649,7 +649,7 @@ exception_t handleSyscall(syscall_t syscall)
         }
 
         case SysNBSendWait:
-            ret = handleInvocation(false, false, true, true, getRegister(NODE_STATE(ksCurThread), replyRegister));
+            ret = handleInvocation(false, false, true, getRegister(NODE_STATE(ksCurThread), replyRegister));
             if (unlikely(ret != EXCEPTION_NONE)) {
                 irq = getActiveIRQ();
                 if (irq != irqInvalid) {

--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -396,7 +396,7 @@ BOOT_CODE cap_t create_it_asid_pool(cap_t root_cnode_cap)
 BOOT_CODE static bool_t configure_sched_context(tcb_t *tcb, sched_context_t *sc_pptr, ticks_t timeslice)
 {
     tcb->tcbSchedContext = sc_pptr;
-    refill_new(tcb->tcbSchedContext, MIN_REFILLS, timeslice, 0);
+    refill_new(tcb->tcbSchedContext, MIN_REFILLS, timeslice, 0, CURRENT_CPU_INDEX());
 
     tcb->tcbSchedContext->scTcb = tcb;
     return true;

--- a/src/kernel/faulthandler.c
+++ b/src/kernel/faulthandler.c
@@ -18,8 +18,7 @@
 #ifdef CONFIG_KERNEL_MCS
 void handleFault(tcb_t *tptr)
 {
-    bool_t hasFaultHandler = sendFaultIPC(tptr, TCB_PTR_CTE_PTR(tptr, tcbFaultHandler)->cap,
-                                          tptr->tcbSchedContext != NULL);
+    bool_t hasFaultHandler = sendFaultIPC(tptr, TCB_PTR_CTE_PTR(tptr, tcbFaultHandler)->cap);
     if (!hasFaultHandler) {
         handleNoFaultHandler(tptr);
     }
@@ -28,10 +27,10 @@ void handleFault(tcb_t *tptr)
 void handleTimeout(tcb_t *tptr)
 {
     assert(validTimeoutHandler(tptr));
-    sendFaultIPC(tptr, TCB_PTR_CTE_PTR(tptr, tcbTimeoutHandler)->cap, false);
+    sendFaultIPC(tptr, TCB_PTR_CTE_PTR(tptr, tcbTimeoutHandler)->cap);
 }
 
-bool_t sendFaultIPC(tcb_t *tptr, cap_t handlerCap, bool_t can_donate)
+bool_t sendFaultIPC(tcb_t *tptr, cap_t handlerCap)
 {
     if (cap_get_capType(handlerCap) == cap_endpoint_cap) {
         assert(cap_endpoint_cap_get_capCanSend(handlerCap));
@@ -42,7 +41,7 @@ bool_t sendFaultIPC(tcb_t *tptr, cap_t handlerCap, bool_t can_donate)
                 cap_endpoint_cap_get_capEPBadge(handlerCap),
                 cap_endpoint_cap_get_capCanGrant(handlerCap),
                 cap_endpoint_cap_get_capCanGrantReply(handlerCap),
-                can_donate, tptr,
+                tptr,
                 EP_PTR(cap_endpoint_cap_get_capEPPtr(handlerCap)));
 
         return true;

--- a/src/kernel/sporadic.c
+++ b/src/kernel/sporadic.c
@@ -154,7 +154,7 @@ static inline void maybe_add_empty_tail(sched_context_t *sc)
     }
 }
 
-void refill_new(sched_context_t *sc, word_t max_refills, ticks_t budget, ticks_t period)
+void refill_new(sched_context_t *sc, word_t max_refills, ticks_t budget, ticks_t period, word_t core)
 {
     sc->scPeriod = period;
     sc->scRefillHead = 0;
@@ -164,7 +164,7 @@ void refill_new(sched_context_t *sc, word_t max_refills, ticks_t budget, ticks_t
     /* full budget available */
     REFILL_HEAD(sc).rAmount = budget;
     /* budget can be used from now */
-    REFILL_HEAD(sc).rTime = NODE_STATE(ksCurTime);
+    REFILL_HEAD(sc).rTime = NODE_STATE_ON_CORE(ksCurTime, core);
     maybe_add_empty_tail(sc);
     REFILL_SANITY_CHECK(sc, budget);
 }

--- a/src/object/endpoint.c
+++ b/src/object/endpoint.c
@@ -90,8 +90,7 @@ void sendIPC(bool_t blocking, bool_t do_call, word_t badge,
             reply_unlink(reply);
         }
 
-        if (do_call ||
-            seL4_Fault_ptr_get_seL4_FaultType(&thread->tcbFault) != seL4_Fault_NullFault) {
+        if (do_call || threadFaulted(thread)) {
             if (reply != NULL && (canGrant || canGrantReply)) {
                 reply_push(thread, dest, reply, canDonate);
             } else {
@@ -225,8 +224,7 @@ void receiveIPC(tcb_t *thread, cap_t cap, bool_t isBlocking)
             do_call = thread_state_ptr_get_blockingIPCIsCall(&sender->tcbState);
 
 #ifdef CONFIG_KERNEL_MCS
-            if (do_call ||
-                seL4_Fault_get_seL4_FaultType(sender->tcbFault) != seL4_Fault_NullFault) {
+            if (do_call || threadFaulted(sender)) {
                 if ((canGrant || canGrantReply) && replyPtr != NULL) {
                     reply_push(sender, thread, replyPtr, sender->tcbSchedContext != NULL);
                 } else {

--- a/src/object/endpoint.c
+++ b/src/object/endpoint.c
@@ -24,13 +24,8 @@ static inline void ep_ptr_set_queue(endpoint_t *epptr, tcb_queue_t queue)
     endpoint_ptr_set_epQueue_tail(epptr, (word_t)queue.end);
 }
 
-#ifdef CONFIG_KERNEL_MCS
-void sendIPC(bool_t blocking, bool_t do_call, word_t badge,
-             bool_t canGrant, bool_t canGrantReply, bool_t canDonate, tcb_t *thread, endpoint_t *epptr)
-#else
 void sendIPC(bool_t blocking, bool_t do_call, word_t badge,
              bool_t canGrant, bool_t canGrantReply, tcb_t *thread, endpoint_t *epptr)
-#endif
 {
     switch (endpoint_ptr_get_state(epptr)) {
     case EPState_Idle:

--- a/src/object/objecttype.c
+++ b/src/object/objecttype.c
@@ -617,7 +617,7 @@ void createNewObjects(object_t t, cte_t *parent, slot_range_t slots,
 exception_t decodeInvocation(word_t invLabel, word_t length,
                              cptr_t capIndex, cte_t *slot, cap_t cap,
                              extra_caps_t excaps, bool_t block, bool_t call,
-                             bool_t canDonate, bool_t firstPhase, word_t *buffer)
+                             bool_t firstPhase, word_t *buffer)
 #else
 exception_t decodeInvocation(word_t invLabel, word_t length,
                              cptr_t capIndex, cte_t *slot, cap_t cap,
@@ -653,19 +653,11 @@ exception_t decodeInvocation(word_t invLabel, word_t length,
         }
 
         setThreadState(NODE_STATE(ksCurThread), ThreadState_Restart);
-#ifdef CONFIG_KERNEL_MCS
-        return performInvocation_Endpoint(
-                   EP_PTR(cap_endpoint_cap_get_capEPPtr(cap)),
-                   cap_endpoint_cap_get_capEPBadge(cap),
-                   cap_endpoint_cap_get_capCanGrant(cap),
-                   cap_endpoint_cap_get_capCanGrantReply(cap), block, call, canDonate);
-#else
         return performInvocation_Endpoint(
                    EP_PTR(cap_endpoint_cap_get_capEPPtr(cap)),
                    cap_endpoint_cap_get_capEPBadge(cap),
                    cap_endpoint_cap_get_capCanGrant(cap),
                    cap_endpoint_cap_get_capCanGrantReply(cap), block, call);
-#endif
 
     case cap_notification_cap: {
         if (unlikely(!cap_notification_cap_get_capNtfnCanSend(cap))) {
@@ -762,16 +754,6 @@ exception_t decodeInvocation(word_t invLabel, word_t length,
     }
 }
 
-#ifdef CONFIG_KERNEL_MCS
-exception_t performInvocation_Endpoint(endpoint_t *ep, word_t badge,
-                                       bool_t canGrant, bool_t canGrantReply,
-                                       bool_t block, bool_t call, bool_t canDonate)
-{
-    sendIPC(block, call, badge, canGrant, canGrantReply, canDonate, NODE_STATE(ksCurThread), ep);
-
-    return EXCEPTION_NONE;
-}
-#else
 exception_t performInvocation_Endpoint(endpoint_t *ep, word_t badge,
                                        bool_t canGrant, bool_t canGrantReply,
                                        bool_t block, bool_t call)
@@ -780,7 +762,6 @@ exception_t performInvocation_Endpoint(endpoint_t *ep, word_t badge,
 
     return EXCEPTION_NONE;
 }
-#endif
 
 exception_t performInvocation_Notification(notification_t *ntfn, word_t badge)
 {

--- a/src/object/schedcontext.c
+++ b/src/object/schedcontext.c
@@ -102,6 +102,12 @@ static exception_t decodeSchedContext_Bind(sched_context_t *sc, extra_caps_t ext
         return EXCEPTION_SYSCALL_ERROR;
     }
 
+    if (sc->scRefillMax == 0 || !refill_ready(sc) || !refill_sufficient(sc, 0)) {
+        userError("SchedContext_Bind: sched context requires re-configuration.");
+        current_syscall_error.type = seL4_IllegalOperation;
+        return EXCEPTION_SYSCALL_ERROR;
+    }
+
     switch (cap_get_capType(cap)) {
     case cap_thread_cap:
         if (TCB_PTR(cap_thread_cap_get_capTCBPtr(cap))->tcbSchedContext != NULL) {

--- a/src/object/schedcontrol.c
+++ b/src/object/schedcontrol.c
@@ -66,7 +66,7 @@ static exception_t invokeSchedControl_Configure(sched_context_t *target, word_t 
     } else {
         /* the scheduling context isn't active - it's budget is not being used, so
          * we can just populate the parameters from now */
-        refill_new(target, max_refills, budget, period);
+        refill_new(target, max_refills, budget, period, core);
     }
 
 #ifdef ENABLE_SMP_SUPPORT

--- a/src/object/tcb.c
+++ b/src/object/tcb.c
@@ -1337,6 +1337,11 @@ exception_t decodeSetSchedParams(cap_t cap, word_t length, extra_caps_t excaps, 
             current_syscall_error.type = seL4_IllegalOperation;
             return EXCEPTION_SYSCALL_ERROR;
         }
+        if (sc->scRefillMax == 0 || !refill_ready(sc) || !refill_sufficient(sc, 0)) {
+            userError("TCB Configure: sched context requires re-configuration.");
+            current_syscall_error.type = seL4_IllegalOperation;
+            return EXCEPTION_SYSCALL_ERROR;
+        }
         break;
     case cap_null_cap:
         if (tcb == NODE_STATE(ksCurThread)) {


### PR DESCRIPTION
The following changes are made to ensure that invariants hold for IPC situations and to ensure that the receiver of an IPC does not need to trust a sender not to cause it to receive an IPC without an SC.

Senders of IPCs to passive servers are not given any control as to
whether SCs are donated so as to avoid the situation where a passive
server expects an SC but ends up inactive with no SC due to misplaced
trust in the sender.

The new semantics for scheduling context donation are simply that if the
sender has not timeout faulted, the receiver has no SC, and the sender
has an SC then the sender's SC will be donated to the receiver.

If the sender has an SC it is guaranteed to be ready on its core unless
it is a time-out fault (in which case the SC won't be donated to the
receiver).

This ensures a receiver will never time-out fault but that it may become
unschedulable if it ends up without an SC. To prevent this, trusted
software should not remove scheduling contexts from TCBs blocked on send
to endpoints serviced by passive servers.

Additionally, scheduling contexts must be configured and ready to execute on the core for which they are configured in order to be bound to a TCB or notification. This ensures that notification objects and threads blocked on endpoints are configured such that a receive operation will lead to the receiver having no SC or a ready SC but never a unready / timed-out SC.

The necessary updates to sel4test can be found in the sel4/sel4test#20 PR.
