### PR TITLE
use include guards for auto generated files

### DIFF
--- a/configs/seL4Config.cmake
+++ b/configs/seL4Config.cmake
@@ -14,8 +14,9 @@ set(bf_declarations "")
 
 include(${CMAKE_CURRENT_LIST_DIR}/../tools/internal.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/../tools/helpers.cmake)
-# Create and set all of the Kernel config options that can
-# be derived from the seL4 arch which is one of the following:
+
+# Create and set all of the Kernel config options that can be derived from the
+# seL4 arch which is one of the following:
 # aarch32, aarch64, arm_hyp, riscv32, riscv64, x86_64, ia32
 # This macro is intended to be called from within a platform config.
 macro(declare_seL4_arch sel4_arch)

--- a/configs/seL4Config.cmake
+++ b/configs/seL4Config.cmake
@@ -93,7 +93,7 @@ endmacro()
 
 # helper macro that prints a message that no sub platform is specified and
 # the default sub platform will be used
-# Usage example: fallback_declare_seL4_arch_default(aarch32)
+# Usage example: check_platform_and_fallback_to_default(KernelARMPlatform "sabre")
 macro(check_platform_and_fallback_to_default var_cmake_kernel_plat default_sub_plat)
     if("${${var_cmake_kernel_plat}}" STREQUAL "")
         print_message_multiple_options_helper("sub platforms" ${default_sub_plat})

--- a/libsel4/arch_include/arm/sel4/arch/simple_types.h
+++ b/libsel4/arch_include/arm/sel4/arch/simple_types.h
@@ -15,4 +15,3 @@ typedef signed int seL4_Int32;
 typedef unsigned char seL4_Uint8;
 typedef unsigned short seL4_Uint16;
 typedef unsigned int seL4_Uint32;
-

--- a/libsel4/arch_include/riscv/sel4/arch/simple_types.h
+++ b/libsel4/arch_include/riscv/sel4/arch/simple_types.h
@@ -13,4 +13,3 @@ typedef signed int seL4_Int32;
 typedef unsigned char seL4_Uint8;
 typedef unsigned short seL4_Uint16;
 typedef unsigned int seL4_Uint32;
-

--- a/libsel4/include/sel4/simple_types.h
+++ b/libsel4/include/sel4/simple_types.h
@@ -21,4 +21,3 @@ typedef seL4_Int8 seL4_Bool;
 #else
 #define seL4_Null ((void*)0)
 #endif // __cplusplus
-

--- a/libsel4/include/sel4/types.h
+++ b/libsel4/include/sel4/types.h
@@ -38,9 +38,9 @@ typedef seL4_CPtr seL4_Untyped;
 typedef seL4_CPtr seL4_DomainSet;
 typedef seL4_CPtr seL4_SchedContext;
 typedef seL4_CPtr seL4_SchedControl;
+
 typedef seL4_Uint64 seL4_Time;
 
 #define seL4_NilData 0
 
 #include <sel4/arch/constants.h>
-

--- a/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/simple_types.h
+++ b/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/simple_types.h
@@ -9,5 +9,3 @@
 typedef signed long long seL4_Int64;
 
 typedef unsigned long long seL4_Uint64;
-
-

--- a/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/types.h
+++ b/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/types.h
@@ -22,4 +22,3 @@ typedef struct seL4_UserContext_ {
     /* Thread ID registers */
     seL4_Word tpidrurw, tpidruro;
 } seL4_UserContext;
-

--- a/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/simple_types.h
+++ b/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/simple_types.h
@@ -5,6 +5,7 @@
  */
 
 #pragma once
+
 typedef signed char seL4_Int8;
 typedef signed short seL4_Int16;
 typedef signed int seL4_Int32;
@@ -14,5 +15,3 @@ typedef unsigned char seL4_Uint8;
 typedef unsigned short seL4_Uint16;
 typedef unsigned int seL4_Uint32;
 typedef unsigned long long seL4_Uint64;
-
-

--- a/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/types.h
+++ b/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/types.h
@@ -22,4 +22,3 @@ typedef struct seL4_UserContext_ {
     /* gpRegisters */
     seL4_Word fs_base, gs_base;
 } seL4_UserContext;
-

--- a/libsel4/sel4_arch_include/riscv32/sel4/sel4_arch/simple_types.h
+++ b/libsel4/sel4_arch_include/riscv32/sel4/sel4_arch/simple_types.h
@@ -5,6 +5,6 @@
  */
 
 #pragma once
