### PR TITLE
zynqmp: update ethernet interrupts in overlay

### DIFF
--- a/src/plat/zynqmp/overlay-zynqmp.dts
+++ b/src/plat/zynqmp/overlay-zynqmp.dts
@@ -5,6 +5,27 @@
  */
 
 / {
+	amba {
+		/* These blocks remove the duplicate interrupt which causes issues
+		 * in the low-level drivers
+		 */
+		ethernet@ff0b0000 {
+			interrupts = < 0x00 0x39 0x04 >;
+		};
+
+		ethernet@ff0c0000 {
+			interrupts = < 0x00 0x3b 0x04 >;
+		};
+
+		ethernet@ff0d0000 {
+			interrupts = < 0x00 0x3d 0x04 >;
+		};
+
+		ethernet@ff0e0000 {
+			interrupts = < 0x00 0x3f 0x04 >;
+		};
+	};
+
     chosen {
 		seL4,elfloader-devices =
 		    "serial0",

--- a/src/plat/zynqmp/overlay-zynqmp32.dts
+++ b/src/plat/zynqmp/overlay-zynqmp32.dts
@@ -5,6 +5,27 @@
  */
 
 / {
+	amba {
+		/* These blocks remove the duplicate interrupt which causes issues
+		 * in the low-level drivers
+		 */
+		ethernet@ff0b0000 {
+			interrupts = < 0x00 0x39 0x04 >;
+		};
+
+		ethernet@ff0c0000 {
+			interrupts = < 0x00 0x3b 0x04 >;
+		};
+
+		ethernet@ff0d0000 {
+			interrupts = < 0x00 0x3d 0x04 >;
+		};
+
+		ethernet@ff0e0000 {
+			interrupts = < 0x00 0x3f 0x04 >;
+		};
+	};
+
     chosen {
 		seL4,elfloader-devices =
 		    "serial0",


### PR DESCRIPTION
The Linux drivers use duplicate interrupts in the device tree; however,
seL4 drivers do not. The duplicate interrupts cause issues while using
templates in CAmkES applications. This commit adds an overlay which
overwrites the duplicate ethernet interrupts.