### PR TITLE
libsel4: Remove weak def of __sel4_ipc_buffer

### DIFF
--- a/libsel4/include/sel4/functions.h
+++ b/libsel4/include/sel4/functions.h
@@ -11,7 +11,6 @@
 #include <sel4/syscalls.h>
 
 extern __thread seL4_IPCBuffer *__sel4_ipc_buffer;
-__thread __attribute__((weak)) seL4_IPCBuffer *__sel4_ipc_buffer;
 
 #ifdef CONFIG_KERNEL_INVOCATION_REPORT_ERROR_IPC
 extern __thread char __sel4_print_error;


### PR DESCRIPTION
This symbol definition leads to an additional thread local storage
allocation for each object file that includes this header file. Then
when the final executable is linked, the weak symbol references are all
replaced by the global symbol declared by libsel4 in sel4_bootinfo.c.
The net result is unnecessarily large thread local storage being
required for each thread.

Signed-off-by: Kent McLeod <kent@kry10.com>