### PR TITLE
Signal fastpath

### DIFF
--- a/include/arch/arm/arch/fastpath/fastpath.h
+++ b/include/arch/arm/arch/fastpath/fastpath.h
@@ -15,7 +15,7 @@ void slowpath(syscall_t syscall)
 NORETURN;
 
 static inline
-void fastpath_signal(cap_t cap)
+void fastpath_signal(word_t cptr)
 NORETURN;
 
 static inline

--- a/include/arch/arm/arch/fastpath/fastpath.h
+++ b/include/arch/arm/arch/fastpath/fastpath.h
@@ -15,7 +15,7 @@ void slowpath(syscall_t syscall)
 NORETURN;
 
 static inline
-void fastpath_signal(word_t cptr)
+void fastpath_signal(word_t cptr, word_t msgInfo)
 NORETURN;
 
 static inline

--- a/include/arch/arm/arch/fastpath/fastpath.h
+++ b/include/arch/arm/arch/fastpath/fastpath.h
@@ -15,6 +15,10 @@ void slowpath(syscall_t syscall)
 NORETURN;
 
 static inline
+void fastpath_signal(cap_t cap)
+NORETURN;
+
+static inline
 void fastpath_call(word_t cptr, word_t r_msgInfo)
 NORETURN;
 

--- a/include/arch/arm/arch/kernel/traps.h
+++ b/include/arch/arm/arch/kernel/traps.h
@@ -29,7 +29,7 @@ VISIBLE SECTION(".vectors.text");
 void c_handle_fastpath_call(word_t cptr, word_t msgInfo)
 VISIBLE SECTION(".vectors.text");
 
-void c_handle_fastpath_signal(word_t cptr, word_t msgInfo, syscall_t syscall)
+void c_handle_fastpath_signal(word_t cptr, word_t msgInfo)
 VISIBLE SECTION(".vectors.text");
 
 #ifdef CONFIG_KERNEL_MCS

--- a/include/arch/arm/arch/kernel/traps.h
+++ b/include/arch/arm/arch/kernel/traps.h
@@ -29,6 +29,9 @@ VISIBLE SECTION(".vectors.text");
 void c_handle_fastpath_call(word_t cptr, word_t msgInfo)
 VISIBLE SECTION(".vectors.text");
 
+void c_handle_fastpath_signal(word_t cptr, word_t msgInfo, syscall_t syscall)
+VISIBLE SECTION(".vectors.text");
+
 #ifdef CONFIG_KERNEL_MCS
 void c_handle_fastpath_reply_recv(word_t cptr, word_t msgInfo, word_t reply)
 #else

--- a/src/arch/arm/32/traps.S
+++ b/src/arch/arm/32/traps.S
@@ -88,6 +88,8 @@ BEGIN_FUNC(arm_swi_syscall)
 #ifdef CONFIG_FASTPATH
     cmp r7, #SYSCALL_CALL
     beq c_handle_fastpath_call
+    cmp r7, #SYSCALL_SEND
+    beq c_handle_fastpath_signal
     cmp r7, #SYSCALL_REPLY_RECV
 #ifdef CONFIG_KERNEL_MCS
     moveq r2, r6
@@ -96,8 +98,6 @@ BEGIN_FUNC(arm_swi_syscall)
 #endif
 
     mov r2, r7
-    cmp r7, #SYSCALL_SEND
-    beq c_handle_fastpath_signal
     b c_handle_syscall
 
 END_FUNC(arm_swi_syscall)

--- a/src/arch/arm/32/traps.S
+++ b/src/arch/arm/32/traps.S
@@ -96,6 +96,8 @@ BEGIN_FUNC(arm_swi_syscall)
 #endif
 
     mov r2, r7
+    cmp r7, #SYSCALL_SEND
+    beq c_handle_fastpath_signal
     b c_handle_syscall
 
 END_FUNC(arm_swi_syscall)

--- a/src/arch/arm/c_traps.c
+++ b/src/arch/arm/c_traps.c
@@ -133,6 +133,14 @@ void VISIBLE c_handle_syscall(word_t cptr, word_t msgInfo, syscall_t syscall)
     ksKernelEntry.is_fastpath = 0;
 #endif /* DEBUG */
 
+    /* TODO: Add checks from fastpath (e.g. valid VTable, etc.) */
+    cap_t cap = lookupCap(NODE_STATE(ksCurThread), cptr).cap;
+    if (syscall == (syscall_t)SysSend && cap_get_capType(cap) == cap_notification_cap) {
+        /* signalling a notification */
+        fastpath_signal(cap);
+        UNREACHABLE();
+    }
+
     slowpath(syscall);
     UNREACHABLE();
 }

--- a/src/arch/arm/c_traps.c
+++ b/src/arch/arm/c_traps.c
@@ -164,7 +164,7 @@ void VISIBLE c_handle_fastpath_signal(word_t cptr, word_t msgInfo)
     ksKernelEntry.is_fastpath = 1;
 #endif /* DEBUG */
 
-    fastpath_signal(cptr);
+    fastpath_signal(cptr, msgInfo);
     UNREACHABLE();
 }
 

--- a/src/arch/arm/c_traps.c
+++ b/src/arch/arm/c_traps.c
@@ -154,7 +154,7 @@ void VISIBLE c_handle_fastpath_call(word_t cptr, word_t msgInfo)
 }
 
 ALIGN(L1_CACHE_LINE_SIZE)
-void VISIBLE c_handle_fastpath_signal(word_t cptr, word_t msgInfo, syscall_t syscall)
+void VISIBLE c_handle_fastpath_signal(word_t cptr, word_t msgInfo)
 {
     NODE_LOCK_SYS;
 
@@ -164,15 +164,7 @@ void VISIBLE c_handle_fastpath_signal(word_t cptr, word_t msgInfo, syscall_t sys
     ksKernelEntry.is_fastpath = 1;
 #endif /* DEBUG */
 
-    /* We land up in here on every SYSCALL_SEND, so we need to check that we are
-     * actually signalling a notification */
-    cap_t cap = lookupCap(NODE_STATE(ksCurThread), cptr).cap;
-    if (cap_get_capType(cap) != cap_notification_cap) {
-        slowpath(syscall);
-        UNREACHABLE();
-    }
-
-    fastpath_signal(cap);
+    fastpath_signal(cptr);
     UNREACHABLE();
 }
 

--- a/src/fastpath/fastpath.c
+++ b/src/fastpath/fastpath.c
@@ -27,6 +27,7 @@ void NORETURN fastpath_signal(cap_t cap)
     notification_t *ntfnPtr = NTFN_PTR(cap_notification_cap_get_capNtfnPtr(cap));
     uint32_t ntfnState = notification_ptr_get_state(ntfnPtr);
     word_t badge = cap_notification_cap_get_capNtfnBadge(cap);
+
     switch (ntfnState) {
         case NtfnState_Active: {
             word_t badge2 = notification_ptr_get_ntfnMsgIdentifier(ntfnPtr);


### PR DESCRIPTION
# Fastpath for signalling a notification
* Add assembly hook to invoke `c_handle_fastpath_signal` in `trap.S`
* Execute `fastpath_signal` if fastpath checks succeed
* TODO: Do not invoke the scheduler when signalling and switching to a higher priority thread