### PR TITLE
Add basic build support for A35 core

### DIFF
--- a/configs/seL4Config.cmake
+++ b/configs/seL4Config.cmake
@@ -168,6 +168,7 @@ foreach(
     KernelArmCortexA8
     KernelArmCortexA9
     KernelArmCortexA15
+    KernelArmCortexA35
     KernelArmCortexA53
     KernelArmCortexA57
     KernelArm1136JF_S
@@ -203,6 +204,7 @@ config_set(KernelArmCortexA7 ARM_CORTEX_A7 "${KernelArmCortexA7}")
 config_set(KernelArmCortexA8 ARM_CORTEX_A8 "${KernelArmCortexA8}")
 config_set(KernelArmCortexA9 ARM_CORTEX_A9 "${KernelArmCortexA9}")
 config_set(KernelArmCortexA15 ARM_CORTEX_A15 "${KernelArmCortexA15}")
+config_set(KernelArmCortexA35 ARM_CORTEX_A35 "${KernelArmCortexA35}")
 config_set(KernelArmCortexA53 ARM_CORTEX_A53 "${KernelArmCortexA53}")
 config_set(KernelArmCortexA57 ARM_CORTEX_A57 "${KernelArmCortexA57}")
 config_set(KernelArm1136JF_S ARM1136JF_S "${KernelArm1136JF_S}")
@@ -233,6 +235,8 @@ elseif(KernelArmCortexA9)
     set(KernelArmCPU "cortex-a9" CACHE INTERNAL "")
 elseif(KernelArmCortexA15)
     set(KernelArmCPU "cortex-a15" CACHE INTERNAL "")
+elseif(KernelArmCortexA35)
+    set(KernelArmCPU "cortex-a35" CACHE INTERNAL "")
 elseif(KernelArmCortexA53)
     set(KernelArmCPU "cortex-a53" CACHE INTERNAL "")
 elseif(KernelArmCortexA57)

--- a/src/arch/arm/config.cmake
+++ b/src/arch/arm/config.cmake
@@ -12,7 +12,10 @@ endif()
 
 set(KernelArmPASizeBits40 OFF)
 set(KernelArmPASizeBits44 OFF)
-if(KernelArmCortexA53)
+if(KernelArmCortexA35)
+    set(KernelArmPASizeBits40 ON)
+    math(EXPR KernelPaddrUserTop "(1 << 40) - 1")
+elseif(KernelArmCortexA53)
     set(KernelArmPASizeBits40 ON)
     math(EXPR KernelPaddrUserTop "(1 << 40) - 1")
 elseif(KernelArmCortexA57)
@@ -77,7 +80,7 @@ config_option(
     KernelArmHypervisorSupport ARM_HYPERVISOR_SUPPORT
     "Build as Hypervisor. Utilise ARM virtualisation extensions to build the kernel as a hypervisor"
     DEFAULT ${default_hyp_support}
-    DEPENDS "KernelArmCortexA15 OR KernelArmCortexA57 OR KernelArmCortexA53"
+    DEPENDS "KernelArmCortexA15 OR KernelArmCortexA35 OR KernelArmCortexA57 OR KernelArmCortexA53"
 )
 
 config_option(
@@ -179,6 +182,7 @@ if(
     KernelArmCortexA7
     OR KernelArmCortexA8
     OR KernelArmCortexA15
+    OR KernelArmCortexA35
     OR KernelArmCortexA53
     OR KernelArmCortexA57
 )


### PR DESCRIPTION
The A35 core is available on some recent ARMv8 SOCs (such as the
NXP i.MX8X family).

This change enables building for the A35, however no platforms
currently target the A35. It is an enabler for future platform
support additions.

Signed-off-by: Ben Leslie <benno@brkawy.com>