### PR TITLE
riscv: Clear reservation state on fastpath exit

### DIFF
--- a/include/arch/riscv/arch/fastpath/fastpath.h
+++ b/include/arch/riscv/arch/fastpath/fastpath.h
@@ -120,6 +120,9 @@ static inline void NORETURN FORCE_INLINE fastpath_restore(word_t badge, word_t m
         LOAD_S "  gp, (2*%[REGSIZE])(t0)  \n"
         /* skip tp */
         /* skip x5/t0 */
+        /* no-op store conditional to clear monitor state */
+        /* this may succeed in implementations with very large reservations, but the saved ra is dead */
+        "sc.w zero, zero, (t0)\n"
         LOAD_S "  t2, (6*%[REGSIZE])(t0)  \n"
         LOAD_S "  s0, (7*%[REGSIZE])(t0)  \n"
         LOAD_S "  s1, (8*%[REGSIZE])(t0)  \n"


### PR DESCRIPTION
This operation matches the same operation performed by the slowpath
exit. It's purpose is to invalidate any existing reservation state from
the previous tcb context executing on this hart.

The fastpath must match a particular execution of the slowpath and so
these operations must match.

Signed-off-by: Kent McLeod <kent@kry10.com>