### PR TITLE
gicv3: Include cluster ID when sending IPIs

### DIFF
--- a/src/arch/arm/machine/gic_v3.c
+++ b/src/arch/arm/machine/gic_v3.c
@@ -347,13 +347,27 @@ BOOT_CODE void cpu_initLocalIRQController(void)
 void ipi_send_target(irq_t irq, word_t cpuTargetList)
 {
     uint64_t sgi1r_base = ((word_t) IRQT_TO_IRQ(irq)) << ICC_SGI1R_INTID_SHIFT;
-    uint64_t sgi1r = 0;
+    word_t sgi1r[CONFIG_MAX_NUM_NODES];
+    word_t last_aff1 = 0;
 
     for (word_t i = 0; i < CONFIG_MAX_NUM_NODES; i++) {
+        sgi1r[i] = 0;
         if (cpuTargetList & BIT(i)) {
             word_t mpidr = mpidr_map[i];
-            sgi1r = sgi1r_base | (MPIDR_AFF1(mpidr) << ICC_SGI1R_AFF1_SHIFT) | (1 << MPIDR_AFF0(mpidr));
-            SYSTEM_WRITE_64(ICC_SGI1R_EL1, sgi1r);
+            word_t aff1 = MPIDR_AFF1(mpidr);
+            word_t aff0 = MPIDR_AFF0(mpidr);
+            // AFF1 is assumed to be contiguous and less than CONFIG_MAX_NUM_NODES.
+            // The targets are grouped by AFF1.
+            assert(aff1 >= 0 && aff1 < CONFIG_MAX_NUM_NODES);
+            sgi1r[aff1] |= sgi1r_base | (aff1 << ICC_SGI1R_AFF1_SHIFT) | (1 << aff0);
+            if (aff1 > last_aff1) {
+                last_aff1 = aff1;
+            }
+        }
+    }
+    for (word_t i = 0; i <= last_aff1; i++) {
+        if (sgi1r[i] != 0) {
+            SYSTEM_WRITE_64(ICC_SGI1R_EL1, sgi1r[i]);
         }
     }
     isb();

--- a/src/arch/arm/machine/gic_v3.c
+++ b/src/arch/arm/machine/gic_v3.c
@@ -351,12 +351,8 @@ void ipi_send_target(irq_t irq, word_t cpuTargetList)
 
     for (word_t i = 0; i < CONFIG_MAX_NUM_NODES; i++) {
         if (cpuTargetList & BIT(i)) {
-            if (MPIDR_MT(mpidr_map[getCurrentCPUIndex()])) {
-                sgi1r = sgi1r_base | (i << ICC_SGI1R_AFF1_SHIFT) | 1;
-            } else {
-                word_t mpidr = mpidr_map[i];
-                sgi1r = sgi1r_base | (MPIDR_AFF1(mpidr) << ICC_SGI1R_AFF1_SHIFT) | (1 << MPIDR_AFF0(mpidr));
-            }
+            word_t mpidr = mpidr_map[i];
+            sgi1r = sgi1r_base | (MPIDR_AFF1(mpidr) << ICC_SGI1R_AFF1_SHIFT) | (1 << MPIDR_AFF0(mpidr));
             SYSTEM_WRITE_64(ICC_SGI1R_EL1, sgi1r);
         }
     }


### PR DESCRIPTION
The MPIDR_AFFI1 field is included when sending IPIs, since cores
for IPI targets can be in a different cluster.

Signed-off-by: Yanyan Shen <yshen@cog.systems>