### PR TITLE
riscv gp fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,7 +164,15 @@ if(KernelArchARM)
     endif()
 endif()
 if(KernelArchRiscV)
-    KernelCommonFlags(-mcmodel=medany)
+    # Group "small" data objects together in a small-data section so they can
+    # be referenced using gp-relative addressing.  The exact value of
+    # small-data-limit is not crucial but it should be lowered if .small
+    # exceeds 4KiB.
+    #
+    # Without -fno-common uninitialized variables are generated as *COM*
+    # symbols with no section information.  -fno-common is the default on
+    # gcc 10+ (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85678).
+    KernelCommonFlags(-mcmodel=medany -fno-common -msmall-data-limit=1024)
 endif()
 KernelCommonFlags(-fno-pic -fno-pie)
 add_compile_options(

--- a/src/arch/riscv/common_riscv.lds
+++ b/src/arch/riscv/common_riscv.lds
@@ -43,12 +43,13 @@ SECTIONS
 
     /* Start of data section */
     _sdata = .;
-    .sdata : {
+    .small : {
+        /* Small data that should be accessed relative to gp.  ld has trouble
+           with the relaxation if they are not in a single section. */
         __global_pointer$ = . + 0x800;
-        *(.sdata*)
-    }
-    .srodata : {
         *(.srodata*)
+        *(.sdata*)
+        *(.sbss)
     }
 
     .rodata . : AT(ADDR(.rodata) - KERNEL_OFFSET)
@@ -65,7 +66,6 @@ SECTIONS
     .bss . : AT(ADDR(.bss) - KERNEL_OFFSET)
     {
         *(.bss)
-        *(.sbss)
 
         /* 4k breakpoint stack */
         _breakpoint_stack_bottom = .;

--- a/src/arch/riscv/traps.S
+++ b/src/arch/riscv/traps.S
@@ -79,7 +79,10 @@ trap_entry:
   csrr s0, scause
   STORE s0, (31*REGBYTES)(t0)
 
+.option push
+.option norelax
   la gp, __global_pointer$
+.option pop
 
 #ifdef ENABLE_SMP_SUPPORT
   /* save the user sp */


### PR DESCRIPTION
Tested via `-DPLATFORM=spike` build and `./simulate`.  (saves 386 of the 14683 instructions in a master release build)