### PR TITLE
pc99: Add CONFIG_PC99_TSC_FREQUENCY config option

### DIFF
--- a/src/plat/pc99/config.cmake
+++ b/src/plat/pc99/config.cmake
@@ -44,3 +44,13 @@ add_bf_source_old(
     "include/plat/pc99/plat/32"
     "plat_mode/machine"
 )
+
+config_string(
+    KernelPC99TSCFrequency PC99_TSC_FREQUENCY
+    "Provide a static definition of the TSC frequency (in Hz). \
+    If this isn't set then the boot code will try and read the frequency from a MSR. \
+    If it can't calculate the frequency from a MSR then it will estimate it from running the PIT for about 200ms."
+    DEFAULT 0
+    DEPENDS "KernelPlatPC99"
+    UNQUOTE UNDEF_DISABLED
+)

--- a/src/plat/pc99/machine/hardware.c
+++ b/src/plat/pc99/machine/hardware.c
@@ -76,6 +76,10 @@ BOOT_CODE static inline uint32_t measure_tsc_khz(void)
 BOOT_CODE uint32_t tsc_init(void)
 {
 
+#if CONFIG_PC99_TSC_FREQUENCY > 0
+    return CONFIG_PC99_TSC_FREQUENCY / 1000000;
+#endif
+
     x86_cpu_identity_t *model_info = x86_cpuid_get_model_info();
     uint32_t valid_models[] = {
         NEHALEM_1_MODEL_ID, NEHALEM_2_MODEL_ID, NEHALEM_3_MODEL_ID,


### PR DESCRIPTION
This option allows a static definition of the TSC frequency. This allows
a kernel to use a known value if the platform doesn't provide access to
an appropriate MSR for reading it during startup. If this config is set,
the kernel won't try and estimate the TSC frequency by running the PIT
for 200ms during startup.

Signed-off-by: Kent McLeod <kent@kry10.com>