### PR TITLE
riscv/smp: Add missing include

### DIFF
--- a/include/arch/riscv/arch/32/mode/machine.h
+++ b/include/arch/riscv/arch/32/mode/machine.h
@@ -8,3 +8,4 @@
 
 /* Place holder for 32-bit machine header */
 
+#include <arch/model/smp.h>

--- a/include/arch/riscv/arch/64/mode/machine.h
+++ b/include/arch/riscv/arch/64/mode/machine.h
@@ -8,3 +8,4 @@
 
 /* Place holder for 64-bit machine header */
 
+#include <arch/model/smp.h>


### PR DESCRIPTION
With this and seL4/seL4_tools#41, I can build riscv32 and riscv64 `-DSMP=ON -DPLATFORM=spike -DSIMULATION=ON` and run the subset of non-timer tests with `./simulate -M virt -b 'qemu-system-riscvNN -smp 4'`, although there are a few "Spurious interrupt" messages.