### PR TITLE
libsel4: define printf format specifier SEL4_PRI_word

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -7,4 +7,3 @@
 #pragma once
 
 #include <sel4/config.h>
-

--- a/libsel4/arch_include/arm/sel4/arch/objecttype.h
+++ b/libsel4/arch_include/arm/sel4/arch/objecttype.h
@@ -6,9 +6,7 @@
 
 #pragma once
 
-#ifdef HAVE_AUTOCONF
 #include <autoconf.h>
-#endif /* HAVE_AUTOCONF */
 
 typedef enum _object {
     seL4_ARM_SmallPageObject = seL4_ModeObjectTypeCount,

--- a/libsel4/arch_include/arm/sel4/arch/objecttype.h
+++ b/libsel4/arch_include/arm/sel4/arch/objecttype.h
@@ -37,5 +37,3 @@ typedef seL4_Word object_t;
 #ifndef CONFIG_TK1_SMMU
 #define seL4_ARM_IOPageTableObject 0xffff
 #endif
-
-

--- a/libsel4/arch_include/arm/sel4/arch/simple_types.h
+++ b/libsel4/arch_include/arm/sel4/arch/simple_types.h
@@ -7,11 +7,3 @@
 #pragma once
 
 #include <sel4/sel4_arch/simple_types.h>
-
-typedef signed char seL4_Int8;
-typedef signed short seL4_Int16;
-typedef signed int seL4_Int32;
-
-typedef unsigned char seL4_Uint8;
-typedef unsigned short seL4_Uint16;
-typedef unsigned int seL4_Uint32;

--- a/libsel4/arch_include/arm/sel4/arch/types.h
+++ b/libsel4/arch_include/arm/sel4/arch/types.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <sel4/macros.h>
 #include <sel4/simple_types.h>
 #include <sel4/sel4_arch/types.h>
 

--- a/libsel4/arch_include/riscv/sel4/arch/objecttype.h
+++ b/libsel4/arch_include/riscv/sel4/arch/objecttype.h
@@ -7,9 +7,7 @@
 
 #pragma once
 
-#ifdef HAVE_AUTOCONF
 #include <autoconf.h>
-#endif /* HAVE_AUTOCONF */
 
 typedef enum _object {
     seL4_RISCV_4K_Page = seL4_ModeObjectTypeCount,

--- a/libsel4/arch_include/riscv/sel4/arch/objecttype.h
+++ b/libsel4/arch_include/riscv/sel4/arch/objecttype.h
@@ -19,5 +19,3 @@ typedef enum _object {
 } seL4_ArchObjectType;
 
 typedef seL4_Word object_t;
-
-

--- a/libsel4/arch_include/riscv/sel4/arch/simple_types.h
+++ b/libsel4/arch_include/riscv/sel4/arch/simple_types.h
@@ -6,10 +6,4 @@
 
 #pragma once
 
-typedef signed char seL4_Int8;
-typedef signed short seL4_Int16;
-typedef signed int seL4_Int32;
-
-typedef unsigned char seL4_Uint8;
-typedef unsigned short seL4_Uint16;
-typedef unsigned int seL4_Uint32;
+#include <sel4/sel4_arch/simple_types.h>

--- a/libsel4/arch_include/riscv/sel4/arch/types.h
+++ b/libsel4/arch_include/riscv/sel4/arch/types.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <autoconf.h>
+#include <sel4/macros.h>
 #include <sel4/simple_types.h>
 #include <sel4/sel4_arch/types.h>
 

--- a/libsel4/arch_include/x86/sel4/arch/objecttype.h
+++ b/libsel4/arch_include/x86/sel4/arch/objecttype.h
@@ -40,4 +40,3 @@ typedef seL4_Word object_t;
 #define seL4_X86_EPTPDObject 0xfffffb
 #define seL4_X86_EPTPTObject 0xfffffa
 #endif
-

--- a/libsel4/arch_include/x86/sel4/arch/objecttype.h
+++ b/libsel4/arch_include/x86/sel4/arch/objecttype.h
@@ -6,9 +6,7 @@
 
 #pragma once
 
-#ifdef HAVE_AUTOCONF
 #include <autoconf.h>
-#endif /* HAVE_AUTOCONF */
 
 typedef enum _object {
     seL4_X86_4K = seL4_ModeObjectTypeCount,

--- a/libsel4/arch_include/x86/sel4/arch/simple_types.h
+++ b/libsel4/arch_include/x86/sel4/arch/simple_types.h
@@ -4,3 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#pragma once
+
+#include <sel4/sel4_arch/simple_types.h>

--- a/libsel4/arch_include/x86/sel4/arch/types.h
+++ b/libsel4/arch_include/x86/sel4/arch/types.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <autoconf.h>
+#include <sel4/macros.h>
 #include <sel4/simple_types.h>
 #include <sel4/sel4_arch/types.h>
 

--- a/libsel4/include/sel4/benchmark_tracepoints_types.h
+++ b/libsel4/include/sel4/benchmark_tracepoints_types.h
@@ -6,9 +6,7 @@
 
 #pragma once
 
-#ifdef HAVE_AUTOCONF
 #include <autoconf.h>
-#endif
 
 #ifdef CONFIG_BENCHMARK_TRACEPOINTS
 typedef struct benchmark_tracepoint_log_entry {

--- a/libsel4/include/sel4/benchmark_tracepoints_types.h
+++ b/libsel4/include/sel4/benchmark_tracepoints_types.h
@@ -16,4 +16,3 @@ typedef struct benchmark_tracepoint_log_entry {
     seL4_Word  duration;
 } benchmark_tracepoint_log_entry_t;
 #endif /* CONFIG_BENCHMARK_TRACEPOINTS */
-

--- a/libsel4/include/sel4/benchmark_track_types.h
+++ b/libsel4/include/sel4/benchmark_track_types.h
@@ -6,11 +6,8 @@
 
 #pragma once
 
-#include <stdint.h>
-
-#ifdef HAVE_AUTOCONF
 #include <autoconf.h>
-#endif
+#include <stdint.h>
 
 #if (defined CONFIG_BENCHMARK_TRACK_KERNEL_ENTRIES || defined CONFIG_DEBUG_BUILD)
 

--- a/libsel4/include/sel4/benchmark_track_types.h
+++ b/libsel4/include/sel4/benchmark_track_types.h
@@ -65,4 +65,3 @@ typedef struct benchmark_syscall_log_entry {
 } benchmark_track_kernel_entry_t;
 
 #endif /* CONFIG_BENCHMARK_TRACK_KERNEL_ENTRIES || CONFIG_DEBUG_BUILD */
-

--- a/libsel4/include/sel4/benchmark_utilisation_types.h
+++ b/libsel4/include/sel4/benchmark_utilisation_types.h
@@ -45,4 +45,3 @@ enum benchmark_track_util_ipc_index {
 };
 
 #endif /* CONFIG_BENCHMARK_TRACK_UTILISATION */
-

--- a/libsel4/include/sel4/benchmark_utilisation_types.h
+++ b/libsel4/include/sel4/benchmark_utilisation_types.h
@@ -6,9 +6,7 @@
 
 #pragma once
 
-#ifdef HAVE_AUTOCONF
 #include <autoconf.h>
-#endif
 
 #ifdef CONFIG_BENCHMARK_TRACK_UTILISATION
 enum benchmark_track_util_ipc_index {

--- a/libsel4/include/sel4/bootinfo_types.h
+++ b/libsel4/include/sel4/bootinfo_types.h
@@ -6,9 +6,7 @@
 
 #pragma once
 
-#ifdef HAVE_AUTOCONF
 #include <autoconf.h>
-#endif
 
 /* caps with fixed slot positions in the root CNode */
 enum {

--- a/libsel4/include/sel4/bootinfo_types.h
+++ b/libsel4/include/sel4/bootinfo_types.h
@@ -11,7 +11,6 @@
 #endif
 
 /* caps with fixed slot positions in the root CNode */
-
 enum {
     seL4_CapNull                =  0, /* null cap */
     seL4_CapInitThreadTCB       =  1, /* initial thread's TCB cap */
@@ -97,4 +96,3 @@ typedef struct seL4_BootInfoHeader {
 #define SEL4_BOOTINFO_HEADER_X86_TSC_FREQ 5 // frequency is in mhz
 #define SEL4_BOOTINFO_HEADER_FDT 6
 #define SEL4_BOOTINFO_HEADER_NUM SEL4_BOOTINFO_HEADER_FDT + 1
-

--- a/libsel4/include/sel4/constants.h
+++ b/libsel4/include/sel4/constants.h
@@ -10,7 +10,6 @@
 #include <sel4/macros.h>
 
 #ifndef __ASSEMBLER__
-#define LIBSEL4_BIT(n) (1ul<<(n))
 
 #ifdef CONFIG_HARDWARE_DEBUG_API
 /* API arg values for breakpoint API, "type" arguments. */

--- a/libsel4/include/sel4/constants.h
+++ b/libsel4/include/sel4/constants.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <autoconf.h>
+#include <sel4/macros.h>
 
 #ifndef __ASSEMBLER__
 #define LIBSEL4_BIT(n) (1ul<<(n))

--- a/libsel4/include/sel4/constants.h
+++ b/libsel4/include/sel4/constants.h
@@ -6,9 +6,7 @@
 
 #pragma once
 
-#ifdef HAVE_AUTOCONF
 #include <autoconf.h>
-#endif
 
 #ifndef __ASSEMBLER__
 #define LIBSEL4_BIT(n) (1ul<<(n))

--- a/libsel4/include/sel4/macros.h
+++ b/libsel4/include/sel4/macros.h
@@ -8,43 +8,57 @@
 
 #include <autoconf.h>
 
+#ifndef CONST
+#define CONST   __attribute__((__const__))
+#endif
+
+#ifndef PURE
+#define PURE    __attribute__((__pure__))
+#endif
+
+#define SEL4_PACKED             __attribute__((packed))
+#define SEL4_DEPRECATED(x)      __attribute__((deprecated(x)))
+#define SEL4_DEPRECATE_MACRO(x) _Pragma("deprecated") x
+
+#define LIBSEL4_UNUSED          __attribute__((unused))
+#define LIBSEL4_WEAK            __attribute__((weak))
+#define LIBSEL4_NOINLINE        __attribute__((noinline))
+
+
+#ifdef CONFIG_LIB_SEL4_INLINE_INVOCATIONS
+
+#define LIBSEL4_INLINE          static inline
+#define LIBSEL4_INLINE_FUNC     static inline
+
+#elif defined(CONFIG_LIB_SEL4_PUBLIC_SYMBOLS)
+
+#define LIBSEL4_INLINE          LIBSEL4_UNUSED LIBSEL4_WEAK
+#define LIBSEL4_INLINE_FUNC     LIBSEL4_UNUSED LIBSEL4_WEAK
+
+#else
+
+#define LIBSEL4_INLINE          LIBSEL4_NOINLINE LIBSEL4_UNUSED LIBSEL4_WEAK
+#define LIBSEL4_INLINE_FUNC     static inline
+
+#endif
+
+
+#define SEL4_COMPILE_ASSERT(name, expr) \
+    typedef int __assert_failed_##name[(expr) ? 1 : -1];
+
+#define SEL4_SIZE_SANITY(index, entry, size) \
+    SEL4_COMPILE_ASSERT(index##entry##size, index + entry == size)
+
+
+#define SEL4_OFFSETOF(type, member) __builtin_offsetof(type, member)
+
+
 /*
  * Some compilers attempt to pack enums into the smallest possible type.
  * For ABI compatibility with the kernel, we need to ensure they remain
  * the same size as a 'long'.
  */
 #define SEL4_FORCE_LONG_ENUM(type) \
-        _enum_pad_ ## type = (1ULL << ((sizeof(long)*8) - 1)) - 1
+    _enum_pad_ ## type = ((1ULL << ((sizeof(long)*8) - 1)) - 1)
 
-#ifndef CONST
-#define CONST        __attribute__((__const__))
-#endif
-
-#ifndef PURE
-#define PURE         __attribute__((__pure__))
-#endif
-
-#define SEL4_OFFSETOF(type, member) __builtin_offsetof(type, member)
-
-#define SEL4_PACKED __attribute__((packed))
-
-#ifdef CONFIG_LIB_SEL4_INLINE_INVOCATIONS
-#define LIBSEL4_INLINE static inline
-#define LIBSEL4_INLINE_FUNC static inline
-
-#elif defined(CONFIG_LIB_SEL4_PUBLIC_SYMBOLS)
-#define LIBSEL4_INLINE __attribute__((unused)) __attribute__((weak))
-#define LIBSEL4_INLINE_FUNC __attribute__((unused)) __attribute__((weak))
-
-#else
-#define LIBSEL4_INLINE __attribute__((noinline)) __attribute__((unused)) __attribute__((weak))
-#define LIBSEL4_INLINE_FUNC static inline
-#endif
-
-#define LIBSEL4_UNUSED __attribute__((unused))
-
-#define SEL4_DEPRECATED(x) __attribute__((deprecated(x)))
-#define SEL4_DEPRECATE_MACRO(x) _Pragma("deprecated") x
-
-#define SEL4_COMPILE_ASSERT(name, expr) typedef int __assert_failed_##name[(expr) ? 1 : -1];
-#define SEL4_SIZE_SANITY(index, entry, size) SEL4_COMPILE_ASSERT(index##entry##size, index + entry == size)
+#define LIBSEL4_BIT(n)  (1ul<<(n))

--- a/libsel4/include/sel4/macros.h
+++ b/libsel4/include/sel4/macros.h
@@ -43,8 +43,13 @@
 #endif
 
 
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
+#define SEL4_COMPILE_ASSERT(name, expr)   _Static_assert(expr, #name);
+#else
 #define SEL4_COMPILE_ASSERT(name, expr) \
     typedef int __assert_failed_##name[(expr) ? 1 : -1];
+#endif
+
 
 #define SEL4_SIZE_SANITY(index, entry, size) \
     SEL4_COMPILE_ASSERT(index##entry##size, index + entry == size)

--- a/libsel4/include/sel4/simple_types.h
+++ b/libsel4/include/sel4/simple_types.h
@@ -105,3 +105,14 @@ typedef seL4_Uint64 seL4_Word;
 #else
 #error missing definition for SEL4_WORD type
 #endif
+
+/* sanity check that the seL4_Word matches the definitions of the constants */
+#include <sel4/sel4_arch/constants.h>
+
+SEL4_COMPILE_ASSERT(
+    seL4_WordSizeBits_matches,
+    sizeof(seL4_Word) == (1u << seL4_WordSizeBits))
+
+SEL4_COMPILE_ASSERT(
+    seL4_WordBits_matches,
+    8 * sizeof(seL4_Word) == seL4_WordBits)

--- a/libsel4/include/sel4/simple_types.h
+++ b/libsel4/include/sel4/simple_types.h
@@ -6,18 +6,102 @@
 
 #pragma once
 
-/* Get the architectural types seL4_{u}int{N} */
+#include <sel4/macros.h>
+
+/*
+ * Data   | short | int | long | long | void*  | notes
+ * model  |       |     |      | long | size_t |
+ * -------+-------+-----+------+------+--------+----------------
+ * IP16   | 16    | 16  | 32   | 64   | 16     | MS-DOS SMALL memory model
+ * LP32   | 16    | 16  | 32   | 64   | 32     | MS-DOS LARGE memory model
+ * ILP32  | 16    | 32  | 32   | 64   | 32     | common for a 32-bit OS
+ * LLP64  | 16    | 32  | 32   | 64   | 64     | 64-bit Windows, VC++, MinGW
+ * LP64   | 16    | 32  | 64   | 64   | 64     | most 64-bit Unix systems
+ * ILP64  | 16    | 64  | 64   | 64   | 64     | SPARC64, Solaris
+ * SILP64 | 64    | 64  | 64   | 64   | 64     | UNICOS
+ *
+ * libsel4 requires ILP32 on 32-bit systems and and LP64 on 64-bit systems
+ */
+
+/* Get the architectural definitions and types */
 #include <sel4/arch/simple_types.h>
-#include <sel4/sel4_arch/simple_types.h>
+
+#define seL4_integer_size_assert(_type_, _size_) \
+    SEL4_COMPILE_ASSERT( \
+        sizeof_##_type_##_is_##_size_##_byte, \
+        sizeof(_type_) == _size_ )
+
+
+/* C99 defines that this is at least 8-bit */
+#define _seL4_int8_type             char
+typedef signed _seL4_int8_type      seL4_Int8;
+typedef unsigned _seL4_int8_type    seL4_Uint8;
+
+seL4_integer_size_assert(seL4_Int8, 1)
+seL4_integer_size_assert(seL4_Uint8, 1)
+
+
+/* C99 defines that a 'short int' is at least 16 bits. Note that 'short' is
+ * no basic C type, but only a type modifier. If nothing else is given, the
+ * default type is 'int' and thus it is often omitted.
+ */
+#define _seL4_int16_type            short int
+typedef signed _seL4_int16_type     seL4_Int16;
+typedef unsigned _seL4_int16_type   seL4_Uint16;
+
+seL4_integer_size_assert(seL4_Int16, 2)
+seL4_integer_size_assert(seL4_Uint16, 2)
+
+
+/* C99 does not define that an 'int' is 32-bit, it just has to be no smaller
+ * than a 'short int'. We require ILP32 on 32-bit systems and and LP64 on 64-bit
+ * systems, so 'int' is 32-bits. */
+#define _seL4_int32_type            int
+typedef signed _seL4_int32_type     seL4_Int32;
+typedef unsigned _seL4_int32_type   seL4_Uint32;
+
+seL4_integer_size_assert(seL4_Int32, 4)
+seL4_integer_size_assert(seL4_Uint32, 4)
+
+
+/* There is no standard 64-bit type in C, so the architecture specific headers
+ * must define what to use. C99 just defines that 'long' is at least 32 bits and
+ * 'long long' at least 64-bit. Note that neither 'long' nor 'long long' are
+ * basic C types, they are only type modifiers. If nothing else is given, the
+ * default base type is 'int' and thus it is often omitted.
+ */
+#if defined(SEL4_INT64_IS_LONG)
+#define _seL4_int64_type    long int
+#elif defined(SEL4_INT64_IS_LONG_LONG)
+#define _seL4_int64_type    long long int
+#else
+#error missing definition for 64-bit types
+#endif
+
+typedef signed _seL4_int64_type     seL4_Int64;
+typedef unsigned _seL4_int64_type   seL4_Uint64;
+
+seL4_integer_size_assert(seL4_Int64, 8)
+seL4_integer_size_assert(seL4_Uint64, 8)
+
 
 /* Define boolean type and true/false */
-#define seL4_True 1
-#define seL4_False 0
-typedef seL4_Int8 seL4_Bool;
+#define seL4_True   1
+#define seL4_False  0
+typedef seL4_Int8   seL4_Bool;
 
 /* Define seL4_Null */
 #ifdef __cplusplus
-#define seL4_Null 0L
+#define seL4_Null   0L
 #else
-#define seL4_Null ((void*)0)
+#define seL4_Null   ((void*)0)
 #endif // __cplusplus
+
+/* Define seL4_Word */
+#if defined(SEL4_WORD_IS_UINT32)
+typedef seL4_Uint32 seL4_Word;
+#elif defined(SEL4_WORD_IS_UINT64)
+typedef seL4_Uint64 seL4_Word;
+#else
+#error missing definition for SEL4_WORD type
+#endif

--- a/libsel4/include/sel4/simple_types.h
+++ b/libsel4/include/sel4/simple_types.h
@@ -72,8 +72,10 @@ seL4_integer_size_assert(seL4_Uint32, 4)
  */
 #if defined(SEL4_INT64_IS_LONG)
 #define _seL4_int64_type    long int
+#define _seL4_int64_fmt     l  // printf() formatting, integer suffix
 #elif defined(SEL4_INT64_IS_LONG_LONG)
 #define _seL4_int64_type    long long int
+#define _seL4_int64_fmt     ll  // printf() formatting, integer suffix
 #else
 #error missing definition for 64-bit types
 #endif
@@ -81,9 +83,18 @@ seL4_integer_size_assert(seL4_Uint32, 4)
 typedef signed _seL4_int64_type     seL4_Int64;
 typedef unsigned _seL4_int64_type   seL4_Uint64;
 
-seL4_integer_size_assert(seL4_Int64, 8)
-seL4_integer_size_assert(seL4_Uint64, 8)
+/* Define printf() format specifiers for seL4_Int64 and seL4_Uint64. The helper
+ * macros ensure these format strings are atoms. The macros passed are evaluated
+ * before the concatenation and stringizing happens.
+ */
+#define _macro_str_concat_helper2(x)    #x
+#define _macro_str_concat_helper1(x,y)  _macro_str_concat_helper2(x ## y)
+#define _macro_str_concat(x,y)          _macro_str_concat_helper1(x,y)
 
+#define SEL4_PRId64     _macro_str_concat(_seL4_int64_fmt, d)
+#define SEL4_PRIi64     _macro_str_concat(_seL4_int64_fmt, i)
+#define SEL4_PRIu64     _macro_str_concat(_seL4_int64_fmt, u)
+#define SEL4_PRIx64     _macro_str_concat(_seL4_int64_fmt, x)
 
 /* Define boolean type and true/false */
 #define seL4_True   1
@@ -100,8 +111,10 @@ typedef seL4_Int8   seL4_Bool;
 /* Define seL4_Word */
 #if defined(SEL4_WORD_IS_UINT32)
 typedef seL4_Uint32 seL4_Word;
+#define SEL4_PRI_word   "u" // seL4_Word printf format specifier
 #elif defined(SEL4_WORD_IS_UINT64)
 typedef seL4_Uint64 seL4_Word;
+#define SEL4_PRI_word   SEL4_PRIu64 // seL4_Word printf format specifier
 #else
 #error missing definition for SEL4_WORD type
 #endif

--- a/libsel4/include/sel4/types.h
+++ b/libsel4/include/sel4/types.h
@@ -6,9 +6,7 @@
 
 #pragma once
 
-#ifdef HAVE_AUTOCONF
 #include <autoconf.h>
-#endif
 #include <sel4/simple_types.h>
 #include <sel4/macros.h>
 #include <sel4/arch/types.h>

--- a/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/constants.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <autoconf.h>
+#include <sel4/macros.h>
 
 #ifndef __ASSEMBLER__
 #ifdef CONFIG_KERNEL_GLOBALS_FRAME

--- a/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/constants.h
@@ -258,4 +258,3 @@ SEL4_SIZE_SANITY(seL4_PGDEntryBits, seL4_PGDIndexBits, seL4_PGDBits);
 
 /* IPC buffer is 512 bytes, giving size bits of 9 */
 #define seL4_IPCBufferSizeBits 9
-

--- a/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/constants.h
@@ -6,9 +6,7 @@
 
 #pragma once
 
-#ifdef HAVE_AUTOCONF
 #include <autoconf.h>
-#endif
 
 #ifndef __ASSEMBLER__
 #ifdef CONFIG_KERNEL_GLOBALS_FRAME

--- a/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/mapping.h
+++ b/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/mapping.h
@@ -22,4 +22,3 @@ LIBSEL4_INLINE_FUNC seL4_Word seL4_MappingFailedLookupLevel(void)
 {
     return seL4_GetMR(SEL4_MAPPING_LOOKUP_LEVEL);
 }
-

--- a/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/mapping.h
+++ b/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/mapping.h
@@ -6,9 +6,7 @@
 
 #pragma once
 
-#ifdef HAVE_AUTOCONF
 #include <autoconf.h>
-#endif
 
 #define SEL4_MAPPING_LOOKUP_LEVEL 2
 

--- a/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/simple_types.h
+++ b/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/simple_types.h
@@ -6,6 +6,5 @@
 
 #pragma once
 
-typedef signed long long seL4_Int64;
-
-typedef unsigned long long seL4_Uint64;
+#define SEL4_WORD_IS_UINT32
+#define SEL4_INT64_IS_LONG_LONG

--- a/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/types.h
+++ b/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/types.h
@@ -8,7 +8,6 @@
 
 #include <sel4/simple_types.h>
 
-typedef seL4_Uint32 seL4_Word;
 typedef seL4_Word seL4_CPtr;
 typedef seL4_Word seL4_NodeId;
 typedef seL4_Word seL4_PAddr;

--- a/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <autoconf.h>
+#include <sel4/macros.h>
 
 #ifndef __ASSEMBLER__
 /* format of an unknown syscall message */

--- a/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
@@ -6,9 +6,7 @@
 
 #pragma once
 
-#ifdef HAVE_AUTOCONF
 #include <autoconf.h>
-#endif
 
 #ifndef __ASSEMBLER__
 /* format of an unknown syscall message */

--- a/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/simple_types.h
+++ b/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/simple_types.h
@@ -6,6 +6,5 @@
 
 #pragma once
 
-typedef signed long seL4_Int64;
-
-typedef unsigned long seL4_Uint64;
+#define SEL4_WORD_IS_UINT64
+#define SEL4_INT64_IS_LONG

--- a/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/types.h
+++ b/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/types.h
@@ -8,7 +8,6 @@
 
 #include <sel4/simple_types.h>
 
-typedef seL4_Uint64 seL4_Word;
 typedef seL4_Word seL4_CPtr;
 typedef seL4_Word seL4_NodeId;
 typedef seL4_Word seL4_PAddr;

--- a/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/constants.h
@@ -6,9 +6,7 @@
 
 #pragma once
 
-#ifdef HAVE_AUTOCONF
 #include <autoconf.h>
-#endif
 
 #define TLS_GDT_ENTRY 6
 #define TLS_GDT_SELECTOR ((TLS_GDT_ENTRY << 3) | 3)

--- a/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/constants.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <autoconf.h>
+#include <sel4/macros.h>
 
 #define TLS_GDT_ENTRY 6
 #define TLS_GDT_SELECTOR ((TLS_GDT_ENTRY << 3) | 3)

--- a/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/objecttype.h
+++ b/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/objecttype.h
@@ -6,9 +6,7 @@
 
 #pragma once
 
-#ifdef HAVE_AUTOCONF
 #include <autoconf.h>
-#endif /* HAVE_AUTOCONF */
 
 typedef enum _mode_object {
     seL4_ModeObjectTypeCount = seL4_NonArchObjectTypeCount,

--- a/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/objecttype.h
+++ b/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/objecttype.h
@@ -15,4 +15,3 @@ typedef enum _mode_object {
 } seL4_ModeObjectType;
 
 #define seL4_IA32_PDPTObject 0xffffffff
-

--- a/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/simple_types.h
+++ b/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/simple_types.h
@@ -6,12 +6,5 @@
 
 #pragma once
 
-typedef signed char seL4_Int8;
-typedef signed short seL4_Int16;
-typedef signed int seL4_Int32;
-typedef signed long long seL4_Int64;
-
-typedef unsigned char seL4_Uint8;
-typedef unsigned short seL4_Uint16;
-typedef unsigned int seL4_Uint32;
-typedef unsigned long long seL4_Uint64;
+#define SEL4_WORD_IS_UINT32
+#define SEL4_INT64_IS_LONG_LONG

--- a/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/types.h
+++ b/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/types.h
@@ -7,8 +7,8 @@
 #pragma once
 
 #include <autoconf.h>
+#include <sel4/simple_types.h>
 
-typedef seL4_Uint32 seL4_Word;
 typedef seL4_Word seL4_NodeId;
 typedef seL4_Word seL4_PAddr;
 typedef seL4_Word seL4_Domain;

--- a/libsel4/sel4_arch_include/riscv32/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/riscv32/sel4/sel4_arch/constants.h
@@ -7,9 +7,7 @@
 
 #pragma once
 
-#ifdef HAVE_AUTOCONF
 #include <autoconf.h>
-#endif
 
 #define seL4_WordBits           32
 /* log 2 bits in a word */

--- a/libsel4/sel4_arch_include/riscv32/sel4/sel4_arch/objecttype.h
+++ b/libsel4/sel4_arch_include/riscv32/sel4/sel4_arch/objecttype.h
@@ -6,9 +6,7 @@
 
 #pragma once
 
-#ifdef HAVE_AUTOCONF
 #include <autoconf.h>
-#endif /* HAVE_AUTOCONF */
 
 typedef enum _mode_object {
     seL4_ModeObjectTypeCount = seL4_NonArchObjectTypeCount

--- a/libsel4/sel4_arch_include/riscv32/sel4/sel4_arch/objecttype.h
+++ b/libsel4/sel4_arch_include/riscv32/sel4/sel4_arch/objecttype.h
@@ -13,4 +13,3 @@
 typedef enum _mode_object {
     seL4_ModeObjectTypeCount = seL4_NonArchObjectTypeCount
 } seL4_ModeObjectType;
-

--- a/libsel4/sel4_arch_include/riscv32/sel4/sel4_arch/simple_types.h
+++ b/libsel4/sel4_arch_include/riscv32/sel4/sel4_arch/simple_types.h
@@ -6,5 +6,5 @@
 
 #pragma once
 
-typedef signed long long seL4_Int64;
-typedef unsigned long long seL4_Uint64;
+#define SEL4_WORD_IS_UINT32
+#define SEL4_INT64_IS_LONG_LONG

--- a/libsel4/sel4_arch_include/riscv32/sel4/sel4_arch/types.h
+++ b/libsel4/sel4_arch_include/riscv32/sel4/sel4_arch/types.h
@@ -9,6 +9,3 @@
 
 #include <autoconf.h>
 #include <sel4/simple_types.h>
-
-#define seL4_WordBits        32
-typedef seL4_Uint32 seL4_Word;

--- a/libsel4/sel4_arch_include/riscv64/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/riscv64/sel4/sel4_arch/constants.h
@@ -7,9 +7,7 @@
 
 #pragma once
 
-#ifdef HAVE_AUTOCONF
 #include <autoconf.h>
-#endif
 
 #define seL4_WordBits           64
 /* log 2 bits in a word */

--- a/libsel4/sel4_arch_include/riscv64/sel4/sel4_arch/objecttype.h
+++ b/libsel4/sel4_arch_include/riscv64/sel4/sel4_arch/objecttype.h
@@ -22,4 +22,3 @@ typedef enum _mode_object {
 #if CONFIG_PT_LEVELS <= 3
 #define seL4_RISCV_Tera_Page 0xffffffff
 #endif
-

--- a/libsel4/sel4_arch_include/riscv64/sel4/sel4_arch/objecttype.h
+++ b/libsel4/sel4_arch_include/riscv64/sel4/sel4_arch/objecttype.h
@@ -7,9 +7,7 @@
 
 #pragma once
 
-#ifdef HAVE_AUTOCONF
 #include <autoconf.h>
-#endif /* HAVE_AUTOCONF */
 
 typedef enum _mode_object {
     seL4_RISCV_Giga_Page = seL4_NonArchObjectTypeCount,

--- a/libsel4/sel4_arch_include/riscv64/sel4/sel4_arch/simple_types.h
+++ b/libsel4/sel4_arch_include/riscv64/sel4/sel4_arch/simple_types.h
@@ -6,5 +6,5 @@
 
 #pragma once
 
-typedef signed long seL4_Int64;
-typedef unsigned long seL4_Uint64;
+#define SEL4_WORD_IS_UINT64
+#define SEL4_INT64_IS_LONG

--- a/libsel4/sel4_arch_include/riscv64/sel4/sel4_arch/types.h
+++ b/libsel4/sel4_arch_include/riscv64/sel4/sel4_arch/types.h
@@ -8,6 +8,3 @@
 
 #include <autoconf.h>
 #include <sel4/simple_types.h>
-
-#define seL4_WordBits        64
-typedef seL4_Uint64 seL4_Word;

--- a/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/constants.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <autoconf.h>
+#include <sel4/macros.h>
 
 #define TLS_GDT_ENTRY   7
 #define TLS_GDT_SELECTOR ((TLS_GDT_ENTRY << 3) | 3)

--- a/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/objecttype.h
+++ b/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/objecttype.h
@@ -6,9 +6,7 @@
 
 #pragma once
 
-#ifdef HAVE_AUTOCONF
 #include <autoconf.h>
-#endif /* HAVE_AUTOCONF */
 
 typedef enum _mode_object {
     seL4_X86_PDPTObject = seL4_NonArchObjectTypeCount,

--- a/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/objecttype.h
+++ b/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/objecttype.h
@@ -25,4 +25,3 @@ typedef enum _mode_object {
 #ifndef CONFIG_HUGE_PAGE
 #define seL4_X64_HugePageObject 0xfffffffe
 #endif
-

--- a/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/simple_types.h
+++ b/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/simple_types.h
@@ -6,12 +6,5 @@
 
 #pragma once
 
-typedef signed char seL4_Int8;
-typedef signed short seL4_Int16;
-typedef signed int seL4_Int32;
-typedef signed long seL4_Int64;
-
-typedef unsigned char seL4_Uint8;
-typedef unsigned short seL4_Uint16;
-typedef unsigned int seL4_Uint32;
-typedef unsigned long seL4_Uint64;
+#define SEL4_WORD_IS_UINT64
+#define SEL4_INT64_IS_LONG

--- a/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/types.h
+++ b/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/types.h
@@ -9,7 +9,6 @@
 #include <autoconf.h>
 #include <sel4/simple_types.h>
 
-typedef seL4_Uint64 seL4_Word;
 typedef seL4_Word seL4_NodeId;
 typedef seL4_Word seL4_PAddr;
 typedef seL4_Word seL4_Domain;

--- a/libsel4/sel4_plat_include/allwinnerA20/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/allwinnerA20/sel4/plat/api/constants.h
@@ -6,9 +6,7 @@
 
 #pragma once
 
-#ifdef HAVE_AUTOCONF
 #include <autoconf.h>
-#endif
 
 /* Cortex A7 manual, table 10-2 */
 #define seL4_NumHWBreakpoints (10)

--- a/libsel4/sel4_plat_include/allwinnerA20/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/allwinnerA20/sel4/plat/api/constants.h
@@ -21,4 +21,3 @@
 
 /* First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xa0000000
-

--- a/libsel4/sel4_plat_include/am335x/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/am335x/sel4/plat/api/constants.h
@@ -6,9 +6,7 @@
 
 #pragma once
 
-#ifdef HAVE_AUTOCONF
 #include <autoconf.h>
-#endif
 
 /* Cortex a8 manual, table 12-11 */
 #define seL4_NumHWBreakpoints (8)

--- a/libsel4/sel4_plat_include/am335x/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/am335x/sel4/plat/api/constants.h
@@ -21,4 +21,3 @@
 
 /* First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xe0000000
-

--- a/libsel4/sel4_plat_include/apq8064/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/apq8064/sel4/plat/api/constants.h
@@ -6,9 +6,7 @@
 
 #pragma once
 
-#ifdef HAVE_AUTOCONF
 #include <autoconf.h>
-#endif
 
 /* Cortex a15 manual, section 10.2.2 */
 #define seL4_NumHWBreakpoints (10)

--- a/libsel4/sel4_plat_include/ariane/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/ariane/sel4/plat/api/constants.h
@@ -5,6 +5,5 @@
  */
 
 #pragma once
-#ifdef HAVE_AUTOCONF
+
 #include <autoconf.h>
-#endif

--- a/libsel4/sel4_plat_include/ariane/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/ariane/sel4/plat/api/constants.h
@@ -8,4 +8,3 @@
 #ifdef HAVE_AUTOCONF
 #include <autoconf.h>
 #endif
-

--- a/libsel4/sel4_plat_include/bcm2837/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/bcm2837/sel4/plat/api/constants.h
@@ -6,9 +6,7 @@
 
 #pragma once
 
-#ifdef HAVE_AUTOCONF
 #include <autoconf.h>
-#endif
 
 /* Cortex A57 manual, section 10.6.1 */
 #define seL4_NumHWBreakpoints (10)

--- a/libsel4/sel4_plat_include/exynos4/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/exynos4/sel4/plat/api/constants.h
@@ -6,9 +6,7 @@
 
 #pragma once
 
-#ifdef HAVE_AUTOCONF
 #include <autoconf.h>
-#endif
 
 /* Cortex a9 manual, section 10.1.2 */
 #define seL4_NumHWBreakpoints (10)

--- a/libsel4/sel4_plat_include/exynos4/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/exynos4/sel4/plat/api/constants.h
@@ -21,5 +21,3 @@
 
 /* First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xe0000000
-
-

--- a/libsel4/sel4_plat_include/exynos5/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/exynos5/sel4/plat/api/constants.h
@@ -5,9 +5,7 @@
  */
 #pragma once
 
-#ifdef HAVE_AUTOCONF
 #include <autoconf.h>
-#endif
 
 /* Cortex a15 manual, section 10.2.2 */
 #define seL4_NumHWBreakpoints (10)

--- a/libsel4/sel4_plat_include/fvp/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/fvp/sel4/plat/api/constants.h
@@ -17,4 +17,3 @@
 #define seL4_FirstWatchpoint (6)
 #define seL4_NumDualFunctionMonitors (0)
 #endif
-

--- a/libsel4/sel4_plat_include/fvp/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/fvp/sel4/plat/api/constants.h
@@ -5,9 +5,8 @@
  */
 
 #pragma once
-#ifdef HAVE_AUTOCONF
+
 #include <autoconf.h>
-#endif
 
 /* Cortex A57 manual, section 10.6.1 */
 #define seL4_NumHWBreakpoints (10)

--- a/libsel4/sel4_plat_include/hifive/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/hifive/sel4/plat/api/constants.h
@@ -6,6 +6,4 @@
 
 #pragma once
 
-#ifdef HAVE_AUTOCONF
 #include <autoconf.h>
-#endif

--- a/libsel4/sel4_plat_include/hikey/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/hikey/sel4/plat/api/constants.h
@@ -25,4 +25,3 @@
 #else
 /* otherwise this is defined at the arch level */
 #endif
-

--- a/libsel4/sel4_plat_include/hikey/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/hikey/sel4/plat/api/constants.h
@@ -6,9 +6,7 @@
 
 #pragma once
 
-#ifdef HAVE_AUTOCONF
 #include <autoconf.h>
-#endif
 
 /* Cortex A57 manual, section 10.6.1 */
 #define seL4_NumHWBreakpoints (10)

--- a/libsel4/sel4_plat_include/imx31/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/imx31/sel4/plat/api/constants.h
@@ -6,9 +6,7 @@
 
 #pragma once
 
-#ifdef HAVE_AUTOCONF
 #include <autoconf.h>
-#endif
 
 /* ARM1136-JF-S manual, table 13-3 */
 #define seL4_NumHWBreakpoints (8)

--- a/libsel4/sel4_plat_include/imx31/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/imx31/sel4/plat/api/constants.h
@@ -21,5 +21,3 @@
 
 /* First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xf0000000
-
-

--- a/libsel4/sel4_plat_include/imx6/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/imx6/sel4/plat/api/constants.h
@@ -6,9 +6,7 @@
 
 #pragma once
 
-#ifdef HAVE_AUTOCONF
 #include <autoconf.h>
-#endif
 
 /* Cortex a9 manual, section 10.1.2 */
 #define seL4_NumHWBreakpoints (10)

--- a/libsel4/sel4_plat_include/imx6/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/imx6/sel4/plat/api/constants.h
@@ -21,5 +21,3 @@
 
 /* First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xe0000000
-
-

--- a/libsel4/sel4_plat_include/imx7/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/imx7/sel4/plat/api/constants.h
@@ -6,9 +6,7 @@
 
 #pragma once
 
-#ifdef HAVE_AUTOCONF
 #include <autoconf.h>
-#endif
 
 /* Cortex A7 manual, table 10-2 */
 #define seL4_NumHWBreakpoints (10)

--- a/libsel4/sel4_plat_include/imx8mq-evk/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/imx8mq-evk/sel4/plat/api/constants.h
@@ -6,9 +6,7 @@
 
 #pragma once
 
-#ifdef HAVE_AUTOCONF
 #include <autoconf.h>
-#endif
 
 #define seL4_NumHWBreakpoints (10)
 #define seL4_NumExclusiveBreakpoints (6)

--- a/libsel4/sel4_plat_include/imx8mq-evk/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/imx8mq-evk/sel4/plat/api/constants.h
@@ -24,4 +24,3 @@
 #else
 /* otherwise this is defined at the arch level */
 #endif
-

--- a/libsel4/sel4_plat_include/odroidc2/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/odroidc2/sel4/plat/api/constants.h
@@ -18,5 +18,3 @@
 #define seL4_FirstWatchpoint (6)
 #define seL4_NumDualFunctionMonitors (0)
 #endif
-
-

--- a/libsel4/sel4_plat_include/odroidc2/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/odroidc2/sel4/plat/api/constants.h
@@ -6,9 +6,7 @@
 
 #pragma once
 
-#ifdef HAVE_AUTOCONF
 #include <autoconf.h>
-#endif
 
 /* Cortex A53 manual, section 11.6.1 */
 #define seL4_NumHWBreakpoints (10)

--- a/libsel4/sel4_plat_include/omap3/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/omap3/sel4/plat/api/constants.h
@@ -21,4 +21,3 @@
 
 /* First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xf0000000
-

--- a/libsel4/sel4_plat_include/omap3/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/omap3/sel4/plat/api/constants.h
@@ -6,9 +6,7 @@
 
 #pragma once
 
-#ifdef HAVE_AUTOCONF
 #include <autoconf.h>
-#endif
 
 /* Cortex a8 manual, table 12-11 */
 #define seL4_NumHWBreakpoints (8)

--- a/libsel4/sel4_plat_include/pc99/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/pc99/sel4/plat/api/constants.h
@@ -6,9 +6,7 @@
 
 #pragma once
 
-#ifdef HAVE_AUTOCONF
 #include <autoconf.h>
-#endif
 
 /* Defined for each architecture: the number of hardware breakpoints
  * available.

--- a/libsel4/sel4_plat_include/pc99/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/pc99/sel4/plat/api/constants.h
@@ -22,4 +22,3 @@
 #define seL4_FirstDualFunctionMonitor (0)
 #define seL4_NumDualFunctionMonitors (4)
 #endif
-

--- a/libsel4/sel4_plat_include/polarfire/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/polarfire/sel4/plat/api/constants.h
@@ -6,6 +6,4 @@
 
 #pragma once
 
-#ifdef HAVE_AUTOCONF
 #include <autoconf.h>
-#endif

--- a/libsel4/sel4_plat_include/qemu-arm-virt/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/qemu-arm-virt/sel4/plat/api/constants.h
@@ -6,9 +6,7 @@
 
 #pragma once
 
-#ifdef HAVE_AUTOCONF
 #include <autoconf.h>
-#endif
 
 /* Cortex A7 manual, table 10-2 */
 #define seL4_NumHWBreakpoints (10)

--- a/libsel4/sel4_plat_include/qemu-arm-virt/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/qemu-arm-virt/sel4/plat/api/constants.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-
 #ifdef HAVE_AUTOCONF
 #include <autoconf.h>
 #endif
@@ -26,4 +25,3 @@
 
 #define seL4_UserTop 0xa0000000
 #endif
-

--- a/libsel4/sel4_plat_include/rocketchip/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/rocketchip/sel4/plat/api/constants.h
@@ -9,4 +9,3 @@
 #ifdef HAVE_AUTOCONF
 #include <autoconf.h>
 #endif
-

--- a/libsel4/sel4_plat_include/rocketchip/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/rocketchip/sel4/plat/api/constants.h
@@ -6,6 +6,4 @@
 
 #pragma once
 
-#ifdef HAVE_AUTOCONF
 #include <autoconf.h>
-#endif

--- a/libsel4/sel4_plat_include/rockpro64/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/rockpro64/sel4/plat/api/constants.h
@@ -9,4 +9,3 @@
 #ifdef HAVE_AUTOCONF
 #include <autoconf.h>
 #endif
-

--- a/libsel4/sel4_plat_include/rockpro64/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/rockpro64/sel4/plat/api/constants.h
@@ -6,6 +6,4 @@
 
 #pragma once
 
-#ifdef HAVE_AUTOCONF
 #include <autoconf.h>
-#endif

--- a/libsel4/sel4_plat_include/spike/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/spike/sel4/plat/api/constants.h
@@ -9,4 +9,3 @@
 #ifdef HAVE_AUTOCONF
 #include <autoconf.h>
 #endif
-

--- a/libsel4/sel4_plat_include/spike/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/spike/sel4/plat/api/constants.h
@@ -6,6 +6,4 @@
 
 #pragma once
 
-#ifdef HAVE_AUTOCONF
 #include <autoconf.h>
-#endif

--- a/libsel4/sel4_plat_include/tk1/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/tk1/sel4/plat/api/constants.h
@@ -5,9 +5,8 @@
  */
 
 #pragma once
-#ifdef HAVE_AUTOCONF
+
 #include <autoconf.h>
-#endif
 
 /* Cortex a15 manual, section 10.2.2 */
 #define seL4_NumHWBreakpoints (10)

--- a/libsel4/sel4_plat_include/tk1/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/tk1/sel4/plat/api/constants.h
@@ -20,4 +20,3 @@
 
 /* First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xe0000000
-

--- a/libsel4/sel4_plat_include/tx1/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/tx1/sel4/plat/api/constants.h
@@ -8,5 +8,3 @@
 #ifdef HAVE_AUTOCONF
 #include <autoconf.h>
 #endif
-
-

--- a/libsel4/sel4_plat_include/tx1/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/tx1/sel4/plat/api/constants.h
@@ -5,6 +5,5 @@
  */
 
 #pragma once
-#ifdef HAVE_AUTOCONF
+
 #include <autoconf.h>
-#endif

--- a/libsel4/sel4_plat_include/tx2/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/tx2/sel4/plat/api/constants.h
@@ -5,6 +5,5 @@
  */
 
 #pragma once
-#ifdef HAVE_AUTOCONF
+
 #include <autoconf.h>
-#endif

--- a/libsel4/sel4_plat_include/tx2/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/tx2/sel4/plat/api/constants.h
@@ -8,4 +8,3 @@
 #ifdef HAVE_AUTOCONF
 #include <autoconf.h>
 #endif
-

--- a/libsel4/sel4_plat_include/zynq7000/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/zynq7000/sel4/plat/api/constants.h
@@ -6,9 +6,7 @@
 
 #pragma once
 
-#ifdef HAVE_AUTOCONF
 #include <autoconf.h>
-#endif
 
 /* Cortex a9 manual, section 10.1.2 */
 #define seL4_NumHWBreakpoints (10)

--- a/libsel4/sel4_plat_include/zynqmp/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/zynqmp/sel4/plat/api/constants.h
@@ -6,9 +6,7 @@
 
 #pragma once
 
-#ifdef HAVE_AUTOCONF
 #include <autoconf.h>
-#endif
 
 /* Cortex A57 manual, section 10.6.1 */
 #define seL4_NumHWBreakpoints (10)


### PR DESCRIPTION
This provides a generic way to print an `SEL4_PRI_word` on 32-bit and 64-bit platforms, aligned with `PRIu64` and friends. 

Use it as:
```
printf("foo = %" SEL4_PRI_word "\n", (seL4_Word)foo);
```

If there is an agreement to merge this, I'll add this in RISC-V and ia32/x86 also.