### PR TITLE
Set CROSS_COMPILER_PREFIX in gcc.cmake template

### DIFF
--- a/gcc.cmake
+++ b/gcc.cmake
@@ -19,6 +19,7 @@ set(CMAKE_STAGING_PREFIX "${CMAKE_BINARY_DIR}/staging")
 set(sel4_arch @KernelSel4Arch@)
 set(arch @KernelArch@)
 set(mode @KernelWordSize@)
+set(CROSS_COMPILER_PREFIX @CROSS_COMPILER_PREFIX@)
 
 # This function hunts for an extant `gcc` with one of the candidate prefixes
 # specified in `ARGN`, allowing us to try different target triple prefixes for


### PR DESCRIPTION
This fixes an issue passing -DCROSS_COMPILER_PREFIX to cmake. Cache
variables (like CROSS_COMPILER_PREFIX) are not consistently accessible
from the toolchain file (gcc.cmake). Theu toolchain file is run several
times in different contexts, and when run in a context without access
to the cache, an incorrect (or no) c compiler is identified, as
CROSS_COMPILER_PREFIX appears to be unset.

To reproduce:
Checkout sel4test with repo. Be in an environment where the default arm toolchain "arm-linux-gnueabi-" or "arm-linux-gnu-" are not in your path.
```
../init-build.sh -DPLATFORM=am335x-boneblack -DAARCH32=1 -DCROSS_COMPILER_PREFIX=arm-none-eabi-
```
(substituting arm-none-eabi- with a cross compiler prefix that is in your path).
When I do this I see:
```
-- Found seL4: /home/steve/src/sel4test/kernel
-- The C compiler identification is GNU 9.2.0
-- The CXX compiler identification is GNU 9.2.0
-- The ASM compiler identification is GNU
-- Found assembler: /usr/bin/arm-none-eabi-gcc
-- Check for working C compiler: /usr/bin/arm-none-eabi-gcc
CMake Error at /home/steve/src/sel4test/cbuild/gcc.cmake:46 (message):
  Unable to find valid cross-compiling GCC
```
The build system clearly found the toolchain, but then later on it couldn't find it? The problem is caused by the toolchain script (gcc.cmake) being run several times in different contexts. The first couple of times it runs in a context where it can access cbuild/CMakeCache.txt, and CROSS_COMPILER_PREFIX is set according to that file (the value passed with -D), but then it runs again without access to the cache file, CROSS_COMPILER_PREFIX is unset, and the script goes looking for the default toolchain which I don't have (and if I did have it installed, I'd now be building with a different toolchain than what I expect (maybe?)).