### PR TITLE
riscv: Clear reservation state on slowpath exit

### DIFF
--- a/src/arch/riscv/c_traps.c
+++ b/src/arch/riscv/c_traps.c
@@ -45,6 +45,9 @@ void VISIBLE NORETURN restore_user_context(void)
         LOAD_S "  gp, (2*%[REGSIZE])(t0)  \n"
         /* skip tp */
         /* skip x5/t0 */
+        /* no-op store conditional to clear monitor state */
+        /* this may succeed in implementations with very large reservations, but the saved ra is dead */
+        "sc.w zero, zero, (t0)\n"
         LOAD_S "  t2, (6*%[REGSIZE])(t0)  \n"
         LOAD_S "  s0, (7*%[REGSIZE])(t0)  \n"
         LOAD_S "  s1, (8*%[REGSIZE])(t0)  \n"


### PR DESCRIPTION
For those wondering, this code was correct when it was written as trap-return instructions were originally specified to clear reservations.  riscv/riscv-isa-manual@03a5e722 broke the link between the privileged architecture and the memory model as part of RVWMO pre-ratification improvements.