### PR TITLE
Fix python warning in syscall stub generator

### DIFF
--- a/libsel4/tools/syscall_stub_gen.py
+++ b/libsel4/tools/syscall_stub_gen.py
@@ -1077,7 +1077,7 @@ def main():
     else:
         wordsize = int(args.wsize)
 
-    if wordsize is -1:
+    if wordsize == -1:
         print("Invalid word size.")
         sys.exit(2)
 


### PR DESCRIPTION
The "is" keyword compares addresses. "==" compares values.

```
+>>> a = 1000
+>>> b = a + 1
+>>> b == 1001
True
+>>> b is 1001
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
False
```