### PR TITLE
aarch64: add missing vcpu cases

### DIFF
--- a/include/arch/arm/arch/64/mode/object/structures.h
+++ b/include/arch/arm/arch/64/mode/object/structures.h
@@ -147,6 +147,11 @@ static inline word_t CONST cap_get_archCapSizeBits(cap_t cap)
     case cap_asid_control_cap:
         return 0;
 
+#ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
+    case cap_vcpu_cap:
+        return seL4_VCPUBits;
+#endif
+
     default:
         /* Unreachable, but GCC can't figure that out */
         return 0;
@@ -182,6 +187,11 @@ static inline bool_t CONST cap_get_archCapIsPhysical(cap_t cap)
     case cap_asid_control_cap:
         return false;
 
+#ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
+    case cap_vcpu_cap:
+        return true;
+#endif
+
     default:
         /* Unreachable, but GCC can't figure that out */
         return false;
@@ -215,6 +225,11 @@ static inline void *CONST cap_get_archCapPtr(cap_t cap)
 
     case cap_asid_pool_cap:
         return ASID_POOL_PTR(cap_asid_pool_cap_get_capASIDPool(cap));
+
+#ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
+    case cap_vcpu_cap:
+        return VCPU_PTR(cap_vcpu_cap_get_capVCPUPtr(cap));
+#endif
 
     default:
         /* Unreachable, but GCC can't figure that out */


### PR DESCRIPTION
Adds missing vcpu cases for some aarch64-specific functions on capabilities.