### PR TITLE
Implementing proposed solutions

### DIFF
--- a/include/kernel/thread.h
+++ b/include/kernel/thread.h
@@ -109,17 +109,22 @@ static inline bool_t PURE isStopped(const tcb_t *thread)
     }
 }
 
+static inline bool_t isCurDomainExpired(void)
+{
+#ifdef CONFIG_KERNEL_MCS
+    return CONFIG_NUM_DOMAINS > 1 && ksDomainTime < NODE_STATE(ksConsumed) + getKernelWcetTicks();
+#else
+    return ksDomainTime == 0;
+#endif
+}
+
+
 #ifdef CONFIG_KERNEL_MCS
 static inline bool_t PURE isRoundRobin(sched_context_t *sc)
 {
     return sc->scPeriod == 0;
 }
 
-static inline bool_t isCurDomainExpired(void)
-{
-    return CONFIG_NUM_DOMAINS > 1 &&
-           ksDomainTime < (NODE_STATE(ksConsumed) + MIN_BUDGET);
-}
 
 static inline void commitTime(bool_t switchedDomain)
 {

--- a/include/kernel/thread.h
+++ b/include/kernel/thread.h
@@ -147,7 +147,6 @@ static inline void commitTime(void)
     }
     if (CONFIG_NUM_DOMAINS > 1) {
         assert(ksDomainTime > NODE_STATE(ksConsumed));
-        assert(ksDomainTime - NODE_STATE(ksConsumed) >= MIN_BUDGET);
         if (NODE_STATE(ksConsumed) < ksDomainTime) {
             ksDomainTime -= NODE_STATE(ksConsumed);
         } else {

--- a/include/kernel/thread.h
+++ b/include/kernel/thread.h
@@ -121,7 +121,7 @@ static inline bool_t isCurDomainExpired(void)
            ksDomainTime < (NODE_STATE(ksConsumed) + MIN_BUDGET);
 }
 
-static inline void commitTime(void)
+static inline void commitTime(bool_t switchedDomain)
 {
     if (NODE_STATE(ksCurSC)->scRefillMax) {
         if (likely(NODE_STATE(ksConsumed) > 0)) {
@@ -145,7 +145,10 @@ static inline void commitTime(void)
         }
         NODE_STATE(ksCurSC)->scConsumed += NODE_STATE(ksConsumed);
     }
-    if (CONFIG_NUM_DOMAINS > 1) {
+    /* If we have switched domains, ksDomainTime has already been reset and is accounted for the
+     * old domain. If we have not switched domains, we still need to account for the time that
+     * has passed. */
+    if (CONFIG_NUM_DOMAINS > 1 && !switchedDomain) {
         assert(ksDomainTime > NODE_STATE(ksConsumed));
         if (NODE_STATE(ksConsumed) < ksDomainTime) {
             ksDomainTime -= NODE_STATE(ksConsumed);

--- a/src/kernel/thread.c
+++ b/src/kernel/thread.c
@@ -349,11 +349,7 @@ void schedule(void)
     awaken();
 #endif
 
-#ifdef CONFIG_KERNEL_MCS
-    bool_t switchedDomain = false;
-#else
-    bool_t switchedDomain __attribute__((unused));
-#endif
+    UNUSED bool_t switchedDomain = false;
     if (NODE_STATE(ksSchedulerAction) != SchedulerAction_ResumeCurrentThread) {
         bool_t was_runnable;
         if (isSchedulable(NODE_STATE(ksCurThread))) {

--- a/src/kernel/thread.c
+++ b/src/kernel/thread.c
@@ -349,8 +349,11 @@ void schedule(void)
     awaken();
 #endif
 
-    /* This flag is only used in the MCS kernel, in which case the attribute is ignored. */
-    UNUSED bool_t switchedDomain = false;
+#ifdef CONFIG_KERNEL_MCS
+    bool_t switchedDomain = false;
+#else
+    UNUSED bool_t switchedDomain;
+#endif
     if (NODE_STATE(ksSchedulerAction) != SchedulerAction_ResumeCurrentThread) {
         bool_t was_runnable;
         if (isSchedulable(NODE_STATE(ksCurThread))) {

--- a/src/kernel/thread.c
+++ b/src/kernel/thread.c
@@ -335,7 +335,7 @@ static void switchSchedContext(bool_t switchedDomain)
 static bool_t scheduleChooseNewThread(void)
 {
     bool_t switchedDomain = false;
-    if (ksDomainTime == 0) {
+    if (isCurDomainExpired()) {
         nextDomain();
         switchedDomain = true;
     }

--- a/src/kernel/thread.c
+++ b/src/kernel/thread.c
@@ -349,6 +349,7 @@ void schedule(void)
     awaken();
 #endif
 
+    /* This flag is only used in the MCS kernel, in which case the attribute is ignored. */
     UNUSED bool_t switchedDomain = false;
     if (NODE_STATE(ksSchedulerAction) != SchedulerAction_ResumeCurrentThread) {
         bool_t was_runnable;


### PR DESCRIPTION
Revelant links are:
* https://sel4.atlassian.net/browse/VER-1302
* https://github.com/seL4/seL4/issues/226

I have implemented the solutions described in the github issue. Except in part 2 where we propose a different solution.
1. Done. If we disallow the current scheduling context, then the corresponding check in `invokeSchedControlConfigure` is no longer needed and so the block is removed. If we can be sure that current thread and current sched context should be bound at this point, it's also unnecessary to make a check on the current thread and so that block is removed.
2. Done. Rather than moving the call to `nextDomain` which could create other problems, we decided to introduce a boolean variable which tracks if the domain was switched at that point. This value is passed through to `commitTime` which will only deduct from  `ksDomainTime` if the domain was not switched.
3. This is already implemented as
```
        if (NODE_STATE(ksConsumed) < ksDomainTime) {
            ksDomainTime -= NODE_STATE(ksConsumed);
        } else {
            ksDomainTime = 0;
        }
``` 
4. Done. I deleted the offending assert.

Fixes #297 