+
 typedef signed long long seL4_Int64;
 typedef unsigned long long seL4_Uint64;
-

--- a/libsel4/sel4_arch_include/riscv64/sel4/sel4_arch/simple_types.h
+++ b/libsel4/sel4_arch_include/riscv64/sel4/sel4_arch/simple_types.h
@@ -8,5 +8,3 @@
 
 typedef signed long seL4_Int64;
 typedef unsigned long seL4_Uint64;
-
-

--- a/libsel4/sel4_arch_include/riscv64/sel4/sel4_arch/types.h
+++ b/libsel4/sel4_arch_include/riscv64/sel4/sel4_arch/types.h
@@ -11,4 +11,3 @@
 
 #define seL4_WordBits        64
 typedef seL4_Uint64 seL4_Word;
-

--- a/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/simple_types.h
+++ b/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/simple_types.h
@@ -3,7 +3,9 @@
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
+
 #pragma once
+
 typedef signed char seL4_Int8;
 typedef signed short seL4_Int16;
 typedef signed int seL4_Int32;
@@ -13,4 +15,3 @@ typedef unsigned char seL4_Uint8;
 typedef unsigned short seL4_Uint16;
 typedef unsigned int seL4_Uint32;
 typedef unsigned long seL4_Uint64;
-

--- a/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/types.h
+++ b/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/types.h
@@ -25,4 +25,3 @@ typedef struct seL4_UserContext_ {
               r8, r9, r10, r11, r12, r13, r14, r15;
     seL4_Word fs_base, gs_base;
 } seL4_UserContext;
-

--- a/src/plat/allwinnerA20/config.cmake
+++ b/src/plat/allwinnerA20/config.cmake
@@ -14,8 +14,8 @@ if(KernelPlatformAllwinnerA20)
     set(KernelArchArmV7a ON)
     config_set(KernelARMPlatform ARM_PLAT allwinnerA20)
 
-    # MCS is not supported on allwinnerA20.
-    # It requires a timer driver that implements the tickless programming requirements.
+    # MCS is not supported on allwinnerA20. It requires a timer driver that
+    # implements the tickless programming requirements.
     set(KernelPlatformSupportsMCS OFF)
 
     list(APPEND KernelDTSList "tools/dts/allwinnerA20.dts")

--- a/src/plat/apq8064/config.cmake
+++ b/src/plat/apq8064/config.cmake
@@ -11,8 +11,8 @@ declare_platform(apq8064 KernelPlatformAPQ8064 PLAT_APQ8064 KernelSel4ArchAarch3
 if(KernelPlatformAPQ8064)
     declare_seL4_arch(aarch32)
 
-    # MCS is not supported on apq8064.
-    # It requires a timer driver that implements the tickless programming requirements.
+    # MCS is not supported on apq8064. It requires a timer driver that
+    # implements the tickless programming requirements.
     set(KernelPlatformSupportsMCS OFF)
 
     set(KernelArmCortexA15 ON)

--- a/tools/helpers.cmake
+++ b/tools/helpers.cmake
@@ -525,7 +525,7 @@ function(add_config_library prefix configure_template)
             config_header_contents
             "${config_header_contents}"
     )
-    file(GENERATE OUTPUT "${config_file}" CONTENT "${config_header_contents}")
+    file(GENERATE OUTPUT "${config_file}" CONTENT "\n#pragma once\n\n${config_header_contents}")
     add_custom_target(${prefix}_Gen DEPENDS "${config_file}")
     add_library(${prefix}_Config INTERFACE)
     target_include_directories(${prefix}_Config INTERFACE "${config_dir}")

--- a/tools/helpers.cmake
+++ b/tools/helpers.cmake
@@ -544,7 +544,7 @@ endmacro(get_generated_files)
 # This rule tries to emulate an 'autoconf' header. autoconf generated headers
 # were previously used as configuration, so this rule provides a way for previous
 # applications and libraries to build without modification. The config_list
-# is a list of 'prefix' values that have been pssed to add_config_library
+# is a list of 'prefix' values that have been passed to add_config_library
 # This generates a library with ${targetname} that when linked against
 # will allow code to simply #include <autoconf.h>
 function(generate_autoconf targetname config_list)


### PR DESCRIPTION
This avoids warnings that the files are included multiple times. Currently such warnings are shown for:
- camkes-tool/libsel4camkes/gen_config/sel4camkes/gen_config.h
- kernel/gen_config/kernel/gen_config.h
- libsel4/gen_config/sel4/gen_config.h