### PR TITLE
Repair barriers in sel4_atomic_exchange

### DIFF
--- a/include/arch/arm/arch/model/smp.h
+++ b/include/arch/arm/arch/model/smp.h
@@ -16,8 +16,7 @@ static inline cpu_id_t cpuIndexToID(word_t index)
     return BIT(index);
 }
 
-static inline bool_t try_arch_atomic_exchange(void *ptr, void *new_val, void **prev, int success_memorder,
-                                              int failure_memorder)
+static inline bool_t try_arch_atomic_exchange_rlx(void *ptr, void *new_val, void **prev)
 {
     uint32_t atomic_status;
     void *temp;
@@ -31,14 +30,6 @@ static inline bool_t try_arch_atomic_exchange(void *ptr, void *new_val, void **p
     );
 
     *prev = temp;
-
-    /* Atomic operation success */
-    if (likely(!atomic_status)) {
-        __atomic_thread_fence(success_memorder);
-    } else {
-        /* Atomic operation failure */
-        __atomic_thread_fence(failure_memorder);
-    }
 
     /* On ARM if an atomic operation succeeds, it returns 0 */
     return (atomic_status == 0);

--- a/include/arch/riscv/arch/model/smp.h
+++ b/include/arch/riscv/arch/model/smp.h
@@ -43,10 +43,9 @@ static inline void add_hart_to_core_map(word_t hart_id, word_t core_id)
     coreMap.map[core_id] = hart_id;
 }
 
-static inline bool_t try_arch_atomic_exchange(void *ptr, void *new_val, void **prev,
-                                              int success_memorder, int failuer_memorder)
+static inline bool_t try_arch_atomic_exchange_rlx(void *ptr, void *new_val, void **prev)
 {
-    *prev = __atomic_exchange_n((void **)ptr, new_val, success_memorder);
+    *prev = __atomic_exchange_n((void **)ptr, new_val, __ATOMIC_RELAXED);
     return true;
 }
 

--- a/include/arch/x86/arch/model/smp.h
+++ b/include/arch/x86/arch/model/smp.h
@@ -36,10 +36,9 @@ static inline PURE word_t getCurrentCPUID(void)
     return cpu_mapping.index_to_cpu_id[getCurrentCPUIndex()];
 }
 
-static inline bool_t try_arch_atomic_exchange(void *ptr, void *new_val, void **prev, int success_memorder,
-                                              int failure_memorder)
+static inline bool_t try_arch_atomic_exchange_rlx(void *ptr, void *new_val, void **prev)
 {
-    *prev = __atomic_exchange_n((void **) ptr, new_val, success_memorder);
+    *prev = __atomic_exchange_n((void **) ptr, new_val, __ATOMIC_RELAXED);
     return true;
 }
 


### PR DESCRIPTION
The implementation of try_arch_atomic_exchange does not correctly pass
RELEASE memory ordering (or stronger) to the exchange operation.
To acknowledge this, try_arch_atomic_exchange is replaced by a relaxed
try_arch_atomic_exchange_rlx which does not apply any memory ordering.
Instead, the memory ordering is now added manually by
sel4_atomic_exchange. This provides better latency for interrupts as no
barriers are evoked inside the loop which performs the relaxed exchange
and checks for interrupts.
Furthermore, the new manual application of barriers ensures the memory
ordering passed to sel4_atomic_exchange.

Signed-off-by: jonas <s9joober@gmail.com>

This pull request is an alternative to #205. It should provide better interrupt latency than #205 but is slightly more invasive.