### PR TITLE
infer_cpu_gic_id now reads cpu id from GICD_TYPER register

### DIFF
--- a/src/arch/arm/machine/gic_v2.c
+++ b/src/arch/arm/machine/gic_v2.c
@@ -37,7 +37,7 @@ volatile struct gic_cpu_iface_map *const gic_cpuiface =
 word_t active_irq[CONFIG_MAX_NUM_NODES] = {IRQ_NONE};
 
 /* The GIC v2 specification tells that the GICD_TYPER register's (gic_dist->ic_type)
- * bits [5:7] have the cpu gic id saved. This can be read on the book 
+ * bits [5:7] have the cpu gic id saved. This can be read on the book
  * 'ARM Generic Interrupt Controller Architecture Specification V2' on page 88 of the PDF.
  */
 BOOT_CODE static uint8_t infer_cpu_gic_id(int nirqs)


### PR DESCRIPTION
Signed-off-by: IkerGalardi <contacto.ikergalardi@gmail.com>

Before, the current cpu gic id was guessed from target registers, but as it can be read in the [documentation](https://developer.arm.com/documentation/ihi0048/b/Programmers--Model/Distributor-register-descriptions/Interrupt-Controller-Type-Register--GICD-TYPER?lang=en), the interrupt controller distributor has a register containing this information. 

Inside the register `GICD_TYPER` (`ic_type` distributor struct) bits [5:7] represent the cpu id. This reimplementation of the function `infer_cpu_gic_id` simply reads that register and returns the information from there.