### PR TITLE
CI: Add a PR check to do a stand-alone kernel compilation 

### DIFF
--- a/.github/workflows/compilation-checks.yml
+++ b/.github/workflows/compilation-checks.yml
@@ -1,0 +1,31 @@
+# Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Compilation actions to run on pull requests
+
+name: Compilation checks
+
+on: [pull_request]
+
+jobs:
+  standalone_kernel:
+    name: Compile kernel
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [ARM, ARM_HYP, RISCV64, X64]
+        compiler: [gcc, llvm]
+        python: [py2, py3]
+        exclude:
+          # llvm RISCV64 compilation is not currently supported
+          - arch: RISCV64
+            compiler: llvm
+    steps:
+    - uses: actions/checkout@v2
+    - uses: seL4/ci-actions/standalone-kernel@master
+      with:
+        ARCH: ${{ matrix.arch }}
+        COMPILER: ${{ matrix.compiler }}
+        PYTHON: ${{ matrix.python }}

--- a/.github/workflows/compilation-checks.yml
+++ b/.github/workflows/compilation-checks.yml
@@ -6,7 +6,11 @@
 
 name: Compilation checks
 
-on: [pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   standalone_kernel:

--- a/.github/workflows/compilation-checks.yml
+++ b/.github/workflows/compilation-checks.yml
@@ -4,7 +4,7 @@
 
 # Compilation actions to run on pull requests
 
-name: Compilation checks
+name: Kernel
 
 on:
   push:

--- a/.github/workflows/compilation-checks.yml
+++ b/.github/workflows/compilation-checks.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   standalone_kernel:
-    name: Compile kernel
+    name: compile
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
On a PR, compile all verified configs of seL4.

I put it in its own yml file, so we can better sort through the results, using the GitHub GUI.