### PR TITLE
Repair barriers in clh_lock_acquire

### DIFF
--- a/include/arch/arm/arch/model/smp.h
+++ b/include/arch/arm/arch/model/smp.h
@@ -16,8 +16,7 @@ static inline cpu_id_t cpuIndexToID(word_t index)
     return BIT(index);
 }
 
-static inline bool_t try_arch_atomic_exchange(void *ptr, void *new_val, void **prev, int success_memorder,
-                                              int failure_memorder)
+static inline bool_t try_arch_atomic_exchange_rlx(void *ptr, void *new_val, void **prev)
 {
     uint32_t atomic_status;
     void *temp;
@@ -31,14 +30,6 @@ static inline bool_t try_arch_atomic_exchange(void *ptr, void *new_val, void **p
     );
 
     *prev = temp;
-
-    /* Atomic operation success */
-    if (likely(!atomic_status)) {
-        __atomic_thread_fence(success_memorder);
-    } else {
-        /* Atomic operation failure */
-        __atomic_thread_fence(failure_memorder);
-    }
 
     /* On ARM if an atomic operation succeeds, it returns 0 */
     return (atomic_status == 0);

--- a/include/arch/riscv/arch/model/smp.h
+++ b/include/arch/riscv/arch/model/smp.h
@@ -43,10 +43,9 @@ static inline void add_hart_to_core_map(word_t hart_id, word_t core_id)
     coreMap.map[core_id] = hart_id;
 }
 
-static inline bool_t try_arch_atomic_exchange(void *ptr, void *new_val, void **prev,
-                                              int success_memorder, int failuer_memorder)
+static inline bool_t try_arch_atomic_exchange_rlx(void *ptr, void *new_val, void **prev)
 {
-    *prev = __atomic_exchange_n((void **)ptr, new_val, success_memorder);
+    *prev = __atomic_exchange_n((void **)ptr, new_val, __ATOMIC_RELAXED);
     return true;
 }
 

--- a/include/arch/x86/arch/model/smp.h
+++ b/include/arch/x86/arch/model/smp.h
@@ -36,10 +36,9 @@ static inline PURE word_t getCurrentCPUID(void)
     return cpu_mapping.index_to_cpu_id[getCurrentCPUIndex()];
 }
 
-static inline bool_t try_arch_atomic_exchange(void *ptr, void *new_val, void **prev, int success_memorder,
-                                              int failure_memorder)
+static inline bool_t try_arch_atomic_exchange_rlx(void *ptr, void *new_val, void **prev)
 {
-    *prev = __atomic_exchange_n((void **) ptr, new_val, success_memorder);
+    *prev = __atomic_exchange_n((void **) ptr, new_val, __ATOMIC_RELAXED);
     return true;
 }
 

--- a/include/smp/lock.h
+++ b/include/smp/lock.h
@@ -95,7 +95,7 @@ static inline void FORCE_INLINE clh_lock_acquire(word_t cpu, bool_t irqPath)
     clh_qnode_t *prev;
     big_kernel_lock.node_owners[cpu].node->value = CLHState_Pending;
 
-    prev = sel4_atomic_exchange(&big_kernel_lock.head, irqPath, cpu, __ATOMIC_ACQUIRE);
+    prev = sel4_atomic_exchange(&big_kernel_lock.head, irqPath, cpu, __ATOMIC_ACQ_REL);
 
     big_kernel_lock.node_owners[cpu].next = prev;
 


### PR DESCRIPTION
Strengthen the clh_lock_acquire to use release on the atomic_exchange that makes the node public. Otherwise (on ARM & RISCV), the store to the node value which sets its state to CLHState_Pending can become visible some time after the node is visible.
In that window of time, the next thread which attempts to acquire the lock will still see the old state (CLHState_Granted) and enters the critical section, leading to a mutual exclusion violation.
See also: https://gist.github.com/JonasOberhauser/6198862f0c47f68040369787f131248f which is a test written by Diogo Behrens that can reproduce the mutual exclusion violation on some ARM servers (Taishan 2280)

The PR should be ready to merge.

Signed-off-by: jonas <s9joober@gmail.com>