### PR TITLE
rockpro64: Enable MCS

### DIFF
--- a/src/plat/rockpro64/config.cmake
+++ b/src/plat/rockpro64/config.cmake
@@ -10,10 +10,6 @@ declare_platform(rockpro64 KernelPlatformRockpro64 PLAT_ROCKPRO64 KernelSel4Arch
 
 if(KernelPlatformRockpro64)
 
-    # MCS is not supported on KernelPlatformRockpro64.
-    # It requires a timer driver that implements the tickless programming requirements.
-    set(KernelPlatformSupportsMCS OFF)
-
     declare_seL4_arch(aarch64)
     set(KernelArmCortexA53 ON)
     set(KernelArchArmV8a ON)
@@ -25,6 +21,7 @@ if(KernelPlatformRockpro64)
         TIMER_FREQUENCY 24000000llu
         MAX_IRQ 181
         NUM_PPI 32
+        KERNEL_WCET 10u
         TIMER drivers/timer/arm_generic.h
         INTERRUPT_CONTROLLER arch/machine/gic_v3.h
     )


### PR DESCRIPTION
**Disposition**: Ready to merge.

Allow rockpro64 to be built with MCS. Sets the kernel WCET to 10u.
Sel4test passes when running on a pinebook pro.

CLK_MAGIC and CLK_SHIFT were not set as this platform is not enabled for
32-bit arm.

Sel4test was built and executed using this procedure (this patch was applied on top of the master kernel):

```
mkdir sel4test
cd sel4test
repo init -u https://github.com/seL4/sel4test-manifest.git -b refs/tags/11.0.0
repo sync
cd kernel
git checkout master
cd ../tools/seL4
git checkout master
cd ../..
mkdir build
cd build
../init-build.sh -DPLATFORM=rockpro64 -DSIMULATION=false -DSMP=on -DNUM_NODES=6 -DMCS=on -DLibUtilsDefaultZfLogLevel=0
ninja
cd images
../../tools/seL4/cmake-tool/helpers/make-uimage /usr/bin/aarch64-linux-gnu-objcopy ../elfloader/elfloader arm64 sel4test-driver-image-arm-rockpro64-uboot
```

Full serial output of sel4test on pinebook pro: [pbpromcs.log](https://github.com/seL4/seL4/files/5177600/pbpromcs.log)

Note that sel4test was built from 11.0.0 with a master kernel and
seL4-tools due to the issue at seL4/sel4test#25.