### PR TITLE
clang 11 build fixes

### DIFF
--- a/libsel4/include/sel4/constants.h
+++ b/libsel4/include/sel4/constants.h
@@ -33,7 +33,7 @@ typedef enum {
 } seL4_BreakpointAccess;
 
 /* Format of a debug-exception message. */
-enum {
+typedef enum {
     seL4_DebugException_FaultIP,
     seL4_DebugException_ExceptionReason,
     seL4_DebugException_TriggerAddress,

--- a/libsel4/include/sel4/shared_types.h
+++ b/libsel4/include/sel4/shared_types.h
@@ -18,7 +18,7 @@ typedef struct seL4_IPCBuffer_ {
     seL4_Word receiveDepth;
 } seL4_IPCBuffer __attribute__((__aligned__(sizeof(struct seL4_IPCBuffer_))));
 
-enum {
+typedef enum {
     seL4_CapFault_IP,
     seL4_CapFault_Addr,
     seL4_CapFault_InRecvPhase,

--- a/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/constants.h
@@ -18,7 +18,7 @@ enum {
 #endif /* CONFIG_KERNEL_GLOBALS_FRAME */
 
 /* format of an unknown syscall message */
-enum {
+typedef enum {
     seL4_UnknownSyscall_R0,
     seL4_UnknownSyscall_R1,
     seL4_UnknownSyscall_R2,
@@ -38,7 +38,7 @@ enum {
 } seL4_UnknownSyscall_Msg;
 
 /* format of a user exception message */
-enum {
+typedef enum {
     seL4_UserException_FaultIP,
     seL4_UserException_SP,
     seL4_UserException_CPSR,
@@ -50,7 +50,7 @@ enum {
 } seL4_UserException_Msg;
 
 /* format of a vm fault message */
-enum {
+typedef enum {
     seL4_VMFault_IP,
     seL4_VMFault_Addr,
     seL4_VMFault_PrefetchFault,
@@ -60,24 +60,24 @@ enum {
 } seL4_VMFault_Msg;
 
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
-enum {
+typedef enum {
     seL4_VGICMaintenance_IDX,
     seL4_VGICMaintenance_Length,
     SEL4_FORCE_LONG_ENUM(seL4_VGICMaintenance_Msg),
 } seL4_VGICMaintenance_Msg;
 
-enum {
+typedef enum {
     seL4_VPPIEvent_IRQ,
     SEL4_FORCE_LONG_ENUM(seL4_VPPIEvent_Msg),
 } seL4_VPPIEvent_Msg;
 
-enum {
+typedef enum {
     seL4_VCPUFault_HSR,
     seL4_VCPUFault_Length,
     SEL4_FORCE_LONG_ENUM(seL4_VCPUFault_Msg),
 } seL4_VCPUFault_Msg;
 
-enum {
+typedef enum {
     seL4_VCPUReg_SCTLR = 0,
     seL4_VCPUReg_ACTLR,
     seL4_VCPUReg_TTBCR,
@@ -128,7 +128,7 @@ enum {
 #endif /* CONFIG_ARM_HYPERVISOR_SUPPORT */
 
 #ifdef CONFIG_KERNEL_MCS
-enum {
+typedef enum {
     seL4_Timeout_Data,
     /* consumed is 64 bits */
     seL4_Timeout_Consumed_HighBits,
@@ -137,7 +137,7 @@ enum {
     SEL4_FORCE_LONG_ENUM(seL4_Timeout_Msg)
 } seL4_TimeoutMsg;
 
-enum {
+typedef enum {
     seL4_TimeoutReply_FaultIP,
     seL4_TimeoutReply_SP,
     seL4_TimeoutReply_CPSR,

--- a/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
@@ -12,7 +12,7 @@
 
 #ifndef __ASSEMBLER__
 /* format of an unknown syscall message */
-enum {
+typedef enum {
     seL4_UnknownSyscall_X0,
     seL4_UnknownSyscall_X1,
     seL4_UnknownSyscall_X2,
@@ -32,7 +32,7 @@ enum {
 } seL4_UnknownSyscall_Msg;
 
 /* format of a user exception message */
-enum {
+typedef enum {
     seL4_UserException_FaultIP,
     seL4_UserException_SP,
     seL4_UserException_SPSR,
@@ -44,7 +44,7 @@ enum {
 } seL4_UserException_Msg;
 
 /* format of a vm fault message */
-enum {
+typedef enum {
     seL4_VMFault_IP,
     seL4_VMFault_Addr,
     seL4_VMFault_PrefetchFault,
@@ -55,25 +55,25 @@ enum {
 
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
 
-enum {
+typedef enum {
     seL4_VGICMaintenance_IDX,
     seL4_VGICMaintenance_Length,
     SEL4_FORCE_LONG_ENUM(seL4_VGICMaintenance_Msg),
 } seL4_VGICMaintenance_Msg;
 
-enum {
+typedef enum {
     seL4_VPPIEvent_IRQ,
     SEL4_FORCE_LONG_ENUM(seL4_VPPIEvent_Msg),
 } seL4_VPPIEvent_Msg;
 
 
-enum {
+typedef enum {
     seL4_VCPUFault_HSR,
     seL4_VCPUFault_Length,
     SEL4_FORCE_LONG_ENUM(seL4_VCPUFault_Msg),
 } seL4_VCPUFault_Msg;
 
-enum {
+typedef enum {
     /* VM control registers EL1 */
     seL4_VCPUReg_SCTLR = 0,
     seL4_VCPUReg_TTBR0,
@@ -120,7 +120,7 @@ enum {
 #endif /* CONFIG_ARM_HYPERVISOR_SUPPORT */
 
 #ifdef CONFIG_KERNEL_MCS
-enum {
+typedef enum {
     seL4_TimeoutReply_FaultIP,
     seL4_TimeoutReply_SP,
     seL4_TimeoutReply_SPSR_EL1,
@@ -159,7 +159,7 @@ enum {
     SEL4_FORCE_LONG_ENUM(seL4_TimeoutReply_Msg)
 } seL4_TimeoutReply_Msg;
 
-enum {
+typedef enum {
     seL4_Timeout_Data,
     seL4_Timeout_Consumed,
     seL4_Timeout_Length,

--- a/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/constants.h
@@ -72,7 +72,7 @@ SEL4_SIZE_SANITY(seL4_WordSizeBits, seL4_ASIDPoolIndexBits, seL4_ASIDPoolBits);
 
 #ifndef __ASSEMBLER__
 /* format of a vm fault message */
-enum {
+typedef enum {
     seL4_VMFault_IP,
     seL4_VMFault_Addr,
     seL4_VMFault_PrefetchFault,
@@ -81,7 +81,7 @@ enum {
     SEL4_FORCE_LONG_ENUM(seL4_VMFault_Msg),
 } seL4_VMFault_Msg;
 
-enum {
+typedef enum {
     seL4_UnknownSyscall_EAX,
     seL4_UnknownSyscall_EBX,
     seL4_UnknownSyscall_ECX,
@@ -97,7 +97,7 @@ enum {
     SEL4_FORCE_LONG_ENUM(seL4_UnknownSyscall_Msg),
 } seL4_UnknownSyscall_Msg;
 
-enum {
+typedef enum {
     seL4_UserException_FaultIP,
     seL4_UserException_SP,
     seL4_UserException_FLAGS,
@@ -108,7 +108,7 @@ enum {
 } seL4_UserException_Msg;
 
 #ifdef CONFIG_KERNEL_MCS
-enum {
+typedef enum {
     seL4_Timeout_Data,
     /* consumed is 64 bits */
     seL4_Timeout_Consumed_HighBits,
@@ -117,7 +117,7 @@ enum {
     SEL4_FORCE_LONG_ENUM(seL4_Timeout_Msg),
 } seL4_Timeout_Msg;
 
-enum {
+typedef enum {
     seL4_TimeoutReply_FaultIP,
     seL4_TimeoutReply_SP,
     seL4_TimeoutReply_FLAGS,

--- a/libsel4/sel4_arch_include/riscv32/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/riscv32/sel4/sel4_arch/constants.h
@@ -44,7 +44,7 @@
 #define seL4_ASIDPoolBits       12
 #ifndef __ASSEMBLER__
 
-enum {
+typedef enum {
     seL4_VMFault_IP,
     seL4_VMFault_Addr,
     seL4_VMFault_PrefetchFault,
@@ -52,7 +52,7 @@ enum {
     seL4_VMFault_Length,
 } seL4_VMFault_Msg;
 
-enum {
+typedef enum {
     seL4_UnknownSyscall_FaultIP,
     seL4_UnknownSyscall_SP,
     seL4_UnknownSyscall_RA,
@@ -67,7 +67,7 @@ enum {
     seL4_UnknownSyscall_Length,
 } seL4_UnknownSyscall_Msg;
 
-enum {
+typedef enum {
     seL4_UserException_FaultIP,
     seL4_UserException_SP,
     seL4_UserException_Number,
@@ -76,7 +76,7 @@ enum {
 } seL4_UserException_Msg;
 
 #ifdef CONFIG_KERNEL_MCS
-enum {
+typedef enum {
     seL4_TimeoutReply_FaultIP,
     seL4_TimeoutReply_LR,
     seL4_TimeoutReply_SP,
@@ -112,7 +112,7 @@ enum {
     seL4_TimeoutReply_Length,
 } seL4_TimeoutReply_Msg;
 
-enum {
+typedef enum {
     seL4_Timeout_Data,
     seL4_Timeout_Consumed_HighBits,
     seL4_Timeout_Consumed_LowBits,

--- a/libsel4/sel4_arch_include/riscv64/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/riscv64/sel4/sel4_arch/constants.h
@@ -50,7 +50,7 @@
 #define seL4_MaxUntypedBits     38
 #ifndef __ASSEMBLER__
 
-enum {
+typedef enum {
     seL4_VMFault_IP,
     seL4_VMFault_Addr,
     seL4_VMFault_PrefetchFault,
@@ -58,7 +58,7 @@ enum {
     seL4_VMFault_Length,
 } seL4_VMFault_Msg;
 
-enum {
+typedef enum {
     seL4_UnknownSyscall_FaultIP,
     seL4_UnknownSyscall_SP,
     seL4_UnknownSyscall_RA,
@@ -73,7 +73,7 @@ enum {
     seL4_UnknownSyscall_Length,
 } seL4_UnknownSyscall_Msg;
 
-enum {
+typedef enum {
     seL4_UserException_FaultIP,
     seL4_UserException_SP,
     seL4_UserException_Number,
@@ -82,7 +82,7 @@ enum {
 } seL4_UserException_Msg;
 
 #ifdef CONFIG_KERNEL_MCS
-enum {
+typedef enum {
     seL4_TimeoutReply_FaultIP,
     seL4_TimeoutReply_LR,
     seL4_TimeoutReply_SP,
@@ -118,7 +118,7 @@ enum {
     seL4_TimeoutReply_Length,
 } seL4_TimeoutReply_Msg;
 
-enum {
+typedef enum {
     seL4_Timeout_Data,
     seL4_Timeout_Consumed,
     seL4_Timeout_Length,

--- a/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/constants.h
@@ -71,7 +71,7 @@ SEL4_SIZE_SANITY(seL4_PDPTEntryBits, seL4_PDPTIndexBits, seL4_PDPTBits);
 SEL4_SIZE_SANITY(seL4_PML4EntryBits, seL4_PML4IndexBits, seL4_PML4Bits);
 SEL4_SIZE_SANITY(seL4_WordSizeBits, seL4_ASIDPoolIndexBits, seL4_ASIDPoolBits);
 
-enum {
+typedef enum {
     seL4_VMFault_IP,
     seL4_VMFault_Addr,
     seL4_VMFault_PrefetchFault,
@@ -80,7 +80,7 @@ enum {
     SEL4_FORCE_LONG_ENUM(seL4_VMFault_Msg),
 } seL4_VMFault_Msg;
 
-enum {
+typedef enum {
     seL4_UnknownSyscall_RAX,
     seL4_UnknownSyscall_RBX,
     seL4_UnknownSyscall_RCX,
@@ -104,7 +104,7 @@ enum {
     SEL4_FORCE_LONG_ENUM(seL4_UnknownSyscall_Msg)
 } seL4_UnknownSyscall_Msg;
 
-enum {
+typedef enum {
     seL4_UserException_FaultIP,
     seL4_UserException_SP,
     seL4_UserException_FLAGS,
@@ -115,14 +115,14 @@ enum {
 } seL4_UserException_Msg;
 
 #ifdef CONFIG_KERNEL_MCS
-enum {
+typedef enum {
     seL4_Timeout_Data,
     seL4_Timeout_Consumed,
     seL4_Timeout_Length,
     SEL4_FORCE_LONG_ENUM(seL4_Timeout_Msg)
 } seL4_TimeoutMsg;
 
-enum {
+typedef enum {
     seL4_TimeoutReply_FaultIP,
     seL4_TimeoutReply_RSP,
     seL4_TimeoutReply_FLAGS,

--- a/llvm.cmake
+++ b/llvm.cmake
@@ -36,6 +36,9 @@ set(CMAKE_CXX_COMPILER_TARGET ${TRIPLE})
 string(APPEND c_common_flags " -Qunused-arguments")
 string(APPEND c_common_flags " -Wno-constant-logical-operand")
 string(APPEND c_common_flags " -fno-integrated-as")
+# clang 11 has a regression in GlobalISel (only used at -O0) affecting the syscall
+# stubs in libsel4runtime; see https://reviews.llvm.org/D83384#2189132
+string(APPEND c_common_flags " -fno-experimental-isel")
 
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)


### PR DESCRIPTION
depends on: SEL4PROJ/sel4runtime#3 and seL4/util_libs#37

With this I can build sel4test using clang 11.0.0-rc1 on aarch64 armv7 x86_64 ia32, and all tests except for SCHED0021 pass on all architectures.  The same builds work and all tests pass on clang 8.0.1 (either built from source or as packaged in the seL4 docker container).  SCHED0021 does pass on x86_64 even with clang 11.0.0-rc1.

I haven't figured out the test failure yet; the test itself looks fishy (due to seemingly reversed logic on https://github.com/seL4/sel4test/blob/6f73c4d2741012a362fc6d24bbdee63a343db5ad/apps/sel4test-tests/src/tests/scheduler.c#L1526 the test makes an out of bounds array access); I don't think it is a kernel miscompilation, because compiling sel4tests with clang 11 and the kernel with clang 8 fails but using clang 11 for the kernel and clang 8 for the tests succeeds, but I have not confirmed anything.

Many thanks to @jrtc27 for tracking down the inline asm issue and finding a workaround.