### PR TITLE
Check for reschedule on sched context return.

### DIFF
--- a/include/object/notification.h
+++ b/include/object/notification.h
@@ -27,6 +27,11 @@ static inline void maybeReturnSchedContext(notification_t *ntfnPtr, tcb_t *tcb)
     if (sc == tcb->tcbSchedContext) {
         tcb->tcbSchedContext = NULL;
         sc->scTcb = NULL;
+        /* If the current thread returns its sched context then it should not
+           by default continue running. */
+        if (tcb == NODE_STATE(ksCurThread)) {
+            rescheduleRequired();
+        }
     }
 }
 #endif


### PR DESCRIPTION
This is my first PR onto seL4, and is therefore somewhat exploratory.

The current state of MCS seL4 verification makes use of an invariant that whenever the scheduler action is set to "resume current thread" then the current thread and the current sc are bound together (point to each other). Since maybeReturnSchedContext may unbind a thread from a scheduling context, it should perform a check on whether it is unbinding from the current thread, and in that case call rescheduleRequired which will (among other things) change the scheduler action.
