### PR TITLE
x64: Fix Github issue #174

### DIFF
--- a/include/arch/arm/arch/model/smp.h
+++ b/include/arch/arm/arch/model/smp.h
@@ -16,8 +16,7 @@ static inline cpu_id_t cpuIndexToID(word_t index)
     return BIT(index);
 }
 
-static inline bool_t try_arch_atomic_exchange(void *ptr, void *new_val, void **prev, int success_memorder,
-                                              int failure_memorder)
+static inline bool_t try_arch_atomic_exchange_rlx(void *ptr, void *new_val, void **prev)
 {
     uint32_t atomic_status;
     void *temp;
@@ -31,14 +30,6 @@ static inline bool_t try_arch_atomic_exchange(void *ptr, void *new_val, void **p
     );
 
     *prev = temp;
-
-    /* Atomic operation success */
-    if (likely(!atomic_status)) {
-        __atomic_thread_fence(success_memorder);
-    } else {
-        /* Atomic operation failure */
-        __atomic_thread_fence(failure_memorder);
-    }
 
     /* On ARM if an atomic operation succeeds, it returns 0 */
     return (atomic_status == 0);

--- a/include/arch/riscv/arch/model/smp.h
+++ b/include/arch/riscv/arch/model/smp.h
@@ -43,10 +43,9 @@ static inline void add_hart_to_core_map(word_t hart_id, word_t core_id)
     coreMap.map[core_id] = hart_id;
 }
 
-static inline bool_t try_arch_atomic_exchange(void *ptr, void *new_val, void **prev,
-                                              int success_memorder, int failuer_memorder)
+static inline bool_t try_arch_atomic_exchange_rlx(void *ptr, void *new_val, void **prev)
 {
-    *prev = __atomic_exchange_n((void **)ptr, new_val, success_memorder);
+    *prev = __atomic_exchange_n((void **)ptr, new_val, __ATOMIC_RELAXED);
     return true;
 }
 

--- a/include/arch/x86/arch/model/smp.h
+++ b/include/arch/x86/arch/model/smp.h
@@ -36,10 +36,9 @@ static inline PURE word_t getCurrentCPUID(void)
     return cpu_mapping.index_to_cpu_id[getCurrentCPUIndex()];
 }
 
-static inline bool_t try_arch_atomic_exchange(void *ptr, void *new_val, void **prev, int success_memorder,
-                                              int failure_memorder)
+static inline bool_t try_arch_atomic_exchange_rlx(void *ptr, void *new_val, void **prev)
 {
-    *prev = __atomic_exchange_n((void **) ptr, new_val, success_memorder);
+    *prev = __atomic_exchange_n((void **) ptr, new_val, __ATOMIC_RELAXED);
     return true;
 }
 

--- a/include/smp/lock.h
+++ b/include/smp/lock.h
@@ -95,7 +95,7 @@ static inline void FORCE_INLINE clh_lock_acquire(word_t cpu, bool_t irqPath)
     clh_qnode_t *prev;
     big_kernel_lock.node_owners[cpu].node->value = CLHState_Pending;
 
-    prev = sel4_atomic_exchange(&big_kernel_lock.head, irqPath, cpu, __ATOMIC_ACQUIRE);
+    prev = sel4_atomic_exchange(&big_kernel_lock.head, irqPath, cpu, __ATOMIC_ACQ_REL);
 
     big_kernel_lock.node_owners[cpu].next = prev;
 

--- a/src/arch/x86/64/head.S
+++ b/src/arch/x86/64/head.S
@@ -126,7 +126,7 @@ BEGIN_FUNC(pcid_check)
     movl $0x1, %eax
     xorl %ecx, %ecx
     cpuid
-    andl $0x800000, %ecx
+    andl $0x20000, %ecx
     jz   1f
     ret
 1:


### PR DESCRIPTION
The PCID feature is the 17th bit in ECX when CPUID is called with
EAX=1. The constant for testing the feature should be 0x20000.