### PR TITLE
Synchronise master kernel and abstract model

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -22,9 +22,14 @@ description indicates whether it is SOURCE-COMPATIBLE, BINARY-COMPATIBLE, or BRE
 Further information about [seL4 releases](https://docs.sel4.systems/sel4_release/) is available.
 
 ---
-Upcoming release: BINARY COMPATIBLE
+Upcoming release: BREAKING
 
 ## Changes
+
+* Scheduling contexts can be configured as constant-bandwidth or sporadic server
+  - Constant bandwidth observes a continuous constant bandwidth of budget/period
+  - Sporadic server behaves as described by Sprunt et. al.
+  - In an overcommitted system, sporadic preserves accumulated time
 
 
 ## Upgrade Notes

--- a/include/kernel/sporadic.h
+++ b/include/kernel/sporadic.h
@@ -150,7 +150,7 @@ static inline bool_t sc_released(sched_context_t *sc)
  */
 static inline bool_t sc_sporadic(sched_context_t *sc)
 {
-    return sc != NULL && !sc->scConstantBandwidth;
+    return sc != NULL && sc->scSporadic;
 }
 
 /*
@@ -160,7 +160,7 @@ static inline bool_t sc_sporadic(sched_context_t *sc)
  */
 static inline bool_t sc_constant_bandwidth(sched_context_t *sc)
 {
-    return sc->scConstantBandwidth;
+    return !sc->scSporadic;
 }
 
 /* Create a new refill in a non-active sc */

--- a/include/kernel/sporadic.h
+++ b/include/kernel/sporadic.h
@@ -144,6 +144,25 @@ static inline bool_t sc_released(sched_context_t *sc)
     }
 }
 
+/*
+ * Return true if a SC's available refills should be delayed at the
+ * point the associated thread becomes runnable (sporadic server).
+ */
+static inline bool_t sc_sporadic(sched_context_t *sc)
+{
+    return sc != NULL && !sc->scConstantBandwidth;
+}
+
+/*
+ * Return true if a SC's available refills should be delayed at the
+ * point the associated thread becomes the current thread (constant
+ * bandwidth).
+ */
+static inline bool_t sc_constant_bandwidth(sched_context_t *sc)
+{
+    return sc->scConstantBandwidth;
+}
+
 /* Create a new refill in a non-active sc */
 #ifdef ENABLE_SMP_SUPPORT
 void refill_new(sched_context_t *sc, word_t max_refills, ticks_t budget, ticks_t period, word_t core);

--- a/include/kernel/sporadic.h
+++ b/include/kernel/sporadic.h
@@ -166,14 +166,6 @@ void refill_update(sched_context_t *sc, ticks_t new_period, ticks_t new_budget, 
 void refill_budget_check(ticks_t used);
 
 /*
- * Charge a the current scheduling context `used` amount from its
- * current refill. This will split the refill, leaving whatever is
- * left over at the head of the refill. This is only called when charging
- * `used` will not deplete the head refill.
- */
-void refill_split_check(ticks_t used);
-
-/*
  * This is called when a thread is eligible to start running: it
  * iterates through the refills queue and merges any
  * refills that overlap.

--- a/include/kernel/sporadic.h
+++ b/include/kernel/sporadic.h
@@ -119,6 +119,15 @@ static inline bool_t refill_ready(sched_context_t *sc)
     return refill_head(sc)->rTime <= (NODE_STATE_ON_CORE(ksCurTime, sc->scCore) + getKernelWcetTicks());
 }
 
+/*
+ * Return true if an SC has been successfully configured with parameters
+ * that allow for a thread to run.
+ */
+static inline bool_t sc_active(sched_context_t *sc)
+{
+    return sc->scRefillMax > 0;
+}
+
 /* Create a new refill in a non-active sc */
 #ifdef ENABLE_SMP_SUPPORT
 void refill_new(sched_context_t *sc, word_t max_refills, ticks_t budget, ticks_t period, word_t core);

--- a/include/kernel/sporadic.h
+++ b/include/kernel/sporadic.h
@@ -128,6 +128,22 @@ static inline bool_t sc_active(sched_context_t *sc)
     return sc->scRefillMax > 0;
 }
 
+/*
+ * Return true if a SC has been 'released', if its head refill is
+ * sufficient and is in the past.
+ */
+static inline bool_t sc_released(sched_context_t *sc)
+{
+    if (sc_active(sc)) {
+        /* All refills must all be greater than MIN_BUDGET so this
+         * should be true for all active SCs */
+        assert(refill_sufficient(sc, 0));
+        return refill_ready(sc);
+    } else {
+        return false;
+    }
+}
+
 /* Create a new refill in a non-active sc */
 #ifdef ENABLE_SMP_SUPPORT
 void refill_new(sched_context_t *sc, word_t max_refills, ticks_t budget, ticks_t period, word_t core);

--- a/include/kernel/thread.h
+++ b/include/kernel/thread.h
@@ -138,7 +138,7 @@ static inline void commitTime(void)
                 refill_head(NODE_STATE(ksCurSC))->rAmount -= NODE_STATE(ksConsumed);
                 refill_tail(NODE_STATE(ksCurSC))->rAmount += NODE_STATE(ksConsumed);
             } else {
-                refill_split_check(NODE_STATE(ksConsumed));
+                refill_budget_check(NODE_STATE(ksConsumed));
             }
             assert(refill_sufficient(NODE_STATE(ksCurSC), 0));
             assert(refill_ready(NODE_STATE(ksCurSC)));

