### PR TITLE
smmuv2: Reserve VSpace slot for holding CB count

### DIFF
--- a/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
@@ -260,8 +260,15 @@ SEL4_SIZE_SANITY(seL4_PUDEntryBits, seL4_PUDIndexBits, seL4_PUDBits);
 #define seL4_IPCBufferSizeBits 10
 
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
+#ifndef CONFIG_ARM_SMMU
 /* 1 slot at the end of the vspace is used to hold the VMID assigned to the vspace */
 #define seL4_VSpaceReservedSlots 1
+#else /*CONFIG_ARM_SMMU*/
+/* 1 slot at the end of the vspace is used to hold the VMID assigned to the vspace */
+/* 1 slot at the end of the vspace is used to hold the number of SMMU CBs assigned to the vspace */
+#define seL4_VSpaceReservedSlots 2
+#endif /*CONFIG_ARM_SMMU*/
+
 /* The userspace occupies the range 0x0 to 0xfffffffffff.
  * The stage-1 translation is disabled, and the stage-2
  * translation input addree size is constrained by the


### PR DESCRIPTION
A slot in the top level VSpace page table is used to hold the number of
SMMUv2 ContextBanks that are assigned to a VSpace. This means a
reduction of available virtual addresses at userlevel as the slot cannot
be used for holding regular mappings.

Signed-off-by: Kent McLeod <kent@kry10.com>