### PR TITLE
Fix MCS+EL2

### DIFF
--- a/include/arch/arm/arch/64/mode/machine.h
+++ b/include/arch/arm/arch/64/mode/machine.h
@@ -26,13 +26,14 @@
 #define CNT_TVAL "cnthp_tval_el2"
 #define CNT_CVAL "cnthp_cval_el2"
 #define CNT_CTL  "cnthp_ctl_el2"
+#define CNT_CT   "cntpct_el0"
 #else
 #define CNT_TVAL "cntv_tval_el0"
 #define CNT_CVAL "cntv_cval_el0"
 #define CNT_CTL  CNTV_CTL
+#define CNT_CT   "cntvct_el0"
 #endif
 #define CNTFRQ   "cntfrq_el0"
-#define CNT_CT   "cntvct_el0"
 
 #ifdef ENABLE_SMP_SUPPORT
 /* Use the first two SGI (Software Generated Interrupt) IDs


### PR DESCRIPTION
When running in EL2 the physical counter is in register cntpct_el0, not cntvct_el0