### PR TITLE
CONFIG_PRINTING, CONFIG_DEBUG_BUILD: Make compile

### DIFF
--- a/include/arch/x86/arch/kernel/cmdline.h
+++ b/include/arch/x86/arch/kernel/cmdline.h
@@ -10,7 +10,7 @@ typedef struct cmdline_opt {
 #ifdef CONFIG_PRINTING
     uint16_t console_port;
 #endif
-#ifdef CONFIG_DEBUG_BUILD
+#if defined(CONFIG_PRINTING) || defined(CONFIG_DEBUG_BUILD)
     uint16_t debug_port;
 #endif
     bool_t   disable_iommu;

--- a/include/arch/x86/arch/model/statedata.h
+++ b/include/arch/x86/arch/model/statedata.h
@@ -81,7 +81,7 @@ extern uint32_t x86KSFirstValidIODomain;
 #ifdef CONFIG_PRINTING
 extern uint16_t x86KSconsolePort;
 #endif
-#ifdef CONFIG_DEBUG_BUILD
+#if defined(CONFIG_PRINTING) || defined(CONFIG_DEBUG_BUILD)
 extern uint16_t x86KSdebugPort;
 #endif
 

--- a/include/machine/io.h
+++ b/include/machine/io.h
@@ -36,4 +36,5 @@ word_t puts(const char *s) VISIBLE;
 #define kernel_putchar(c) ((void)(0))
 #define printf(args...) ((void)(0))
 #define puts(s) ((void)(0))
+#define putchar(s) ((void)(0))
 #endif /* CONFIG_PRINTING */

--- a/src/arch/arm/32/machine/capdl.c
+++ b/src/arch/arm/32/machine/capdl.c
@@ -265,8 +265,8 @@ void print_cap_arch(cap_t cap)
     switch (cap_get_capType(cap)) {
     case cap_page_table_cap: {
         asid_t asid = cap_page_table_cap_get_capPTMappedASID(cap);
-        findPDForASID_ret_t find_ret = findPDForASID(asid);
-        vptr_t vptr = cap_page_table_cap_get_capPTMappedAddress(cap);
+        UNUSED findPDForASID_ret_t find_ret = findPDForASID(asid);
+        UNUSED vptr_t vptr = cap_page_table_cap_get_capPTMappedAddress(cap);
         if (asid) {
             printf("pt_%p_%04lu (asid: %lu)\n",
                    lookupPDSlot(find_ret.pd, vptr), PD_INDEX(vptr), (long unsigned int)asid);
@@ -277,7 +277,7 @@ void print_cap_arch(cap_t cap)
     }
     case cap_page_directory_cap: {
         asid_t asid = cap_page_directory_cap_get_capPDMappedASID(cap);
-        findPDForASID_ret_t find_ret = findPDForASID(asid);
+        UNUSED findPDForASID_ret_t find_ret = findPDForASID(asid);
         if (asid) {
             printf("%p_pd (asid: %lu)\n",
                    find_ret.pd, (long unsigned int)asid);

--- a/src/arch/arm/64/kernel/vspace.c
+++ b/src/arch/arm/64/kernel/vspace.c
@@ -2436,7 +2436,7 @@ void kernelDataAbort(word_t pc) VISIBLE;
 
 void kernelPrefetchAbort(word_t pc)
 {
-    word_t ifsr = getIFSR();
+    UNUSED word_t ifsr = getIFSR();
 
     printf("\n\nKERNEL PREFETCH ABORT!\n");
     printf("Faulting instruction: 0x%x\n", (unsigned int)pc);
@@ -2447,8 +2447,8 @@ void kernelPrefetchAbort(word_t pc)
 
 void kernelDataAbort(word_t pc)
 {
-    word_t dfsr = getDFSR();
-    word_t far = getFAR();
+    UNUSED word_t dfsr = getDFSR();
+    UNUSED word_t far = getFAR();
 
     printf("\n\nKERNEL DATA ABORT!\n");
     printf("Faulting instruction: 0x%lx\n", (unsigned long)pc);

--- a/src/arch/arm/64/machine/capdl.c
+++ b/src/arch/arm/64/machine/capdl.c
@@ -291,8 +291,8 @@ void print_cap_arch(cap_t cap)
     switch (cap_get_capType(cap)) {
     case cap_page_table_cap: {
         asid_t asid = cap_page_table_cap_get_capPTMappedASID(cap);
-        findVSpaceForASID_ret_t find_ret = findVSpaceForASID(asid);
-        vptr_t vptr = cap_page_table_cap_get_capPTMappedAddress(cap);
+        UNUSED findVSpaceForASID_ret_t find_ret = findVSpaceForASID(asid);
+        UNUSED vptr_t vptr = cap_page_table_cap_get_capPTMappedAddress(cap);
         if (asid) {
             printf("pt_%p_%04lu (asid: %lu)\n",
                    lookupPDSlot(find_ret.vspace_root, vptr).pdSlot, GET_PD_INDEX(vptr), (long unsigned int)asid);
@@ -303,8 +303,8 @@ void print_cap_arch(cap_t cap)
     }
     case cap_page_directory_cap: {
         asid_t asid = cap_page_directory_cap_get_capPDMappedASID(cap);
-        findVSpaceForASID_ret_t find_ret = findVSpaceForASID(asid);
-        vptr_t vptr = cap_page_directory_cap_get_capPDMappedAddress(cap);
+        UNUSED findVSpaceForASID_ret_t find_ret = findVSpaceForASID(asid);
+        UNUSED vptr_t vptr = cap_page_directory_cap_get_capPDMappedAddress(cap);
         if (asid) {
             printf("pd_%p_%04lu (asid: %lu)\n",
                    lookupPUDSlot(find_ret.vspace_root, vptr).pudSlot, GET_PUD_INDEX(vptr), (long unsigned int)asid);
@@ -316,8 +316,8 @@ void print_cap_arch(cap_t cap)
     }
     case cap_page_upper_directory_cap: {
         asid_t asid = cap_page_upper_directory_cap_get_capPUDMappedASID(cap);
-        findVSpaceForASID_ret_t find_ret = findVSpaceForASID(asid);
-        vptr_t vptr = cap_page_upper_directory_cap_get_capPUDMappedAddress(cap);
+        UNUSED findVSpaceForASID_ret_t find_ret = findVSpaceForASID(asid);
+        UNUSED vptr_t vptr = cap_page_upper_directory_cap_get_capPUDMappedAddress(cap);
 
 #ifdef AARCH64_VSPACE_S2_START_L1
         if (asid) {
@@ -338,7 +338,7 @@ void print_cap_arch(cap_t cap)
     }
     case cap_page_global_directory_cap: {
         asid_t asid = cap_page_global_directory_cap_get_capPGDMappedASID(cap);
-        findVSpaceForASID_ret_t find_ret = findVSpaceForASID(asid);
+        UNUSED findVSpaceForASID_ret_t find_ret = findVSpaceForASID(asid);
         if (asid) {
             printf("%p_pd (asid: %lu)\n",
                    find_ret.vspace_root, (long unsigned int)asid);

--- a/src/arch/riscv/machine/capdl.c
+++ b/src/arch/riscv/machine/capdl.c
@@ -19,7 +19,7 @@ static void cap_frame_print_attrs_pt(pte_t *ptSlot);
 
 static void obj_asidpool_print_attrs(cap_t asid_cap)
 {
-    asid_t asid = cap_asid_pool_cap_get_capASIDBase(asid_cap);
+    UNUSED asid_t asid = cap_asid_pool_cap_get_capASIDBase(asid_cap);
     printf("(asid_high: 0x%lx)\n", ASID_HIGH(asid));
 }
 
@@ -113,7 +113,7 @@ static void cap_frame_print_attrs_vptr(word_t vptr, pte_t *lvl1pt)
 {
     lookupPTSlot_ret_t lu_ret = lookupPTSlot(lvl1pt, vptr);
     assert(lu_ret.ptBitsLeft == seL4_PageBits);
-    word_t slot = ((vptr >> lu_ret.ptBitsLeft) & MASK(PT_INDEX_BITS));
+    UNUSED word_t slot = ((vptr >> lu_ret.ptBitsLeft) & MASK(PT_INDEX_BITS));
 
     printf("frame_%p_%04lu ", lu_ret.ptSlot, slot);
     cap_frame_print_attrs_pt(lu_ret.ptSlot);
@@ -124,11 +124,11 @@ void print_cap_arch(cap_t cap)
     switch (cap_get_capType(cap)) {
     case cap_page_table_cap: {
         asid_t asid = cap_page_table_cap_get_capPTMappedASID(cap);
-        findVSpaceForASID_ret_t find_ret = findVSpaceForASID(asid);
+        UNUSED findVSpaceForASID_ret_t find_ret = findVSpaceForASID(asid);
         vptr_t vptr = cap_page_table_cap_get_capPTMappedAddress(cap);
 
         word_t ptBitsLeft = PT_INDEX_BITS * CONFIG_PT_LEVELS + seL4_PageBits;
-        word_t slot = ((vptr >> ptBitsLeft) & MASK(PT_INDEX_BITS));
+        UNUSED word_t slot = ((vptr >> ptBitsLeft) & MASK(PT_INDEX_BITS));
         if (asid) {
             printf("pt_%p_%04lu (asid: %lu)\n",
                    lookupPTSlot(find_ret.vspace_root, vptr).ptSlot, slot, (long unsigned int)asid);

--- a/src/arch/x86/64/machine/capdl.c
+++ b/src/arch/x86/64/machine/capdl.c
@@ -221,8 +221,8 @@ void print_cap_arch(cap_t cap)
     /* arch specific caps */
     case cap_page_table_cap: {
         asid_t asid = cap_page_table_cap_get_capPTMappedASID(cap);
-        findVSpaceForASID_ret_t find_ret = findVSpaceForASID(asid);
-        vptr_t vptr = cap_page_table_cap_get_capPTMappedAddress(cap);
+        UNUSED findVSpaceForASID_ret_t find_ret = findVSpaceForASID(asid);
+        UNUSED vptr_t vptr = cap_page_table_cap_get_capPTMappedAddress(cap);
         if (asid) {
             printf("pt_%p_%04lu (asid: %lu)\n",
                    lookupPDSlot(find_ret.vspace_root, vptr).pdSlot, GET_PD_INDEX(vptr), (long unsigned int)asid);
@@ -233,8 +233,8 @@ void print_cap_arch(cap_t cap)
     }
     case cap_page_directory_cap: {
         asid_t asid = cap_page_directory_cap_get_capPDMappedASID(cap);
-        findVSpaceForASID_ret_t find_ret = findVSpaceForASID(asid);
-        vptr_t vptr = cap_page_directory_cap_get_capPDMappedAddress(cap);
+        UNUSED findVSpaceForASID_ret_t find_ret = findVSpaceForASID(asid);
+        UNUSED vptr_t vptr = cap_page_directory_cap_get_capPDMappedAddress(cap);
         if (asid) {
             printf("pd_%p_%04lu (asid: %lu)\n",
                    lookupPDPTSlot(find_ret.vspace_root, vptr).pdptSlot, GET_PDPT_INDEX(vptr), (long unsigned int)asid);
@@ -245,8 +245,8 @@ void print_cap_arch(cap_t cap)
     }
     case cap_pdpt_cap: {
         asid_t asid = cap_pdpt_cap_get_capPDPTMappedASID(cap);
-        findVSpaceForASID_ret_t find_ret = findVSpaceForASID(asid);
-        vptr_t vptr = cap_pdpt_cap_get_capPDPTMappedAddress(cap);
+        UNUSED findVSpaceForASID_ret_t find_ret = findVSpaceForASID(asid);
+        UNUSED vptr_t vptr = cap_pdpt_cap_get_capPDPTMappedAddress(cap);
         if (asid) {
             printf("pdpt_%p_%04lu (asid: %lu)\n",
                    lookupPML4Slot(find_ret.vspace_root, vptr), GET_PML4_INDEX(vptr), (long unsigned int)asid);
@@ -257,7 +257,7 @@ void print_cap_arch(cap_t cap)
     }
     case cap_pml4_cap: {
         asid_t asid = cap_pml4_cap_get_capPML4MappedASID(cap);
-        findVSpaceForASID_ret_t find_ret = findVSpaceForASID(asid);
+        UNUSED findVSpaceForASID_ret_t find_ret = findVSpaceForASID(asid);
         if (asid) {
             printf("%p_pd (asid: %lu)\n",
                    find_ret.vspace_root, (long unsigned int)asid);
@@ -313,7 +313,7 @@ void print_cap_arch(cap_t cap)
 
 static void obj_asidpool_print_attrs(cap_t asid_cap)
 {
-    asid_t asid = cap_asid_pool_cap_get_capASIDBase(asid_cap);
+    UNUSED asid_t asid = cap_asid_pool_cap_get_capASIDBase(asid_cap);
     printf("(asid_high: 0x%lx)\n", ASID_HIGH(asid));
 }
 

--- a/src/arch/x86/kernel/cmdline.c
+++ b/src/arch/x86/kernel/cmdline.c
@@ -136,7 +136,7 @@ void cmdline_parse(const char *cmdline, cmdline_opt_t *cmdline_opt)
     }
 #endif
 
-#ifdef CONFIG_DEBUG_BUILD
+#if defined(CONFIG_PRINTING) || defined(CONFIG_DEBUG_BUILD)
     /* initialise to default or use BDA if available */
     cmdline_opt->debug_port = bda_ports_count && *bda_port ? *bda_port : 0x3f8;
     if (parse_opt(cmdline, "debug_port", cmdline_val, MAX_CMDLINE_VAL_LEN) != -1) {

--- a/src/arch/x86/model/statedata.c
+++ b/src/arch/x86/model/statedata.c
@@ -60,7 +60,7 @@ UP_STATE_DEFINE(vcpu_t *, x86KSCurrentVCPU);
 #ifdef CONFIG_PRINTING
 uint16_t x86KSconsolePort;
 #endif
-#ifdef CONFIG_DEBUG_BUILD
+#if defined(CONFIG_PRINTING) || defined(CONFIG_DEBUG_BUILD)
 uint16_t x86KSdebugPort;
 #endif
 

--- a/src/machine/capdl.c
+++ b/src/machine/capdl.c
@@ -278,7 +278,7 @@ void obj_tcb_print_slots(tcb_t *tcb)
 
     /* TCB of most recent IPC sender */
     if (cap_get_capType(TCB_PTR_CTE_PTR(tcb, tcbCaller)->cap) != cap_null_cap) {
-        tcb_t *caller = TCB_PTR(cap_thread_cap_get_capTCBPtr(TCB_PTR_CTE_PTR(tcb, tcbCaller)->cap));
+        UNUSED tcb_t *caller = TCB_PTR(cap_thread_cap_get_capTCBPtr(TCB_PTR_CTE_PTR(tcb, tcbCaller)->cap));
         printf("caller_slot: %p_tcb\n", caller);
     }
 #endif /* CONFIG_KERNEL_MCS */


### PR DESCRIPTION
CONFIG_DEBUG_BUILD and CONFIG_PRINTING are different config options that
can be used independently from each other. CONFIG_PRINTING controls the
backend of kernel print functions while CONFIG_DEBUG_BUILD controls
other kernel debug features.
Note that CONFIG_VERIFICATION_BUILD is the config option that controls
whether any of these options can be used.

Signed-off-by: Kent McLeod <kent@kry10.com>