### PR TITLE
mcs: cancel IPC when finalising reply caps

### DIFF
--- a/src/object/objecttype.c
+++ b/src/object/objecttype.c
@@ -142,7 +142,7 @@ finaliseCap_ret_t finaliseCap(cap_t cap, bool_t final, bool_t exposed)
                     reply_remove(reply, reply->replyTCB);
                     break;
                 case ThreadState_BlockedOnReceive:
-                    reply_unlink(reply, reply->replyTCB);
+                    cancelIPC(reply->replyTCB);
                     break;
                 default:
                     fail("Invalid tcb state");


### PR DESCRIPTION
Deleting a reply object that is linked to a `BlockedOnReceive` thread is unusual behaviour and it's not clear what the expected behaviour should be. Previously, `finaliseCap` called `replyUnlink` but this sets the thread to `Inactive` while leaving it in the endpoint's queue, which breaks the invariants. Calling `cancelIPC` at least guarantees that the system ends up in a consistent state.

There are potentially other options here, but it is strongly preferred that we take this approach during the current verification work. We'll be happy to come back to this decision if necessary once we're finished.