### PR TITLE
Add kernel log for debug tracing

### DIFF
--- a/config.cmake
+++ b/config.cmake
@@ -379,6 +379,12 @@ config_option(
     DEPENDS "KernelBenchmarksNone;NOT KernelVerificationBuild"
     DEFAULT_DISABLED OFF
 )
+config_option(
+    KernelDebugLogEntries KERNEL_DEBUG_LOG_ENTRIES "Enable debug logging of entry and exit"
+    DEFAULT ON
+    DEPENDS "KernelDebugLogBuffer"
+    DEFAULT_DISABLED OFF
+)
 
 config_option(
     KernelIRQReporting IRQ_REPORTING

--- a/config.cmake
+++ b/config.cmake
@@ -374,6 +374,13 @@ config_string(
 )
 
 config_option(
+    KernelDebugLogBuffer KERNEL_DEBUG_LOG_BUFFER "Enable debug logging of kernel events"
+    DEFAULT OFF
+    DEPENDS "KernelBenchmarksNone;NOT KernelVerificationBuild"
+    DEFAULT_DISABLED OFF
+)
+
+config_option(
     KernelIRQReporting IRQ_REPORTING
     "seL4 does not properly check for and handle spurious interrupts. This can result \
     in unnecessary output from the kernel during debug builds. If you are CERTAIN these \

--- a/include/arch/arm/arch/benchmark.h
+++ b/include/arch/arm/arch/benchmark.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <config.h>
-#ifdef CONFIG_ENABLE_BENCHMARKS
+#if defined(CONFIG_ENABLE_BENCHMARKS) || defined(CONFIG_KERNEL_DEBUG_LOG_ENTRIES)
 
 #include <armv/benchmark.h>
 #include <mode/machine.h>

--- a/include/arch/arm/armv/armv6/armv/benchmark.h
+++ b/include/arch/arm/armv/armv6/armv/benchmark.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <config.h>
-#ifdef CONFIG_ENABLE_BENCHMARKS
+#if defined(CONFIG_ENABLE_BENCHMARKS) || defined(CONFIG_KERNEL_DEBUG_LOG_ENTRIES)
 
 #define CCNT "p15, 0, %0, c15, c12, 1"
 #define PMCR "p15, 0, %0, c15, c12, 0"

--- a/include/arch/arm/armv/armv7-a/armv/benchmark.h
+++ b/include/arch/arm/armv/armv7-a/armv/benchmark.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#ifdef CONFIG_ENABLE_BENCHMARKS
+#if defined(CONFIG_ENABLE_BENCHMARKS) || defined(CONFIG_KERNEL_DEBUG_LOG_ENTRIES)
 #include <config.h>
 
 #define PMCR "p15, 0, %0, c9, c12, 0"

--- a/include/arch/arm/armv/armv8-a/64/armv/benchmark.h
+++ b/include/arch/arm/armv/armv8-a/64/armv/benchmark.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <config.h>
-#ifdef CONFIG_ENABLE_BENCHMARKS
+#if defined(CONFIG_ENABLE_BENCHMARKS) || defined(CONFIG_KERNEL_DEBUG_LOG_ENTRIES)
 
 #define CCNT "PMCCNTR_EL0"
 #define PMCR "PMCR_EL0"

--- a/include/arch/riscv/arch/benchmark.h
+++ b/include/arch/riscv/arch/benchmark.h
@@ -11,7 +11,7 @@
 #include <arch/object/structures.h>
 #include <mode/hardware.h>
 
-#ifdef CONFIG_ENABLE_BENCHMARKS
+#if defined(CONFIG_ENABLE_BENCHMARKS) || defined(CONFIG_KERNEL_DEBUG_LOG_ENTRIES)
 static inline timestamp_t timestamp(void)
 {
     return riscv_read_cycle();

--- a/include/arch/x86/arch/benchmark.h
+++ b/include/arch/x86/arch/benchmark.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <config.h>
-#ifdef CONFIG_ENABLE_BENCHMARKS
+#if defined(CONFIG_ENABLE_BENCHMARKS) || defined(CONFIG_KERNEL_DEBUG_LOG_ENTRIES)
 
 static inline uint64_t timestamp(void)
 {

--- a/include/benchmark/benchmark_track.h
+++ b/include/benchmark/benchmark_track.h
@@ -18,7 +18,7 @@
 #if defined(CONFIG_DEBUG_BUILD) || defined(CONFIG_BENCHMARK_TRACK_KERNEL_ENTRIES)
 #define TRACK_KERNEL_ENTRIES 1
 extern kernel_entry_t ksKernelEntry;
-#ifdef CONFIG_BENCHMARK_TRACK_KERNEL_ENTRIES
+#if defined(CONFIG_BENCHMARK_TRACK_KERNEL_ENTRIES) || defined(CONFIG_KERNEL_DEBUG_LOG_ENTRIES)
 /**
  *  Calculate the maximum number of kernel entries that can be tracked,
  *  limited by the log buffer size. This is also the number of ksLog entries.

--- a/include/kernel/traps.h
+++ b/include/kernel/traps.h
@@ -10,6 +10,7 @@
 #include <util.h>
 #include <arch/kernel/traps.h>
 #include <smp/lock.h>
+#include <log.h>
 
 /* This C function should be the first thing called from C after entry from
  * assembly. It provides a single place to do any entry work that is not
@@ -20,6 +21,8 @@ static inline void c_entry_hook(void)
 #if defined(CONFIG_BENCHMARK_TRACK_KERNEL_ENTRIES) || defined(CONFIG_BENCHMARK_TRACK_UTILISATION)
     ksEnter = timestamp();
 #endif
+
+    debugLog(Entry);
 }
 
 /* This C function should be the last thing called from C before exiting
@@ -40,6 +43,8 @@ static inline void c_exit_hook(void)
         NODE_STATE(benchmark_kernel_time) += exit - ksEnter;
     }
 #endif /* CONFIG_BENCHMARK_TRACK_UTILISATION */
+
+    debugLog(Exit);
 
     arch_c_exit_hook();
 }

--- a/include/log.h
+++ b/include/log.h
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#pragma once
+
+#include <config.h>
+
+#ifdef CONFIG_KERNEL_DEBUG_LOG_BUFFER
+#include <sel4/log.h>
+#include <basic_types.h>
+
+/* The global logbuffer reference used by the kernel */
+extern seL4_LogBuffer ksLogBuffer;
+extern bool_t ksLogEnabled;
+
+/* Reset the log buffer to start logging at the beginning */
+static inline void logBuffer_reset(void)
+{
+    if (ksLogBuffer.buffer != NULL) {
+        ksLogBuffer.index = 0;
+        ksLogEnabled = true;
+    }
+}
+
+/* Initialise the kernel log buffer with a new memory region */
+static inline void logBuffer_init(seL4_Word *buffer, seL4_Word words)
+{
+    ksLogBuffer = seL4_LogBuffer_new(buffer);
+    seL4_LogBuffer_setSize(&ksLogBuffer, words);
+    logBuffer_reset();
+}
+
+/* Finalise the log buffer and ensure no further events will be written. */
+static inline word_t logBuffer_finalize(void)
+{
+    ksLogEnabled = false;
+    return ksLogBuffer.index;
+}
+
+/* Clear the log buffer if buffer matches the given address */
+static inline void logBuffer_maybeClear(seL4_Word *base_addr)
+{
+    if (ksLogBuffer.buffer == base_addr) {
+        logBuffer_reset();
+        logBuffer_finalize();
+        ksLogBuffer.buffer = NULL;
+    }
+}
+
+/* Get a reference to an event of a given size to next be written to a log */
+static inline seL4_LogEvent *logBuffer_reserveGeneric(seL4_Word type)
+{
+    word_t length = seL4_LogType_length(type);
+    assert(length >= seL4_Log_Length(None));
+    word_t remaining = ksLogBuffer.size - ksLogBuffer.index;
+    if (ksLogEnabled && remaining >= length) {
+        /* Get a reference to the event and initialise */
+        seL4_LogEvent *event = seL4_LogBuffer_event(ksLogBuffer, ksLogBuffer.index);
+
+        /* Event lengths are recorded as one less */
+        event->type = type;
+
+        /* Advance the log to the next location */
+        ksLogBuffer.index += length;
+
+        return event;
+    } else {
+        /* Insufficient space in log buffer so finalise */
+        logBuffer_finalize();
+        return NULL;
+    }
+}
+
+/* Reserve an event in the buffer for a specific event type */
+#define logBuffer_reserve(event) \
+    (seL4_Log_Cast(event)(logBuffer_reserveGeneric( \
+        seL4_Log_TypeId(event) \
+    )))\
+
+/*
+ * Definition of log events
+ * ========================
+ *
+ * Each log even must have a log function declared below.
+ *
+ * The data structures used to describe the events within the log buffer
+ * are defined in libsel4/include/sel4/log.h
+ */
+
+/* Get the function name used to log an event */
+#define debugLog_Function(event) seL4_Log_Function_ ## event
+
+/* Log a particular event to the kernel log buffer */
+#define debugLog(event, ...) debugLog_Function(event)(__VA_ARGS__)
+
+/* Log a particular event if a condition holds */
+#define debugLogIf(event, cond, ...) if (cond) debugLog(event, __VA_ARGS__)
+
+/* Log an empty event */
+static inline void debugLog_Function(None)(void)
+{
+    logBuffer_reserve(None);
+}
+
+#else /* CONFIG_KERNEL_DEBUG_LOG_BUFFER */
+/* With logging disabled, any logging functions become no-ops */
+#define debugLog(...)
+#define debugLogIf(...)
+#define ksLogEnabled false
+#endif /* !CONFIG_KERNEL_DEBUG_LOG_BUFFER */

--- a/include/log.h
+++ b/include/log.h
@@ -11,6 +11,9 @@
 #ifdef CONFIG_KERNEL_DEBUG_LOG_BUFFER
 #include <sel4/log.h>
 #include <basic_types.h>
+#include <arch/benchmark.h>
+#include <model/statedata.h>
+#include <arch/model/smp.h>
 
 /* The global logbuffer reference used by the kernel */
 extern seL4_LogBuffer ksLogBuffer;
@@ -103,6 +106,30 @@ static inline seL4_LogEvent *logBuffer_reserveGeneric(seL4_Word type)
 static inline void debugLog_Function(None)(void)
 {
     logBuffer_reserve(None);
+}
+
+/* Log a kernel entry */
+static inline void debugLog_Function(Entry)(void)
+{
+#ifdef CONFIG_KERNEL_DEBUG_LOG_ENTRIES
+    seL4_Log_Type(Entry) *event = logBuffer_reserve(Entry);
+    if (event != NULL) {
+        event->header.data = CURRENT_CPU_INDEX();
+        event->timestamp = timestamp();
+    }
+#endif
+}
+
+/* Log a kernel exit */
+static inline void debugLog_Function(Exit)(void)
+{
+#ifdef CONFIG_KERNEL_DEBUG_LOG_ENTRIES
+    seL4_Log_Type(Exit) *event = logBuffer_reserve(Exit);
+    if (event != NULL) {
+        event->header.data = CURRENT_CPU_INDEX();
+        event->timestamp = timestamp();
+    }
+#endif
 }
 
 #else /* CONFIG_KERNEL_DEBUG_LOG_BUFFER */

--- a/libsel4/arch_include/arm/sel4/arch/syscalls.h
+++ b/libsel4/arch_include/arm/sel4/arch/syscalls.h
@@ -660,7 +660,7 @@ LIBSEL4_INLINE_FUNC void seL4_DebugRun(void (* userfn)(void *), void *userarg)
 }
 #endif
 
-#ifdef CONFIG_ENABLE_BENCHMARKS
+#if defined(CONFIG_ENABLE_BENCHMARKS) || defined(CONFIG_KERNEL_DEBUG_LOG_BUFFER)
 /* set the log index back to 0 */
 LIBSEL4_INLINE_FUNC seL4_Error seL4_BenchmarkResetLog(void)
 {
@@ -703,7 +703,9 @@ LIBSEL4_INLINE_FUNC seL4_Error seL4_BenchmarkSetLogBuffer(seL4_Word frame_cptr)
 
     return (seL4_Error) frame_cptr;
 }
+#endif
 
+#ifdef CONFIG_ENABLE_BENCHMARKS
 LIBSEL4_INLINE_FUNC void seL4_BenchmarkNullSyscall(void)
 {
     arm_sys_null(seL4_SysBenchmarkNullSyscall);

--- a/libsel4/arch_include/riscv/sel4/arch/syscalls.h
+++ b/libsel4/arch_include/riscv/sel4/arch/syscalls.h
@@ -861,7 +861,7 @@ LIBSEL4_INLINE_FUNC void seL4_DebugRun(void (* userfn)(void *), void *userarg)
 }
 #endif
 
-#ifdef CONFIG_ENABLE_BENCHMARKS
+#if defined(CONFIG_ENABLE_BENCHMARKS) || defined(CONFIG_KERNEL_DEBUG_LOG_BUFFER)
 /* set the log index back to 0 */
 LIBSEL4_INLINE_FUNC seL4_Error seL4_BenchmarkResetLog(void)
 {
@@ -905,7 +905,9 @@ LIBSEL4_INLINE_FUNC seL4_Error seL4_BenchmarkSetLogBuffer(seL4_Word frame_cptr)
 
     return (seL4_Error) frame_cptr;
 }
+#endif
 
+#ifdef CONFIG_ENABLE_BENCHMARKS
 LIBSEL4_INLINE_FUNC void seL4_BenchmarkNullSyscall(void)
 {
     riscv_sys_null(seL4_SysBenchmarkNullSyscall);

--- a/libsel4/include/api/syscall.xml
+++ b/libsel4/include/api/syscall.xml
@@ -55,10 +55,12 @@
         </config>
         <config condition="defined CONFIG_ENABLE_BENCHMARKS">
             <syscall name="BenchmarkFlushCaches" />
+            <syscall name="BenchmarkNullSyscall"  />
+        </config>
+        <config condition="defined CONFIG_ENABLE_BENCHMARKS || defined CONFIG_KERNEL_DEBUG_LOG_BUFFER">
             <syscall name="BenchmarkResetLog" />
             <syscall name="BenchmarkFinalizeLog"  />
             <syscall name="BenchmarkSetLogBuffer"  />
-            <syscall name="BenchmarkNullSyscall"  />
         </config>
         <config condition="defined CONFIG_BENCHMARK_TRACK_UTILISATION">
             <syscall name="BenchmarkGetThreadUtilisation"  />

--- a/libsel4/include/sel4/config.h
+++ b/libsel4/include/sel4/config.h
@@ -106,6 +106,7 @@
 
 /* Configurations requring the kernel log buffer */
 #if defined CONFIG_BENCHMARK_TRACK_KERNEL_ENTRIES || \
-    defined CONFIG_BENCHMARK_TRACEPOINTS
+    defined CONFIG_BENCHMARK_TRACEPOINTS || \
+    defined CONFIG_KERNEL_DEBUG_LOG_BUFFER
 #define CONFIG_KERNEL_LOG_BUFFER
 #endif

--- a/libsel4/include/sel4/log.h
+++ b/libsel4/include/sel4/log.h
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <sel4/simple_types.h>
+#include <sel4/constants.h>
+#include <sel4/sel4_arch/constants.h>
+#include <sel4/benchmark_track_types.h>
+
+/*
+ * Log event implementation
+ * ========================
+ *
+ * Each event is a sequence of words in the log buffer. The first word
+ * of an event is the seL4_LogEvent which describes the length in words
+ * of the event and the event type. There is also an additional
+ * component to the seL4_LogEvent with use dependend on the event type.
+ *
+ * For an event of type t, there will be an event identifier
+ * seL4_Log_TypeId(t), and a struct representing the event
+ * seL4_Log_Type(t).
+ *
+ * The event can be logged from within the kernel using
+ * seL4_Log(t)(event_args...). seL4_Log expressions are automatically
+ * removed if logging is disabled.
+ */
+
+/* The event header word which appears at the start of every event */
+typedef struct {
+    /* Type of event logged */
+    seL4_Word type: 8;
+    /* The remaining 24 or 56 bits of the header word can be used for
+     * the event itself */
+#if seL4_WordSizeBits == 2
+    seL4_Word data: 24;
+#elif seL4_WordSizeBits == 3
+    seL4_Word data: 56;
+#else
+#error "Unsupported word seL4_WordSizeBits"
+#endif
+} seL4_LogEvent;
+
+/* The name of the type identifier for a given log event type */
+#define seL4_Log_TypeId(event) seL4_Log_TypeId_ ## event
+
+/* The name of the stuct type for a given log event type */
+#define seL4_Log_Type(event) seL4_Log_Struct_ ## event
+
+/* Cast a log event to a particular log type */
+#define seL4_Log_Cast(event) (seL4_Log_Type(event) *)
+
+/* Get the length of an event structure as a number of words */
+#define seL4_Log_Length(event) (((sizeof(seL4_Log_Type(event)) - 1ul) >> seL4_WordSizeBits) + 1ul)
+
+/*
+ * Definition of log events
+ * ========================
+ *
+ * Each log event must have a type identifier in the enum below, a
+ * struct describing the layout of the message (with the first field
+ * being the seL4_LogEvent).
+ *
+ * The functions used to log the events within the kernel are defined in
+ * seL4/include/log.h
+ */
+
+/* Event type identifiers */
+enum {
+    seL4_Log_TypeId(None),
+    seL4_NumLogTypeIds,
+};
+
+/* Log an empty event */
+typedef struct {
+    seL4_LogEvent header;
+} seL4_Log_Type(None);
+
+/*
+ * Reading information from log events
+ * ===================================
+ *
+ * These functions can be used at user-level to inspect events from the
+ * log buffer.
+ */
+
+/* Get the length of an event type */
+static inline seL4_Word seL4_LogType_length(seL4_Word type)
+{
+    static seL4_Word type_lengths[seL4_NumLogTypeIds] = {
+        [seL4_Log_TypeId(None)] = seL4_Log_Length(None),
+    };
+
+    if (type >= seL4_NumLogTypeIds) {
+        return 0;
+    } else {
+        return type_lengths[type];
+    }
+}
+
+/* Get the type of an event */
+static inline seL4_Word seL4_LogEvent_type(seL4_LogEvent *event)
+{
+    if (event == seL4_Null) {
+        return seL4_Log_TypeId(None);
+    } else {
+        return event->type;
+    }
+}
+
+/* Get the length of an event */
+static inline seL4_Word seL4_LogEvent_length(seL4_LogEvent *event)
+{
+    if (event == seL4_Null) {
+        return 0;
+    } else {
+        return seL4_LogType_length(seL4_LogEvent_type(event));
+    }
+}
+
+/*
+ * Managing user-level log buffer references
+ * =========================================
+ *
+ * These functions are used to create references to the log buffer at
+ * user-level and iterate through the events in the buffer.
+ *
+ * The log buffer is a shared array of seL4_Word in memory. The first
+ * word tracks the number of words in the array used for events and the
+ * second word is the index that the next event will be written to. All
+ * subsequent words then form the series of events.
+ */
+
+/* A log buffer reference */
+typedef struct {
+    seL4_Word *volatile buffer;
+    seL4_Word index;
+    /* The kernel uses this to track the size of the memory region but
+     * user-level uses this to track how much of the buffer was actually
+     * used by the kernel. */
+    seL4_Word size;
+} seL4_LogBuffer;
+
+/* Create a new log buffer reference */
+static inline seL4_LogBuffer seL4_LogBuffer_new(void *buffer)
+{
+    return (seL4_LogBuffer) {
+        .buffer = buffer,
+        .index = 0,
+        .size = 0,
+    };
+}
+
+/* Set the size of the log buffer */
+static inline void seL4_LogBuffer_setSize(seL4_LogBuffer *buffer, seL4_Word words)
+{
+    buffer->size = words;
+}
+
+/* Reset a log buffer for new logging */
+static inline void seL4_LogBuffer_reset(seL4_LogBuffer *buffer)
+{
+    buffer->size = 0;
+    buffer->index = 0;
+}
+
+/* Get an event at a particular index in the buffer */
+static inline seL4_LogEvent *seL4_LogBuffer_event(seL4_LogBuffer buffer, seL4_Word index)
+{
+    return (seL4_LogEvent *)(&buffer.buffer[index]);
+}
+
+/* Get the next event in the log buffer. */
+static inline seL4_LogEvent *seL4_LogBuffer_next(seL4_LogBuffer *buffer)
+{
+    if (buffer == seL4_Null || buffer->buffer == seL4_Null || buffer->index >= buffer->size) {
+        return seL4_Null;
+    } else {
+        seL4_LogEvent *event = seL4_LogBuffer_event(*buffer, buffer->index);
+        buffer->index += seL4_LogEvent_length(event);
+        return event;
+    }
+}

--- a/libsel4/include/sel4/log.h
+++ b/libsel4/include/sel4/log.h
@@ -71,6 +71,8 @@ typedef struct {
 /* Event type identifiers */
 enum {
     seL4_Log_TypeId(None),
+    seL4_Log_TypeId(Entry),
+    seL4_Log_TypeId(Exit),
     seL4_NumLogTypeIds,
 };
 
@@ -78,6 +80,22 @@ enum {
 typedef struct {
     seL4_LogEvent header;
 } seL4_Log_Type(None);
+
+/* Entry into kernel */
+typedef struct {
+    /* Header data contains core ID */
+    seL4_LogEvent header;
+    /* Timestamp from cycle counter */
+    seL4_Uint64 timestamp;
+} seL4_Log_Type(Entry);
+
+/* Exit from kernel */
+typedef struct {
+    /* Header data contains core ID */
+    seL4_LogEvent header;
+    /* Timestamp from cycle counter */
+    seL4_Uint64 timestamp;
+} seL4_Log_Type(Exit);
 
 /*
  * Reading information from log events
@@ -92,6 +110,8 @@ static inline seL4_Word seL4_LogType_length(seL4_Word type)
 {
     static seL4_Word type_lengths[seL4_NumLogTypeIds] = {
         [seL4_Log_TypeId(None)] = seL4_Log_Length(None),
+        [seL4_Log_TypeId(Entry)] = seL4_Log_Length(Entry),
+        [seL4_Log_TypeId(Exit)] = seL4_Log_Length(Exit),
     };
 
     if (type >= seL4_NumLogTypeIds) {

--- a/libsel4/include/sel4/syscalls.h
+++ b/libsel4/include/sel4/syscalls.h
@@ -173,7 +173,7 @@ seL4_DebugRun(void (* userfn)(void *), void *userarg);
  *
  * @{
  */
-#ifdef CONFIG_ENABLE_BENCHMARKS
+#if defined(CONFIG_ENABLE_BENCHMARKS) || defined(CONFIG_KERNEL_DEBUG_LOG_BUFFER)
 /*
   */
 
@@ -223,7 +223,9 @@ seL4_BenchmarkFinalizeLog(void);
  */
 LIBSEL4_INLINE_FUNC seL4_Error
 seL4_BenchmarkSetLogBuffer(seL4_Word frame_cptr);
+#endif
 
+#ifdef CONFIG_ENABLE_BENCHMARKS
 /**
  * @xmlonly <manual name="Null Syscall" label="sel4_benchmarknullsyscall"/> @endxmlonly
  * @brief Null system call that enters and exits the kernel immediately, for timing kernel traps in microbenchmarks.

--- a/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/constants.h
@@ -243,7 +243,9 @@ SEL4_SIZE_SANITY(seL4_PGDEntryBits, seL4_PGDIndexBits, seL4_PGDBits);
 #define seL4_MinUntypedBits 4
 #define seL4_MaxUntypedBits 29
 
-#ifdef CONFIG_ENABLE_BENCHMARKS
+#if defined(CONFIG_ENABLE_BENCHMARKS) || defined(CONFIG_KERNEL_DEBUG_LOG_BUFFER)
+/* Size of log buffer frame in bits */
+#define seL4_LogBufferBits seL4_SectionBits
 /* size of kernel log buffer in bytes */
 #define seL4_LogBufferSize (LIBSEL4_BIT(20))
 #endif /* CONFIG_ENABLE_BENCHMARKS */

--- a/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
@@ -243,7 +243,9 @@ SEL4_SIZE_SANITY(seL4_PGDEntryBits, seL4_PGDIndexBits, seL4_PGDBits);
 SEL4_SIZE_SANITY(seL4_PUDEntryBits, seL4_PUDIndexBits, seL4_PUDBits);
 #endif
 
-#ifdef CONFIG_ENABLE_BENCHMARKS
+#if defined(CONFIG_ENABLE_BENCHMARKS) || defined(CONFIG_KERNEL_DEBUG_LOG_BUFFER)
+/* Size of log buffer frame in bits */
+#define seL4_LogBufferBits seL4_LargePageBits
 /* size of kernel log buffer in bytes */
 #define seL4_LogBufferSize (LIBSEL4_BIT(20))
 #endif /* CONFIG_ENABLE_BENCHMARKS */

--- a/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/constants.h
@@ -65,7 +65,9 @@ SEL4_SIZE_SANITY(seL4_WordSizeBits, seL4_ASIDPoolIndexBits, seL4_ASIDPoolBits);
 #define seL4_MinUntypedBits 4
 #define seL4_MaxUntypedBits 29
 
-#ifdef CONFIG_ENABLE_BENCHMARKS
+#if defined(CONFIG_ENABLE_BENCHMARKS) || defined(CONFIG_KERNEL_DEBUG_LOG_BUFFER)
+/* Size of log buffer frame in bits */
+#define seL4_LogBufferBits seL4_LargePageBits
 /* size of kernel log buffer in bytes */
 #define seL4_LogBufferSize (LIBSEL4_BIT(20))
 #endif /* CONFIG_ENABLE_BENCHMARKS */

--- a/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/syscalls.h
+++ b/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/syscalls.h
@@ -910,7 +910,7 @@ LIBSEL4_INLINE_FUNC seL4_Uint64 seL4_X86DangerousRDMSR(seL4_Word msr)
 }
 #endif
 
-#ifdef CONFIG_ENABLE_BENCHMARKS
+#if defined(CONFIG_ENABLE_BENCHMARKS) || defined(CONFIG_KERNEL_DEBUG_LOG_BUFFER)
 LIBSEL4_INLINE_FUNC seL4_Error seL4_BenchmarkResetLog(void)
 {
     seL4_Word unused0 = 0;
@@ -945,8 +945,9 @@ LIBSEL4_INLINE_FUNC seL4_Error seL4_BenchmarkSetLogBuffer(seL4_Word frame_cptr)
 
     return (seL4_Error) frame_cptr;
 }
+#endif
 
-
+#ifdef CONFIG_ENABLE_BENCHMARKS
 LIBSEL4_INLINE_FUNC void seL4_BenchmarkNullSyscall(void)
 {
     x86_sys_null(seL4_SysBenchmarkNullSyscall);

--- a/libsel4/sel4_arch_include/riscv32/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/riscv32/sel4/sel4_arch/constants.h
@@ -124,7 +124,9 @@ typedef enum {
 /* First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0x80000000lu
 
-#ifdef CONFIG_ENABLE_BENCHMARKS
+#if defined(CONFIG_ENABLE_BENCHMARKS) || defined(CONFIG_KERNEL_DEBUG_LOG_BUFFER)
+/* Size of log buffer frame in bits */
+#define seL4_LogBufferBits seL4_LargePageBits
 /* size of kernel log buffer in bytes */
 #define seL4_LogBufferSize (LIBSEL4_BIT(20))
 #endif /* CONFIG_ENABLE_BENCHMARKS */

--- a/libsel4/sel4_arch_include/riscv64/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/riscv64/sel4/sel4_arch/constants.h
@@ -129,7 +129,9 @@ typedef enum {
 /* First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0x0000003ffffff000
 
-#ifdef CONFIG_ENABLE_BENCHMARKS
+#if defined(CONFIG_ENABLE_BENCHMARKS) || defined(CONFIG_KERNEL_DEBUG_LOG_BUFFER)
+/* Size of log buffer frame in bits */
+#define seL4_LogBufferBits seL4_LargePageBits
 /* size of kernel log buffer in bytes */
 #define seL4_LogBufferSize (LIBSEL4_BIT(20))
 #endif /* CONFIG_ENABLE_BENCHMARKS */

--- a/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/constants.h
@@ -63,6 +63,13 @@
 #define seL4_MinUntypedBits 4
 #define seL4_MaxUntypedBits 47
 
+#if defined(CONFIG_ENABLE_BENCHMARKS) || defined(CONFIG_KERNEL_DEBUG_LOG_BUFFER)
+/* Size of log buffer frame in bits */
+#define seL4_LogBufferBits seL4_LargePageBits
+/* size of kernel log buffer in bytes */
+#define seL4_LogBufferSize (LIBSEL4_BIT(20))
+#endif /* CONFIG_ENABLE_BENCHMARKS */
+
 #ifndef __ASSEMBLER__
 
 SEL4_SIZE_SANITY(seL4_PageTableEntryBits, seL4_PageTableIndexBits, seL4_PageTableBits);

--- a/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/syscalls.h
+++ b/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/syscalls.h
@@ -683,7 +683,7 @@ LIBSEL4_INLINE_FUNC void seL4_DebugRun(void (*userfn)(void *), void *userarg)
 }
 #endif
 
-#if CONFIG_ENABLE_BENCHMARKS
+#if defined(CONFIG_ENABLE_BENCHMARKS) || defined(CONFIG_KERNEL_DEBUG_LOG_BUFFER)
 LIBSEL4_INLINE_FUNC seL4_Error seL4_BenchmarkResetLog(void)
 {
     seL4_Word unused0 = 0;
@@ -725,7 +725,9 @@ LIBSEL4_INLINE_FUNC seL4_Error seL4_BenchmarkSetLogBuffer(seL4_Word frame_cptr)
 
     return (seL4_Error) frame_cptr;
 }
+#endif
 
+#if CONFIG_ENABLE_BENCHMARKS
 LIBSEL4_INLINE_FUNC void seL4_BenchmarkNullSyscall(void)
 {
     x64_sys_null(seL4_SysBenchmarkNullSyscall);

--- a/src/api/syscall.c
+++ b/src/api/syscall.c
@@ -188,20 +188,8 @@ exception_t handleUnknownSyscall(word_t w)
     }
 #endif
 
-#ifdef CONFIG_ENABLE_BENCHMARKS
-    if (w == SysBenchmarkFlushCaches) {
-#ifdef CONFIG_ARCH_ARM
-        tcb_t *thread = NODE_STATE(ksCurThread);
-        if (getRegister(thread, capRegister)) {
-            arch_clean_invalidate_L1_caches(getRegister(thread, msgInfoRegister));
-        } else {
-            arch_clean_invalidate_caches();
-        }
-#else
-        arch_clean_invalidate_caches();
-#endif
-        return EXCEPTION_NONE;
-    } else if (w == SysBenchmarkResetLog) {
+#if defined(CONFIG_ENABLE_BENCHMARKS) || defined(CONFIG_KERNEL_LOG_BUFFER)
+    if (w == SysBenchmarkResetLog) {
 #ifdef CONFIG_KERNEL_LOG_BUFFER
         if (ksUserLogBuffer == 0) {
             userError("A user-level buffer has to be set before resetting benchmark.\
@@ -248,7 +236,22 @@ exception_t handleUnknownSyscall(word_t w)
         return EXCEPTION_NONE;
 #endif /* CONFIG_KERNEL_LOG_BUFFER */
     }
+#endif /* defined(CONFIG_ENABLE_BENCHMARKS) || defined(CONFIG_KERNEL_LOG_BUFFER) */
 
+#ifdef CONFIG_ENABLE_BENCHMARKS
+    if (w == SysBenchmarkFlushCaches) {
+#ifdef CONFIG_ARCH_ARM
+        tcb_t *thread = NODE_STATE(ksCurThread);
+        if (getRegister(thread, capRegister)) {
+            arch_clean_invalidate_L1_caches(getRegister(thread, msgInfoRegister));
+        } else {
+            arch_clean_invalidate_caches();
+        }
+#else
+        arch_clean_invalidate_caches();
+#endif
+        return EXCEPTION_NONE;
+    }
 #ifdef CONFIG_BENCHMARK_TRACK_UTILISATION
     else if (w == SysBenchmarkGetThreadUtilisation) {
         benchmark_track_utilisation_dump();

--- a/src/api/syscall.c
+++ b/src/api/syscall.c
@@ -24,6 +24,7 @@
 #include <string.h>
 #include <kernel/traps.h>
 #include <arch/machine.h>
+#include <log.h>
 
 #ifdef CONFIG_DEBUG_BUILD
 #include <arch/machine/capdl.h>
@@ -197,8 +198,12 @@ exception_t handleUnknownSyscall(word_t w)
             setRegister(NODE_STATE(ksCurThread), capRegister, seL4_IllegalOperation);
             return EXCEPTION_SYSCALL_ERROR;
         }
-
+#ifdef CONFIG_KERNEL_DEBUG_LOG_BUFFER
+        logBuffer_reset();
+#else
         ksLogIndex = 0;
+#endif /* CONFIG_KERNEL_DEBUG_LOG_BUFFER */
+
 #endif /* CONFIG_KERNEL_LOG_BUFFER */
 #ifdef CONFIG_BENCHMARK_TRACK_UTILISATION
         NODE_STATE(benchmark_log_utilisation_enabled) = true;
@@ -216,8 +221,12 @@ exception_t handleUnknownSyscall(word_t w)
         return EXCEPTION_NONE;
     } else if (w == SysBenchmarkFinalizeLog) {
 #ifdef CONFIG_KERNEL_LOG_BUFFER
+#ifdef CONFIG_KERNEL_DEBUG_LOG_BUFFER
+        setRegister(NODE_STATE(ksCurThread), capRegister, logBuffer_finalize());
+#else /* CONFIG_KERNEL_DEBUG_LOG_BUFFER */
         ksLogIndexFinalized = ksLogIndex;
         setRegister(NODE_STATE(ksCurThread), capRegister, ksLogIndexFinalized);
+#endif /* !CONFIG_KERNEL_DEBUG_LOG_BUFFER */
 #endif /* CONFIG_KERNEL_LOG_BUFFER */
 #ifdef CONFIG_BENCHMARK_TRACK_UTILISATION
         benchmark_utilisation_finalise();

--- a/src/arch/arm/32/kernel/vspace.c
+++ b/src/arch/arm/32/kernel/vspace.c
@@ -26,6 +26,7 @@
 #include <arch/object/iospace.h>
 #include <arch/object/vcpu.h>
 #include <arch/machine/tlb.h>
+#include <log.h>
 
 #ifdef CONFIG_BENCHMARK_TRACK_KERNEL_ENTRIES
 #include <benchmark/benchmark_track.h>
@@ -2773,6 +2774,10 @@ exception_t benchmark_arch_map_logBuffer(word_t frame_cptr)
         cleanByVA_PoU((vptr_t)&armKSGlobalLogPT[idx], pptr_to_paddr(&armKSGlobalLogPT[idx]));
         invalidateTranslationSingle(KS_LOG_PPTR + (idx * BIT(seL4_PageBits)));
     }
+
+#ifdef CONFIG_KERNEL_DEBUG_LOG_BUFFER
+    logBuffer_init((seL4_Word *)KS_LOG_PPTR, BIT(pageBitsForSize(frameSize) - seL4_WordSizeBits));
+#endif /* !CONFIG_KERNEL_DEBUG_LOG_BUFFER */
 
     return EXCEPTION_NONE;
 }

--- a/src/arch/arm/64/kernel/vspace.c
+++ b/src/arch/arm/64/kernel/vspace.c
@@ -26,6 +26,7 @@
 #include <arch/object/iospace.h>
 #include <arch/object/vcpu.h>
 #include <arch/machine/tlb.h>
+#include <log.h>
 #define RESERVED 3
 
 /*
@@ -2578,6 +2579,11 @@ exception_t benchmark_arch_map_logBuffer(word_t frame_cptr)
 
     cleanByVA_PoU((vptr_t)armKSGlobalLogPDE, pptr_to_paddr(armKSGlobalLogPDE));
     invalidateTranslationSingle(KS_LOG_PPTR);
+
+#ifdef CONFIG_KERNEL_DEBUG_LOG_BUFFER
+    logBuffer_init((seL4_Word *)KS_LOG_PPTR, BIT(pageBitsForSize(frameSize) - seL4_WordSizeBits));
+#endif /* !CONFIG_KERNEL_DEBUG_LOG_BUFFER */
+
     return EXCEPTION_NONE;
 }
 #endif /* CONFIG_KERNEL_LOG_BUFFER */

--- a/src/arch/arm/benchmark/benchmark.c
+++ b/src/arch/arm/benchmark/benchmark.c
@@ -19,7 +19,7 @@ seL4_Word ksLogIndexFinalized = 0;
 UP_STATE_DEFINE(uint64_t, ccnt_num_overflows);
 #endif /* CONFIG_ARM_ENABLE_PMU_OVERFLOW_INTERRUPT */
 
-#ifdef CONFIG_ENABLE_BENCHMARKS
+#if defined(CONFIG_ENABLE_BENCHMARKS) || defined(CONFIG_KERNEL_DEBUG_LOG_ENTRIES)
 void arm_init_ccnt(void)
 {
 

--- a/src/arch/arm/kernel/boot.c
+++ b/src/arch/arm/kernel/boot.c
@@ -222,7 +222,7 @@ BOOT_CODE static bool_t init_cpu(void)
 
     cpu_initLocalIRQController();
 
-#ifdef CONFIG_ENABLE_BENCHMARKS
+#if defined(CONFIG_ENABLE_BENCHMARKS) || defined(CONFIG_KERNEL_DEBUG_LOG_ENTRIES)
     arm_init_ccnt();
 #endif /* CONFIG_ENABLE_BENCHMARKS */
 

--- a/src/arch/riscv/kernel/vspace.c
+++ b/src/arch/riscv/kernel/vspace.c
@@ -1229,6 +1229,10 @@ exception_t benchmark_arch_map_logBuffer(word_t frame_cptr)
 
     sfence();
 
+#ifdef CONFIG_KERNEL_DEBUG_LOG_BUFFER
+    logBuffer_init((seL4_Word *)KS_LOG_PPTR, BIT(pageBitsForSize(frameSize) - seL4_WordSizeBits));
+#endif /* !CONFIG_KERNEL_DEBUG_LOG_BUFFER */
+
     return EXCEPTION_NONE;
 }
 #endif /* CONFIG_KERNEL_LOG_BUFFER */

--- a/src/arch/x86/32/kernel/vspace.c
+++ b/src/arch/x86/32/kernel/vspace.c
@@ -16,6 +16,7 @@
 #include <benchmark/benchmark_track.h>
 #include <arch/kernel/tlb_bitmap.h>
 #include <mode/kernel/tlb.h>
+#include <log.h>
 
 /* 'gdt_idt_ptr' is declared globally because of a C-subset restriction.
  * It is only used in init_drts(), which therefore is non-reentrant.
@@ -714,6 +715,10 @@ exception_t benchmark_arch_map_logBuffer(word_t frame_cptr)
         ia32KSGlobalLogPT[idx] = pte;
         invalidateTLBEntry(KS_LOG_PPTR + (idx << seL4_PageBits), MASK(ksNumCPUs));
     }
+
+#ifdef CONFIG_KERNEL_DEBUG_LOG_BUFFER
+    logBuffer_init((seL4_Word *)KS_LOG_PPTR, BIT(pageBitsForSize(frameSize) - seL4_WordSizeBits));
+#endif /* !CONFIG_KERNEL_DEBUG_LOG_BUFFER */
 
     return EXCEPTION_NONE;
 }

--- a/src/arch/x86/64/kernel/vspace.c
+++ b/src/arch/x86/64/kernel/vspace.c
@@ -16,6 +16,7 @@
 #include <mode/kernel/tlb.h>
 #include <arch/kernel/tlb_bitmap.h>
 #include <object/structures.h>
+#include <log.h>
 
 /* When using the SKIM window to isolate the kernel from the user we also need to
  * not use global mappings as having global mappings and entries in the TLB is
@@ -1679,6 +1680,10 @@ exception_t benchmark_arch_map_logBuffer(word_t frame_cptr)
     x64KSKernelPDs[BIT(PDPT_INDEX_BITS) - 1][1] = pde;
 #endif
     invalidateTranslationAll(MASK(CONFIG_MAX_NUM_NODES));
+
+#ifdef CONFIG_KERNEL_DEBUG_LOG_BUFFER
+    logBuffer_init((seL4_Word *)KS_LOG_PPTR, BIT(pageBitsForSize(frameSize) - seL4_WordSizeBits));
+#endif /* !CONFIG_KERNEL_DEBUG_LOG_BUFFER */
 
     return EXCEPTION_NONE;
 }

--- a/src/model/statedata.c
+++ b/src/model/statedata.c
@@ -13,6 +13,7 @@
 #include <object/structures.h>
 #include <object/tcb.h>
 #include <benchmark/benchmark_track.h>
+#include <log.h>
 
 /* Collective cpu states, including both pre core architecture dependant and independent data */
 SMP_STATE_DEFINE(smpStatedata_t, ksSMP[CONFIG_MAX_NUM_NODES] ALIGN(L1_CACHE_LINE_SIZE));
@@ -110,4 +111,8 @@ kernel_entry_t ksKernelEntry;
 
 #ifdef CONFIG_KERNEL_LOG_BUFFER
 paddr_t ksUserLogBuffer;
+#ifdef CONFIG_KERNEL_DEBUG_LOG_BUFFER
+seL4_LogBuffer ksLogBuffer;
+bool_t ksLogEnabled;
+#endif /* CONFIG_KERNEL_DEBUG_LOG_BUFFER */
 #endif /* CONFIG_KERNEL_LOG_BUFFER */


### PR DESCRIPTION
This extends the existing benchmarking log and logging API for debugging purposes. It provides a general set of tools for describing and logging kernel events of varying size to a memory frame visible at user-level.

The intent for this PR is to enable new logging events to be added to trace kernel behavior in debugging situations in a manner that allows multiple different kinds of events to be traced together and to make it easy to add log events to the kernel source while debugging it without having to fully determine a new messaging format each time.

Rather than adding a new log buffer and a new set of syscalls, this PR adds a kernel configuration option that allows the benchmark log buffer to be enabled and configured in non-benchmark debug configurations and a messaging format with variable-length messages to the logs.

The nature of the messaging format prohibits existing messaging formats in the log buffer from being used at the same time, so this PR also implements a set of entry tracking messages that can be used along with any other added messages in the newer message format.

Much like the existing log message formats, the new format with messages of varying size only ever requires the kernel to write to the log region itself and always writes in a linear fashion through the log region so should demonstrate similar minimal use of the cache, although the number of cache lines accessed for each message write may be greater due to the lack of cache-line alignment on messages.

The impact of the new message format on system performance has not been checked and so logging in performance-sensitive cases should continue to use the existing benchmark logging APIs. It may well be that this new log format has sufficiently low overhead that it replaces the existing log buffer message formats, although removing those formats should be considered in a separate PR.

This change does not resolve the existing issues of the kernel log buffer for SMP configurations whereby all cores access the same log buffer region and the same global internal kernel state for tracking the kernel's write position in the buffer. The easiest solution for that problem would be to maintain a distinct cursor for each core and to divide the region into a set of smaller per-core logs. It would then require user-level to reset each core's log separately by some change to the syscall API. This fix is out of scope of this PR but could be implemented and proposed in a separate PR.

A complimenting set of tools will be added to seL4_utils for managing and exporting the log-buffer at user-level for offline analysis. seL4/seL4_libs#25 demonstrates how this would be used at user level.