### PR TITLE
manual: remove mention of system criticality

### DIFF
--- a/manual/parts/threads.tex
+++ b/manual/parts/threads.tex
@@ -335,11 +335,6 @@ If a reply message is sent to a nested server and a scheduling context without
 available budget returned, another timeout fault will be generated if the
 nested server also has a timeout fault handler.
 
-Additionally, if the system criticality is changed while a thread with higher
-criticality than the system criticality is running on a scheduling context that
-is bound to a thread with criticality lower than the system criticality, a
-timeout exception will be raised.
-
 \subsection{Message Layout of the Read-/Write-Registers Methods}
 \label{sec:read_write_registers}
 


### PR DESCRIPTION
The concept of system criticality has been removed from the kernel, this
commit removes a last remnant of it from the manual.

Fixes github issue #240