### PR TITLE
Handle read/write of VCPU CPACR register correctly

### DIFF
--- a/src/arch/arm/object/vcpu.c
+++ b/src/arch/arm/object/vcpu.c
@@ -67,6 +67,14 @@ static word_t readVCPUReg(vcpu_t *vcpu, word_t field)
             } else {
                 return vcpu_read_reg(vcpu, field);
             }
+#ifdef CONFIG_HAVE_FPU
+        case seL4_VCPUReg_CPACR:
+            if (ARCH_NODE_STATE(armHSVCPUActive)) {
+                return vcpu_hw_read_reg(field);
+            } else {
+                return vcpu_read_reg(vcpu, field);
+            }
+#endif
         default:
             return vcpu_hw_read_reg(field);
         }
@@ -86,6 +94,15 @@ static void writeVCPUReg(vcpu_t *vcpu, word_t field, word_t value)
                 vcpu_write_reg(vcpu, field, value);
             }
             break;
+#ifdef CONFIG_HAVE_FPU
+        case seL4_VCPUReg_CPACR:
+            if (ARCH_NODE_STATE(armHSVCPUActive)) {
+                vcpu_hw_write_reg(field, value);
+            } else {
+                vcpu_write_reg(vcpu, field, value);
+            }
+            break;
+#endif
         default:
             vcpu_hw_write_reg(field, value);
         }


### PR DESCRIPTION
The CPACR register should not be directly read/written to hardware
unless the VCPU is currently active. CPACR is effectively managed
by the kernel for non-VCPU TCBs, so writing it directly causes
problems. Instead write to (read from) the shadow. It will be
written to hardware register on a context switch.

Note: Logic for reading/writing CPACR register on context switch
is already implemented in vcpu_disable/vcpu_enable functions. This
is just making the direct read/write consistent with that existing
implementation.

See: [SELFOUR-2821]

[SELFOUR-2821]: https://sel4.atlassian.net/browse/SELFOUR-2821