--- a/include/object/structures.h
+++ b/include/object/structures.h
@@ -376,7 +376,7 @@ struct sched_context {
 
     /* Whether to apply constant-bandwidth/sliding-window constraint
      * rather than only sporadic server constraints */
-    bool_t scConstantBandwidth;
+    bool_t scSporadic;
 };
 
 struct reply {

--- a/include/object/structures.h
+++ b/include/object/structures.h
@@ -373,6 +373,10 @@ struct sched_context {
     word_t scRefillHead;
     /* Index of the tail of the refill circular buffer */
     word_t scRefillTail;
+
+    /* Whether to apply constant-bandwidth/sliding-window constraint
+     * rather than only sporadic server constraints */
+    bool_t scConstantBandwidth;
 };
 
 struct reply {

--- a/libsel4/include/interfaces/sel4.xml
+++ b/libsel4/include/interfaces/sel4.xml
@@ -644,7 +644,7 @@
 
     <interface name="seL4_SchedControl">
 
-        <method id="SchedControlConfigure" name="Configure" manual_name="Configure" manual_label="schedcontrol_configure" condition="defined(CONFIG_KERNEL_MCS)">
+        <method id="SchedControlConfigureFull" name="ConfigureFull" manual_name="ConfigureFull" manual_label="schedcontrol_configurefull" condition="defined(CONFIG_KERNEL_MCS)">
             <brief>
                 Set the parameters of a scheduling context by invoking the scheduling control capability. If the scheduling context is bound to a currently running thread, the parameters will take effect immediately: that is the current budget will be increased or reduced by the difference between the new and previous budget and the replenishment time will be updated according to any difference in the period. This can result in active threads being post-poned or released depending on the nature of the parameter change and the state of the thread. Additionally, if the scheduling context was previously empty (no budget) but bound to a runnable thread, this can result in a thread running for the first time since it now has access to CPU time. This call will return seL4 Invalid Argument if the parameters are too small (smaller than the kernel WCET for this platform) or too large (will overflow the timer).
             </brief>

--- a/libsel4/include/interfaces/sel4.xml
+++ b/libsel4/include/interfaces/sel4.xml
@@ -644,7 +644,7 @@
 
     <interface name="seL4_SchedControl">
 
-        <method id="SchedControlConfigureFull" name="ConfigureFull" manual_name="ConfigureFull" manual_label="schedcontrol_configurefull" condition="defined(CONFIG_KERNEL_MCS)">
+        <method id="SchedControlConfigureFlags" name="ConfigureFlags" manual_name="ConfigureFlags" manual_label="schedcontrol_configureflags" condition="defined(CONFIG_KERNEL_MCS)">
             <brief>
                 Set the parameters of a scheduling context by invoking the scheduling control capability. If the scheduling context is bound to a currently running thread, the parameters will take effect immediately: that is the current budget will be increased or reduced by the difference between the new and previous budget and the replenishment time will be updated according to any difference in the period. This can result in active threads being post-poned or released depending on the nature of the parameter change and the state of the thread. Additionally, if the scheduling context was previously empty (no budget) but bound to a runnable thread, this can result in a thread running for the first time since it now has access to CPU time. This call will return seL4 Invalid Argument if the parameters are too small (smaller than the kernel WCET for this platform) or too large (will overflow the timer).
             </brief>
@@ -662,8 +662,8 @@
                 description="Number of extra sporadic replenishments this scheduling context should use. Ignored for round-robin threads."/>
             <param dir="in" name="badge" type="seL4_Word"
                 description="Identifier for this scheduling context. Delivered to timeout exception handler. Can be used to determine which scheduling context triggered the timeout." />
-            <param dir="in" name="constant_bandwidth" type="seL4_Bool"
-                description="Whether the scheduling context should have bandwidth restricted continuously rather than only as a sporadic task." />
+            <param dir="in" name="flags" type="seL4_Word"
+                description="Bitwise OR'd set of seL4_SchedContextFlag." />
         </method>
 
     </interface>

--- a/libsel4/include/interfaces/sel4.xml
+++ b/libsel4/include/interfaces/sel4.xml
@@ -662,6 +662,8 @@
                 description="Number of extra sporadic replenishments this scheduling context should use. Ignored for round-robin threads."/>
             <param dir="in" name="badge" type="seL4_Word"
                 description="Identifier for this scheduling context. Delivered to timeout exception handler. Can be used to determine which scheduling context triggered the timeout." />
+            <param dir="in" name="constant_bandwidth" type="seL4_Bool"
+                description="Whether the scheduling context should have bandwidth restricted continuously rather than only as a sporadic task." />
         </method>
 
     </interface>

--- a/libsel4/include/sel4/constants.h
+++ b/libsel4/include/sel4/constants.h
@@ -95,6 +95,14 @@ static inline seL4_Word seL4_MaxExtraRefills(seL4_Word size)
     return (LIBSEL4_BIT(size) -  seL4_CoreSchedContextBytes) / seL4_RefillSizeBytes;
 }
 #endif /* !__ASSEMBLER__ */
+
+/* Flags to be used with seL4_SchedControl_ConfigureFlags */
+typedef enum {
+    seL4_SchedContext_NoFlag = 0x0,
+    seL4_SchedContext_Sporadic = 0x1,
+    SEL4_FORCE_LONG_ENUM(seL4_SchedContextFlag),
+} seL4_SchedContextFlag;
+
 #endif /* CONFIG_KERNEL_MCS */
 
 #ifdef CONFIG_KERNEL_INVOCATION_REPORT_ERROR_IPC

--- a/libsel4/include/sel4/sel4.h
+++ b/libsel4/include/sel4/sel4.h
@@ -14,6 +14,7 @@
 
 #include <sel4/invocation.h>
 #include <interfaces/sel4_client.h>
+#include <sel4/virtual_client.h>
 
 #include <sel4/bootinfo.h>
 #include <sel4/faults.h>

--- a/libsel4/include/sel4/virtual_client.h
+++ b/libsel4/include/sel4/virtual_client.h
@@ -9,6 +9,7 @@
 #include <sel4/types.h>
 #include <sel4/macros.h>
 #include <sel4/invocation.h>
+#include <sel4/constants.h>
 #include <interfaces/sel4_client.h>
 
 /*
@@ -20,6 +21,7 @@
 LIBSEL4_INLINE seL4_Error seL4_SchedControl_Configure(seL4_SchedControl _service, seL4_SchedContext schedcontext,
                                                       seL4_Time budget, seL4_Time period, seL4_Word extra_refills, seL4_Word badge)
 {
-    return seL4_SchedControl_ConfigureFull(_service, schedcontext, budget, period, extra_refills, badge, seL4_True);
+    return seL4_SchedControl_ConfigureFlags(_service, schedcontext, budget, period, extra_refills, badge,
+                                            seL4_SchedContext_NoFlag);
 }
 #endif

--- a/libsel4/include/sel4/virtual_client.h
+++ b/libsel4/include/sel4/virtual_client.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+#include <autoconf.h>
+#include <sel4/types.h>
+#include <sel4/macros.h>
+#include <sel4/invocation.h>
+#include <interfaces/sel4_client.h>
+
+/*
+ * This file specifies virtual implementations of older invocations
+ * that can be aliased directly to new invocations.
+ */
+
+#ifdef CONFIG_KERNEL_MCS
+LIBSEL4_INLINE seL4_Error seL4_SchedControl_Configure(seL4_SchedControl _service, seL4_SchedContext schedcontext,
+                                                      seL4_Time budget, seL4_Time period, seL4_Word extra_refills, seL4_Word badge)
+{
+    return seL4_SchedControl_ConfigureFull(_service, schedcontext, budget, period, extra_refills, badge, seL4_True);
+}
+#endif

--- a/manual/parts/threads.tex
+++ b/manual/parts/threads.tex
@@ -200,8 +200,15 @@ invoke the appropriate \obj{SchedControl} capability, which provides access to C
 on a single node.  A scheduling control cap for each node is provided to the initial task at run
 time.  Threads run on the node that their scheduling context is configured for.  Scheduling context
 parameters can then be set and updated using
-\apifunc{seL4\_SchedControl\_Configure}{schedcontrol_configure}, which allows the budget and period
-to be specified.
+\apifunc{seL4\_SchedControl\_ConfigureFlags}{schedcontrol_configureflags}, which allows the budget and period
+to be specified along with a bitwise OR'd set of the following flags.
+
+\begin{description}
+
+\item[seL4_SchedContext_Sporadic]: constrain the execution time only according to the
+sporadic server algorithm rather than to a continuous constant bandwidth.
+
+\end{description}
 
 The kernel does not conduct any schedulability tests, as task admission is left to user-level policy
 and can be conducted online or offline, statically or dynamically or not at all.

--- a/src/kernel/sporadic.c
+++ b/src/kernel/sporadic.c
@@ -235,6 +235,17 @@ static inline void ensure_sufficient_head(sched_context_t *sc)
     }
 }
 
