### PR TITLE
boot: Allocate init bookkeeping structs in bss

### DIFF
--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -18,10 +18,10 @@
 #include <util.h>
 
 /* (node-local) state accessed only during bootstrapping */
-ndks_boot_t ndks_boot BOOT_DATA;
+ndks_boot_t ndks_boot BOOT_BSS;
 
-rootserver_mem_t rootserver BOOT_DATA;
-static region_t rootserver_mem BOOT_DATA;
+rootserver_mem_t rootserver BOOT_BSS;
+static region_t rootserver_mem BOOT_BSS;
 
 BOOT_CODE static void merge_regions(void)
 {


### PR DESCRIPTION
ndks_boot, rootserver and rootserver_mem don't contain any non-zero init
values and can be moved to bss so they don't take up space in the ELF.
ndks_boot contains a sparse struct that is > 4MiB on x86_64 and so this
change allows the x86_64 ELF to return to < 200KiB.

Signed-off-by: Kent McLeod <kent@kry10.com>