### PR TITLE
Remove HAVE_AUTOCONF guard in sel4/config.h

### DIFF
--- a/libsel4/include/sel4/config.h
+++ b/libsel4/include/sel4/config.h
@@ -8,9 +8,7 @@
 
 /* Compile-time configuration parameters. Might be set by the build system. */
 
-#ifdef HAVE_AUTOCONF
 #include <autoconf.h>
-#endif
 
 /* size of the initial thread's root CNode (2^x slots, x >= 4) */
 #ifndef CONFIG_ROOT_CNODE_SIZE_BITS


### PR DESCRIPTION
This option was legacy from when autoconf.h wasn't always present in the
include path. Now it causes incorrect configuration options.

Signed-off-by: Kent McLeod <kent@kry10.com>