### PR TITLE
arm-hyp: read cntv_ctl from saved context when necessary

### DIFF
--- a/include/arch/arm/armv/armv8-a/64/armv/vcpu.h
+++ b/include/arch/arm/armv/armv8-a/64/armv/vcpu.h
@@ -664,6 +664,7 @@ static inline bool_t vcpu_reg_saved_when_disabled(word_t field)
 {
     switch (field) {
     case seL4_VCPUReg_SCTLR:
+    case seL4_VCPUReg_CNTV_CTL:
 #ifdef CONFIG_HAVE_FPU
     case seL4_VCPUReg_CPACR:
 #endif


### PR DESCRIPTION
Like `SCTLR`, `CNTV_CTL` is switched to/from hardware when we enable/disable the VCPU, so it must be read from a saved VCPU context when that VCPU isn't active.

`CNTV_CTL` is switched to/from hardware by `{save,restore}_virt_timer`.