+static bool_t refill_head_overlapping(sched_context_t *sc)
+{
+    if (!refill_single(sc)) {
+        ticks_t amount = refill_head(sc)->rAmount;
+        ticks_t tail = refill_head(sc)->rTime + amount;
+        return refill_index(sc, refill_next(sc, sc->scRefillHead))->rTime <= tail;
+    } else {
+        return false;
+    }
+}
+
 void refill_budget_check(ticks_t usage)
 {
     sched_context_t *sc = NODE_STATE(ksCurSC);
@@ -332,14 +343,6 @@ void refill_split_check(ticks_t usage)
 }
 
 
-static bool_t refill_unblock_check_mergable(sched_context_t *sc)
-{
-    ticks_t amount = refill_head(sc)->rAmount;
-    ticks_t tail = NODE_STATE_ON_CORE(ksCurTime, sc->scCore) + amount;
-    bool_t enough_time = refill_index(sc, refill_next(sc, sc->scRefillHead))->rTime <= tail;
-    return !refill_single(sc) && enough_time;
-}
-
 void refill_unblock_check(sched_context_t *sc)
 {
 
@@ -355,7 +358,7 @@ void refill_unblock_check(sched_context_t *sc)
         NODE_STATE(ksReprogram) = true;
 
         /* merge available replenishments */
-        while (refill_unblock_check_mergable(sc)) {
+        while (refill_head_overlapping(sc)) {
             ticks_t amount = refill_head(sc)->rAmount;
             refill_pop_head(sc);
             refill_head(sc)->rAmount += amount;

--- a/src/kernel/sporadic.c
+++ b/src/kernel/sporadic.c
@@ -64,11 +64,15 @@ UNUSED static inline void refill_print(sched_context_t *sc)
 /* check a refill queue is ordered correctly */
 static UNUSED bool_t refill_ordered(sched_context_t *sc)
 {
+    if (isRoundRobin(sc)) {
+        return true;
+    }
+
     word_t current = sc->scRefillHead;
     word_t next = refill_next(sc, sc->scRefillHead);
 
     while (current != sc->scRefillTail) {
-        if (!(refill_index(sc, current)->rTime <= refill_index(sc, next)->rTime)) {
+        if (!(refill_index(sc, current)->rTime + refill_index(sc, current)->rAmount <= refill_index(sc, next)->rTime)) {
             refill_print(sc);
             return false;
         }

--- a/src/kernel/thread.c
+++ b/src/kernel/thread.c
@@ -91,8 +91,8 @@ void restart(tcb_t *target)
         cancelIPC(target);
 #ifdef CONFIG_KERNEL_MCS
         setThreadState(target, ThreadState_Restart);
-        if (target->tcbSchedContext != NULL && sc_active(target->tcbSchedContext)) {
-            assert(target->tcbSchedContext != NODE_STATE(ksCurSC));
+        if (target->tcbSchedContext != NULL && sc_active(target->tcbSchedContext)
+            && target->tcbSchedContext != NODE_STATE(ksCurSC)) {
             refill_unblock_check(target->tcbSchedContext);
         }
         schedContext_resume(target->tcbSchedContext);

--- a/src/kernel/thread.c
+++ b/src/kernel/thread.c
@@ -91,7 +91,7 @@ void restart(tcb_t *target)
         cancelIPC(target);
 #ifdef CONFIG_KERNEL_MCS
         setThreadState(target, ThreadState_Restart);
-        if (target->tcbSchedContext != NULL) {
+        if (target->tcbSchedContext != NULL && sc_active(target->tcbSchedContext)) {
             assert(target->tcbSchedContext != NODE_STATE(ksCurSC));
             refill_unblock_check(target->tcbSchedContext);
         }
@@ -142,7 +142,8 @@ void doReplyTransfer(tcb_t *sender, tcb_t *receiver, cte_t *slot, bool_t grant)
     assert(thread_state_get_replyObject(receiver->tcbState) == REPLY_REF(0));
     assert(reply->replyTCB == NULL);
 
-    if (receiver->tcbSchedContext && receiver->tcbSchedContext != NODE_STATE(ksCurSC)) {
+    if (receiver->tcbSchedContext && sc_active(receiver->tcbSchedContext)
+        && receiver->tcbSchedContext != NODE_STATE(ksCurSC)) {
         refill_unblock_check(receiver->tcbSchedContext);
     }
 #else

--- a/src/object/endpoint.c
+++ b/src/object/endpoint.c
@@ -103,7 +103,7 @@ void sendIPC(bool_t blocking, bool_t do_call, word_t badge,
         assert(dest->tcbSchedContext == NULL || refill_sufficient(dest->tcbSchedContext, 0));
         assert(dest->tcbSchedContext == NULL || refill_ready(dest->tcbSchedContext));
         setThreadState(dest, ThreadState_Running);
-        if (dest->tcbSchedContext != NULL && dest->tcbSchedContext != NODE_STATE(ksCurSC)) {
+        if (sc_sporadic(dest->tcbSchedContext) && dest->tcbSchedContext != NODE_STATE(ksCurSC)) {
             refill_unblock_check(dest->tcbSchedContext);
         }
         possibleSwitchTo(dest);
@@ -236,7 +236,7 @@ void receiveIPC(tcb_t *thread, cap_t cap, bool_t isBlocking)
             do_call = thread_state_ptr_get_blockingIPCIsCall(&sender->tcbState);
 
 #ifdef CONFIG_KERNEL_MCS
-            if (sender->tcbSchedContext != NULL) {
+            if (sc_sporadic(sender->tcbSchedContext)) {
                 assert(sender->tcbSchedContext != NODE_STATE(ksCurSC));
                 refill_unblock_check(sender->tcbSchedContext);
             }
@@ -393,7 +393,7 @@ void cancelAllIPC(endpoint_t *epptr)
             }
             if (seL4_Fault_get_seL4_FaultType(thread->tcbFault) == seL4_Fault_NullFault) {
                 setThreadState(thread, ThreadState_Restart);
-                if (thread->tcbSchedContext != NULL) {
+                if (sc_sporadic(thread->tcbSchedContext)) {
                     assert(thread->tcbSchedContext != NODE_STATE(ksCurSC));
                     refill_unblock_check(thread->tcbSchedContext);
                 }
@@ -442,7 +442,7 @@ void cancelBadgedSends(endpoint_t *epptr, word_t badge)
                 if (seL4_Fault_get_seL4_FaultType(thread->tcbFault) ==
                     seL4_Fault_NullFault) {
                     setThreadState(thread, ThreadState_Restart);
-                    if (thread->tcbSchedContext != NULL) {
+                    if (sc_sporadic(thread->tcbSchedContext)) {
                         assert(thread->tcbSchedContext != NODE_STATE(ksCurSC));
                         refill_unblock_check(thread->tcbSchedContext);
                     }

--- a/src/object/notification.c
+++ b/src/object/notification.c
@@ -45,7 +45,7 @@ static inline void maybeDonateSchedContext(tcb_t *tcb, notification_t *ntfnPtr)
         sched_context_t *sc = SC_PTR(notification_ptr_get_ntfnSchedContext(ntfnPtr));
         if (sc != NULL && sc->scTcb == NULL) {
             schedContext_donate(sc, tcb);
-            if (sc != NODE_STATE(ksCurSC)) {
+            if (sc != NODE_STATE(ksCurSC) && sc_active(sc)) {
                 /* refill_unblock_check should not be called on the
                  * current SC as it is already running. The current SC
                  * may have been bound to a notificaiton object if the

--- a/src/object/notification.c
+++ b/src/object/notification.c
@@ -154,7 +154,7 @@ void sendSignal(notification_t *ntfnPtr, word_t badge)
         })
 
 #ifdef CONFIG_KERNEL_MCS
-        if (dest->tcbSchedContext != NULL && is_active(dest->tcbSchedContext)) {
+        if (dest->tcbSchedContext != NULL && sc_active(dest->tcbSchedContext)) {
             assert(dest->tcbSchedContext != NODE_STATE(ksCurSC));
             refill_unblock_check(dest->tcbSchedContext);
         }

--- a/src/object/notification.c
+++ b/src/object/notification.c
@@ -81,7 +81,7 @@ void sendSignal(notification_t *ntfnPtr, word_t badge)
                     possibleSwitchTo(tcb);
                 })
 #ifdef CONFIG_KERNEL_MCS
-                if (tcb->tcbSchedContext != NULL && sc_active(tcb->tcbSchedContext)) {
+                if (sc_sporadic(tcb->tcbSchedContext) && sc_active(tcb->tcbSchedContext)) {
                     assert(tcb->tcbSchedContext != NODE_STATE(ksCurSC));
                     refill_unblock_check(tcb->tcbSchedContext);
                 }
@@ -154,7 +154,7 @@ void sendSignal(notification_t *ntfnPtr, word_t badge)
         })
 
 #ifdef CONFIG_KERNEL_MCS
-        if (dest->tcbSchedContext != NULL && sc_active(dest->tcbSchedContext)) {
+        if (sc_sporadic(dest->tcbSchedContext) && sc_active(dest->tcbSchedContext)) {
             assert(dest->tcbSchedContext != NODE_STATE(ksCurSC));
             refill_unblock_check(dest->tcbSchedContext);
         }
@@ -234,7 +234,7 @@ void cancelAllSignals(notification_t *ntfnPtr)
         for (; thread; thread = thread->tcbEPNext) {
             setThreadState(thread, ThreadState_Restart);
 #ifdef CONFIG_KERNEL_MCS
-            if (thread->tcbSchedContext != NULL) {
+            if (sc_sporadic(thread->tcbSchedContext)) {
                 assert(thread->tcbSchedContext != NODE_STATE(ksCurSC));
                 refill_unblock_check(thread->tcbSchedContext);
             }

--- a/src/object/schedcontext.c
+++ b/src/object/schedcontext.c
@@ -286,7 +286,9 @@ void schedContext_bindTCB(sched_context_t *sc, tcb_t *tcb)
 
     SMP_COND_STATEMENT(migrateTCB(tcb, sc->scCore));
 
-    refill_unblock_check(sc);
+    if (sc_active(sc)) {
+        refill_unblock_check(sc);
+    }
     schedContext_resume(sc);
     if (isSchedulable(tcb)) {
         SCHED_ENQUEUE(tcb);

--- a/src/object/schedcontext.c
+++ b/src/object/schedcontext.c
@@ -181,7 +181,6 @@ static exception_t invokeSchedContext_YieldTo(sched_context_t *sc, word_t *buffe
 
     bool_t return_now = true;
     if (isSchedulable(sc->scTcb)) {
-        refill_unblock_check(sc);
         if (SMP_COND_STATEMENT(sc->scCore != getCurrentCPUIndex() ||)
             sc->scTcb->tcbPriority < NODE_STATE(ksCurThread)->tcbPriority) {
             tcbSchedDequeue(sc->scTcb);
@@ -287,6 +286,7 @@ void schedContext_bindTCB(sched_context_t *sc, tcb_t *tcb)
 
     SMP_COND_STATEMENT(migrateTCB(tcb, sc->scCore));
 
+    refill_unblock_check(sc);
     schedContext_resume(sc);
     if (isSchedulable(tcb)) {
         SCHED_ENQUEUE(tcb);

--- a/src/object/schedcontext.c
+++ b/src/object/schedcontext.c
@@ -5,6 +5,9 @@
  */
 
 #include <machine/timer.h>
+#include <kernel/sporadic.h>
+#include <kernel/thread.h>
+#include <object/structures.h>
 #include <object/schedcontext.h>
 
 static exception_t invokeSchedContext_UnbindObject(sched_context_t *sc, cap_t cap)
@@ -101,6 +104,13 @@ static exception_t decodeSchedContext_Bind(sched_context_t *sc, extra_caps_t ext
     case cap_thread_cap:
         if (TCB_PTR(cap_thread_cap_get_capTCBPtr(cap))->tcbSchedContext != NULL) {
             userError("SchedContext_Bind: tcb already bound.");
+            current_syscall_error.type = seL4_IllegalOperation;
+            return EXCEPTION_SYSCALL_ERROR;
+        }
+
+        if (isBlocked(TCB_PTR(cap_thread_cap_get_capTCBPtr(cap))) && (!sc_active(sc) || !refill_sufficient(sc, 0)
+                                                                      || !refill_ready(sc))) {
+            userError("SchedContext_Bind: tcb blocked and scheduling context not schedulable.");
             current_syscall_error.type = seL4_IllegalOperation;
             return EXCEPTION_SYSCALL_ERROR;
         }

--- a/src/object/schedcontext.c
+++ b/src/object/schedcontext.c
@@ -108,8 +108,7 @@ static exception_t decodeSchedContext_Bind(sched_context_t *sc, extra_caps_t ext
             return EXCEPTION_SYSCALL_ERROR;
         }
 
-        if (isBlocked(TCB_PTR(cap_thread_cap_get_capTCBPtr(cap))) && (!sc_active(sc) || !refill_sufficient(sc, 0)
-                                                                      || !refill_ready(sc))) {
+        if (isBlocked(TCB_PTR(cap_thread_cap_get_capTCBPtr(cap))) && !sc_released(sc)) {
             userError("SchedContext_Bind: tcb blocked and scheduling context not schedulable.");
             current_syscall_error.type = seL4_IllegalOperation;
             return EXCEPTION_SYSCALL_ERROR;

--- a/src/object/schedcontrol.c
+++ b/src/object/schedcontrol.c
@@ -99,7 +99,9 @@ static exception_t decodeSchedControl_Configure(word_t length, cap_t cap, extra_
     }
 
     time_t budget_us = mode_parseTimeArg(0, buffer);
+    ticks_t budget_ticks = usToTicks(budget_us);
     time_t period_us = mode_parseTimeArg(TIME_ARG_SIZE, buffer);
+    ticks_t period_ticks = usToTicks(period_us);
     word_t extra_refills = getSyscallArg(TIME_ARG_SIZE * 2, buffer);
     word_t badge = getSyscallArg(TIME_ARG_SIZE * 2 + 1, buffer);
 
@@ -111,7 +113,7 @@ static exception_t decodeSchedControl_Configure(word_t length, cap_t cap, extra_
         return EXCEPTION_SYSCALL_ERROR;
     }
 
-    if (budget_us > MAX_BUDGET_US || budget_us < MIN_BUDGET_US) {
+    if (budget_us > MAX_BUDGET_US || budget_ticks < MIN_BUDGET) {
         userError("SchedControl_Configure: budget out of range.");
         current_syscall_error.type = seL4_RangeError;
         current_syscall_error.rangeErrorMin = MIN_BUDGET_US;
@@ -119,7 +121,7 @@ static exception_t decodeSchedControl_Configure(word_t length, cap_t cap, extra_
         return EXCEPTION_SYSCALL_ERROR;
     }
 
-    if (period_us > MAX_BUDGET_US || period_us < MIN_BUDGET_US) {
+    if (period_us > MAX_BUDGET_US || period_ticks < MIN_BUDGET) {
         userError("SchedControl_Configure: period out of range.");
         current_syscall_error.type = seL4_RangeError;
         current_syscall_error.rangeErrorMin = MIN_BUDGET_US;
@@ -127,7 +129,7 @@ static exception_t decodeSchedControl_Configure(word_t length, cap_t cap, extra_
         return EXCEPTION_SYSCALL_ERROR;
     }
 
-    if (budget_us > period_us) {
+    if (budget_ticks > period_ticks) {
         userError("SchedControl_Configure: budget must be <= period");
         current_syscall_error.type = seL4_RangeError;
         current_syscall_error.rangeErrorMin = MIN_BUDGET_US;
@@ -148,8 +150,8 @@ static exception_t decodeSchedControl_Configure(word_t length, cap_t cap, extra_
     setThreadState(NODE_STATE(ksCurThread), ThreadState_Restart);
     return invokeSchedControl_Configure(SC_PTR(cap_sched_context_cap_get_capSCPtr(targetCap)),
                                         cap_sched_control_cap_get_core(cap),
-                                        usToTicks(budget_us),
-                                        usToTicks(period_us),
+                                        budget_ticks,
+                                        period_ticks,
                                         extra_refills + MIN_REFILLS,
                                         badge);
 }

--- a/src/object/schedcontrol.c
+++ b/src/object/schedcontrol.c
@@ -47,12 +47,9 @@ static exception_t invokeSchedControl_Configure(sched_context_t *target, word_t 
          * period to 0, which means that the budget will always be ready to be refilled
          * and avoids some special casing.
          */
-        period = 0;
-        max_refills = MIN_REFILLS;
-    }
-
-    if (SMP_COND_STATEMENT(core == target->scCore &&) target->scRefillMax > 0 && target->scTcb
-        && isRunnable(target->scTcb)) {
+        REFILL_NEW(target, MIN_REFILLS, budget, 0, core);
+    } else if (SMP_COND_STATEMENT(core == target->scCore &&) target->scRefillMax > 0 && target->scTcb
+               && isRunnable(target->scTcb)) {
         /* the scheduling context is active - it can be used, so
          * we need to preserve the bandwidth */
         refill_update(target, period, budget, max_refills);

--- a/src/object/schedcontrol.c
+++ b/src/object/schedcontrol.c
@@ -10,8 +10,8 @@
 #include <object/schedcontrol.h>
 #include <kernel/sporadic.h>
 
-static exception_t invokeSchedControl_Configure(sched_context_t *target, word_t core, ticks_t budget,
-                                                ticks_t period, word_t max_refills, word_t badge, bool_t constant_bandwidth)
+static exception_t invokeSchedControl_ConfigureFull(sched_context_t *target, word_t core, ticks_t budget,
+                                                    ticks_t period, word_t max_refills, word_t badge, bool_t constant_bandwidth)
 {
 
     target->scBadge = badge;
@@ -86,16 +86,16 @@ static exception_t invokeSchedControl_Configure(sched_context_t *target, word_t 
     return EXCEPTION_NONE;
 }
 
-static exception_t decodeSchedControl_Configure(word_t length, cap_t cap, extra_caps_t extraCaps, word_t *buffer)
+static exception_t decodeSchedControl_ConfigureFull(word_t length, cap_t cap, extra_caps_t extraCaps, word_t *buffer)
 {
     if (extraCaps.excaprefs[0] == NULL) {
-        userError("SchedControl_Configure: Truncated message.");
+        userError("SchedControl_ConfigureFull: Truncated message.");
         current_syscall_error.type = seL4_TruncatedMessage;
         return EXCEPTION_SYSCALL_ERROR;
     }
 
     if (length < (TIME_ARG_SIZE * 2) + 2) {
-        userError("SchedControl_configure: truncated message.");
+        userError("SchedControl_configureFull: truncated message.");
         current_syscall_error.type = seL4_TruncatedMessage;
         return EXCEPTION_SYSCALL_ERROR;
     }
@@ -110,14 +110,14 @@ static exception_t decodeSchedControl_Configure(word_t length, cap_t cap, extra_
 
     cap_t targetCap = extraCaps.excaprefs[0]->cap;
     if (unlikely(cap_get_capType(targetCap) != cap_sched_context_cap)) {
-        userError("SchedControl_Configure: target cap not a scheduling context cap");
+        userError("SchedControl_ConfigureFull: target cap not a scheduling context cap");
         current_syscall_error.type = seL4_InvalidCapability;
         current_syscall_error.invalidCapNumber = 1;
         return EXCEPTION_SYSCALL_ERROR;
     }
 
     if (budget_us > MAX_BUDGET_US || budget_ticks < MIN_BUDGET) {
-        userError("SchedControl_Configure: budget out of range.");
+        userError("SchedControl_ConfigureFull: budget out of range.");
         current_syscall_error.type = seL4_RangeError;
         current_syscall_error.rangeErrorMin = MIN_BUDGET_US;
         current_syscall_error.rangeErrorMax = MAX_BUDGET_US;
@@ -125,7 +125,7 @@ static exception_t decodeSchedControl_Configure(word_t length, cap_t cap, extra_
     }
 
     if (period_us > MAX_BUDGET_US || period_ticks < MIN_BUDGET) {
-        userError("SchedControl_Configure: period out of range.");
+        userError("SchedControl_ConfigureFull: period out of range.");
         current_syscall_error.type = seL4_RangeError;
         current_syscall_error.rangeErrorMin = MIN_BUDGET_US;
         current_syscall_error.rangeErrorMax = MAX_BUDGET_US;
@@ -133,7 +133,7 @@ static exception_t decodeSchedControl_Configure(word_t length, cap_t cap, extra_
     }
 
     if (budget_ticks > period_ticks) {
-        userError("SchedControl_Configure: budget must be <= period");
+        userError("SchedControl_ConfigureFull: budget must be <= period");
         current_syscall_error.type = seL4_RangeError;
         current_syscall_error.rangeErrorMin = MIN_BUDGET_US;
         current_syscall_error.rangeErrorMax = period_us;
@@ -151,21 +151,21 @@ static exception_t decodeSchedControl_Configure(word_t length, cap_t cap, extra_
     }
 
     setThreadState(NODE_STATE(ksCurThread), ThreadState_Restart);
-    return invokeSchedControl_Configure(SC_PTR(cap_sched_context_cap_get_capSCPtr(targetCap)),
-                                        cap_sched_control_cap_get_core(cap),
-                                        budget_ticks,
-                                        period_ticks,
-                                        extra_refills + MIN_REFILLS,
-                                        badge,
-                                        constant_bandwidth);
+    return invokeSchedControl_ConfigureFull(SC_PTR(cap_sched_context_cap_get_capSCPtr(targetCap)),
+                                            cap_sched_control_cap_get_core(cap),
+                                            budget_ticks,
+                                            period_ticks,
+                                            extra_refills + MIN_REFILLS,
+                                            badge,
+                                            constant_bandwidth);
 }
 
 exception_t decodeSchedControlInvocation(word_t label, cap_t cap, word_t length, extra_caps_t extraCaps,
                                          word_t *buffer)
 {
     switch (label) {
-    case SchedControlConfigure:
-        return  decodeSchedControl_Configure(length, cap, extraCaps, buffer);
+    case SchedControlConfigureFull:
+        return  decodeSchedControl_ConfigureFull(length, cap, extraCaps, buffer);
     default:
         userError("SchedControl invocation: Illegal operation attempted.");
         current_syscall_error.type = seL4_IllegalOperation;

--- a/src/object/schedcontrol.c
+++ b/src/object/schedcontrol.c
@@ -66,7 +66,8 @@ static exception_t invokeSchedControl_Configure(sched_context_t *target, word_t 
     }
 #endif /* ENABLE_SMP_SUPPORT */
 
-    if (target->scTcb && target->scRefillMax > 0) {
+    assert(target->scRefillMax > 0);
+    if (target->scTcb) {
         schedContext_resume(target);
         if (SMP_TERNARY(core == CURRENT_CPU_INDEX(), true)) {
             if (isRunnable(target->scTcb) && target->scTcb != NODE_STATE(ksCurThread)) {

--- a/src/object/schedcontrol.c
+++ b/src/object/schedcontrol.c
@@ -11,7 +11,7 @@
 #include <kernel/sporadic.h>
 
 static exception_t invokeSchedControl_Configure(sched_context_t *target, word_t core, ticks_t budget,
-                                                ticks_t period, word_t max_refills, word_t badge)
+                                                ticks_t period, word_t max_refills, word_t badge, bool_t constant_bandwidth)
 {
 
     target->scBadge = badge;
@@ -41,6 +41,8 @@ static exception_t invokeSchedControl_Configure(sched_context_t *target, word_t 
 #endif /* ENABLE_SMP_SUPPORT */
         }
     }
+
+    target->scConstantBandwidth = constant_bandwidth;
 
     if (budget == period) {
         /* this is a cool hack: for round robin, we set the
@@ -104,6 +106,7 @@ static exception_t decodeSchedControl_Configure(word_t length, cap_t cap, extra_
     ticks_t period_ticks = usToTicks(period_us);
     word_t extra_refills = getSyscallArg(TIME_ARG_SIZE * 2, buffer);
     word_t badge = getSyscallArg(TIME_ARG_SIZE * 2 + 1, buffer);
+    bool_t constant_bandwidth = getSyscallArg(TIME_ARG_SIZE * 2 + 2, buffer);
 
     cap_t targetCap = extraCaps.excaprefs[0]->cap;
     if (unlikely(cap_get_capType(targetCap) != cap_sched_context_cap)) {
@@ -153,7 +156,8 @@ static exception_t decodeSchedControl_Configure(word_t length, cap_t cap, extra_
                                         budget_ticks,
                                         period_ticks,
                                         extra_refills + MIN_REFILLS,
-                                        badge);
+                                        badge,
+                                        constant_bandwidth);
 }
 
 exception_t decodeSchedControlInvocation(word_t label, cap_t cap, word_t length, extra_caps_t extraCaps,

--- a/src/object/tcb.c
+++ b/src/object/tcb.c
@@ -1343,7 +1343,7 @@ exception_t decodeSetSchedParams(cap_t cap, word_t length, extra_caps_t excaps, 
         return EXCEPTION_SYSCALL_ERROR;
     }
 
-    if (isBlocked(tcb) && (!sc_active(sc) || !refill_sufficient(sc, 0) || !refill_ready(sc))) {
+    if (isBlocked(tcb) && !sc_released(sc)) {
         userError("TCB Configure: tcb blocked and scheduling context not schedulable.");
         current_syscall_error.type = seL4_IllegalOperation;
         return EXCEPTION_SYSCALL_ERROR;

--- a/src/object/tcb.c
+++ b/src/object/tcb.c
@@ -1343,6 +1343,12 @@ exception_t decodeSetSchedParams(cap_t cap, word_t length, extra_caps_t excaps, 
         return EXCEPTION_SYSCALL_ERROR;
     }
 
+    if (isBlocked(tcb) && (!sc_active(sc) || !refill_sufficient(sc, 0) || !refill_ready(sc))) {
+        userError("TCB Configure: tcb blocked and scheduling context not schedulable.");
+        current_syscall_error.type = seL4_IllegalOperation;
+        return EXCEPTION_SYSCALL_ERROR;
+    }
+
     if (!validFaultHandler(fhCap)) {
         userError("TCB Configure: fault endpoint cap invalid.");
         current_syscall_error.type = seL4_InvalidCapability;

--- a/src/object/tcb.c
+++ b/src/object/tcb.c
@@ -1328,6 +1328,11 @@ exception_t decodeSetSchedParams(cap_t cap, word_t length, extra_caps_t excaps, 
             current_syscall_error.type = seL4_IllegalOperation;
             return EXCEPTION_SYSCALL_ERROR;
         }
+        if (isBlocked(tcb) && !sc_released(sc)) {
+            userError("TCB Configure: tcb blocked and scheduling context not schedulable.");
+            current_syscall_error.type = seL4_IllegalOperation;
+            return EXCEPTION_SYSCALL_ERROR;
+        }
         break;
     case cap_null_cap:
         if (tcb == NODE_STATE(ksCurThread)) {
@@ -1340,12 +1345,6 @@ exception_t decodeSetSchedParams(cap_t cap, word_t length, extra_caps_t excaps, 
         userError("TCB Configure: sched context cap invalid.");
         current_syscall_error.type = seL4_InvalidCapability;
         current_syscall_error.invalidCapNumber = 2;
-        return EXCEPTION_SYSCALL_ERROR;
-    }
-
-    if (isBlocked(tcb) && !sc_released(sc)) {
-        userError("TCB Configure: tcb blocked and scheduling context not schedulable.");
-        current_syscall_error.type = seL4_IllegalOperation;
         return EXCEPTION_SYSCALL_ERROR;
     }
 


### PR DESCRIPTION
This change outlines the changes to the master branch of the kernel that were used in the process of verifying the MCS implementation.

Some of these commits are still being actively worked on for verification; 7cc034b is one that has been discussed before but has not yet been included.

3ae3ee1673d24ab73f51f15ce198bd70c3cb9fae and 754cbc9 are needed given the invariants in the master kernel but the changes in #216 will make these checks unnecessary and should result in their eventual removal.

At some point there was a change to the representation used for the refill queue such that changed it from a pair of head and tail to a pair of head and the number of elements. This was done as changes (that have since been abandoned) were introduced that would lead to the queue being made empty during `refill_budget_check`. The current changes do not include the changes to the representation of the list as there is no longer the need to represent an empty list during operations on scheduling contexts.

A side effect of these changes having been made is that the Haskell specification currently uses the head+ count model and, as such, so do the refine proofs from the abstract model down to the Haskell specification. Resolving this requires either making the kernel consistent with the Haskell or the Haskell and refine proofs consistent with the kernel.