### PR TITLE
 Sub PR3 (Synchronise master kernel and abstract model)

### DIFF
--- a/include/kernel/sporadic.h
+++ b/include/kernel/sporadic.h
@@ -119,6 +119,31 @@ static inline bool_t refill_ready(sched_context_t *sc)
     return refill_head(sc)->rTime <= (NODE_STATE_ON_CORE(ksCurTime, sc->scCore) + getKernelWcetTicks());
 }
 
+/*
+ * Return true if an SC has been successfully configured with parameters
+ * that allow for a thread to run.
+ */
+static inline bool_t sc_active(sched_context_t *sc)
+{
+    return sc->scRefillMax > 0;
+}
+
+/*
+ * Return true if a SC has been 'released', if its head refill is
+ * sufficient and is in the past.
+ */
+static inline bool_t sc_released(sched_context_t *sc)
+{
+    if (sc_active(sc)) {
+        /* All refills must all be greater than MIN_BUDGET so this
+         * should be true for all active SCs */
+        assert(refill_sufficient(sc, 0));
+        return refill_ready(sc);
+    } else {
+        return false;
+    }
+}
+
 /* Create a new refill in a non-active sc */
 #ifdef ENABLE_SMP_SUPPORT
 void refill_new(sched_context_t *sc, word_t max_refills, ticks_t budget, ticks_t period, word_t core);

--- a/src/object/tcb.c
+++ b/src/object/tcb.c
@@ -1328,6 +1328,11 @@ exception_t decodeSetSchedParams(cap_t cap, word_t length, extra_caps_t excaps, 
             current_syscall_error.type = seL4_IllegalOperation;
             return EXCEPTION_SYSCALL_ERROR;
         }
+        if (isBlocked(tcb) && !sc_released(sc)) {
+            userError("TCB Configure: tcb blocked and scheduling context not schedulable.");
+            current_syscall_error.type = seL4_IllegalOperation;
+            return EXCEPTION_SYSCALL_ERROR;
+        }
         break;
     case cap_null_cap:
         if (tcb == NODE_STATE(ksCurThread)) {


### PR DESCRIPTION
This PR adds a check to SchedContext_Bind and TCB_SetSchedParams that prevents binding an SC to a thread if the SC is not released and the thread is blocked (On an endpoint, notification or reply object). 

So as to ensure that all TCBs in queues are either faulted, passive, or
have schedulable SCs we cannot allow arbitrary SCs to be bound to TCBs
that are already in queues.

If a TCB is in a queue it should first be removed before having an SC
bound to it.

