### PR TITLE
 Sub PR2.1 (Synchronise master kernel and abstract model)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -22,9 +22,14 @@ description indicates whether it is SOURCE-COMPATIBLE, BINARY-COMPATIBLE, or BRE
 Further information about [seL4 releases](https://docs.sel4.systems/sel4_release/) is available.
 
 ---
-Upcoming release: BINARY COMPATIBLE
+Upcoming release: BREAKING
 
 ## Changes
+
+* Scheduling contexts can be configured as constant-bandwidth or sporadic server
+  - Constant bandwidth observes a continuous constant bandwidth of budget/period
+  - Sporadic server behaves as described by Sprunt et. al.
+  - In an overcommitted system, sporadic preserves accumulated time
 
 
 ## Upgrade Notes

--- a/include/kernel/sporadic.h
+++ b/include/kernel/sporadic.h
@@ -144,6 +144,25 @@ static inline bool_t sc_released(sched_context_t *sc)
     }
 }
 
+/*
+ * Return true if a SC's available refills should be delayed at the
+ * point the associated thread becomes runnable (sporadic server).
+ */
+static inline bool_t sc_sporadic(sched_context_t *sc)
+{
+    return sc != NULL && sc->scSporadic;
+}
+
+/*
+ * Return true if a SC's available refills should be delayed at the
+ * point the associated thread becomes the current thread (constant
+ * bandwidth).
+ */
+static inline bool_t sc_constant_bandwidth(sched_context_t *sc)
+{
+    return !sc->scSporadic;
+}
+
 /* Create a new refill in a non-active sc */
 #ifdef ENABLE_SMP_SUPPORT
 void refill_new(sched_context_t *sc, word_t max_refills, ticks_t budget, ticks_t period, word_t core);

--- a/include/object/structures.h
+++ b/include/object/structures.h
@@ -373,6 +373,10 @@ struct sched_context {
     word_t scRefillHead;
     /* Index of the tail of the refill circular buffer */
     word_t scRefillTail;
+
+    /* Whether to apply constant-bandwidth/sliding-window constraint
+     * rather than only sporadic server constraints */
+    bool_t scSporadic;
 };
 
 struct reply {

--- a/libsel4/include/interfaces/sel4.xml
+++ b/libsel4/include/interfaces/sel4.xml
@@ -644,7 +644,7 @@
 
     <interface name="seL4_SchedControl">
 
-        <method id="SchedControlConfigure" name="Configure" manual_name="Configure" manual_label="schedcontrol_configure" condition="defined(CONFIG_KERNEL_MCS)">
+        <method id="SchedControlConfigureFlags" name="ConfigureFlags" manual_name="ConfigureFlags" manual_label="schedcontrol_configureflags" condition="defined(CONFIG_KERNEL_MCS)">
             <brief>
                 Set the parameters of a scheduling context by invoking the scheduling control capability. If the scheduling context is bound to a currently running thread, the parameters will take effect immediately: that is the current budget will be increased or reduced by the difference between the new and previous budget and the replenishment time will be updated according to any difference in the period. This can result in active threads being post-poned or released depending on the nature of the parameter change and the state of the thread. Additionally, if the scheduling context was previously empty (no budget) but bound to a runnable thread, this can result in a thread running for the first time since it now has access to CPU time. This call will return seL4 Invalid Argument if the parameters are too small (smaller than the kernel WCET for this platform) or too large (will overflow the timer).
             </brief>
@@ -662,6 +662,8 @@
                 description="Number of extra sporadic replenishments this scheduling context should use. Ignored for round-robin threads."/>
             <param dir="in" name="badge" type="seL4_Word"
                 description="Identifier for this scheduling context. Delivered to timeout exception handler. Can be used to determine which scheduling context triggered the timeout." />
+            <param dir="in" name="flags" type="seL4_Word"
+                description="Bitwise OR'd set of seL4_SchedContextFlag." />
         </method>
 
     </interface>

--- a/libsel4/include/sel4/constants.h
+++ b/libsel4/include/sel4/constants.h
@@ -93,6 +93,14 @@ static inline seL4_Word seL4_MaxExtraRefills(seL4_Word size)
     return (LIBSEL4_BIT(size) -  seL4_CoreSchedContextBytes) / seL4_RefillSizeBytes;
 }
 #endif /* !__ASSEMBLER__ */
+
+/* Flags to be used with seL4_SchedControl_ConfigureFlags */
+typedef enum {
+    seL4_SchedContext_NoFlag = 0x0,
+    seL4_SchedContext_Sporadic = 0x1,
+    SEL4_FORCE_LONG_ENUM(seL4_SchedContextFlag),
+} seL4_SchedContextFlag;
+
 #endif /* CONFIG_KERNEL_MCS */
 
 #ifdef CONFIG_KERNEL_INVOCATION_REPORT_ERROR_IPC

--- a/libsel4/include/sel4/sel4.h
+++ b/libsel4/include/sel4/sel4.h
@@ -14,6 +14,7 @@
 
 #include <sel4/invocation.h>
 #include <interfaces/sel4_client.h>
+#include <sel4/virtual_client.h>
 
 #include <sel4/bootinfo.h>
 #include <sel4/faults.h>

--- a/libsel4/include/sel4/virtual_client.h
+++ b/libsel4/include/sel4/virtual_client.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+#include <autoconf.h>
+#include <sel4/types.h>
+#include <sel4/macros.h>
+#include <sel4/invocation.h>
+#include <sel4/constants.h>
+#include <interfaces/sel4_client.h>
+
+/*
+ * This file specifies virtual implementations of older invocations
+ * that can be aliased directly to new invocations.
+ */
+
+#ifdef CONFIG_KERNEL_MCS
+LIBSEL4_INLINE seL4_Error seL4_SchedControl_Configure(seL4_SchedControl _service, seL4_SchedContext schedcontext,
+                                                      seL4_Time budget, seL4_Time period, seL4_Word extra_refills, seL4_Word badge)
+{
+    return seL4_SchedControl_ConfigureFlags(_service, schedcontext, budget, period, extra_refills, badge,
+                                            seL4_SchedContext_NoFlag);
+}
+#endif

--- a/manual/parts/threads.tex
+++ b/manual/parts/threads.tex
@@ -200,8 +200,15 @@ invoke the appropriate \obj{SchedControl} capability, which provides access to C
 on a single node.  A scheduling control cap for each node is provided to the initial task at run
 time.  Threads run on the node that their scheduling context is configured for.  Scheduling context
 parameters can then be set and updated using
-\apifunc{seL4\_SchedControl\_Configure}{schedcontrol_configure}, which allows the budget and period
-to be specified.
+\apifunc{seL4\_SchedControl\_ConfigureFlags}{schedcontrol_configureflags}, which allows the budget and period
+to be specified along with a bitwise OR'd set of the following flags.
+
+\begin{description}
+
+\item[seL4\_SchedContext\_Sporadic]: constrain the execution time only according to the
+sporadic server algorithm rather than to a continuous constant bandwidth.
+
+\end{description}
 
 The kernel does not conduct any schedulability tests, as task admission is left to user-level policy
 and can be conducted online or offline, statically or dynamically or not at all.

--- a/src/object/endpoint.c
+++ b/src/object/endpoint.c
@@ -103,6 +103,9 @@ void sendIPC(bool_t blocking, bool_t do_call, word_t badge,
         assert(dest->tcbSchedContext == NULL || refill_sufficient(dest->tcbSchedContext, 0));
         assert(dest->tcbSchedContext == NULL || refill_ready(dest->tcbSchedContext));
         setThreadState(dest, ThreadState_Running);
+        if (sc_sporadic(dest->tcbSchedContext) && dest->tcbSchedContext != NODE_STATE(ksCurSC)) {
+            refill_unblock_check(dest->tcbSchedContext);
+        }
         possibleSwitchTo(dest);
 #else
         bool_t replyCanGrant = thread_state_ptr_get_blockingIPCCanGrant(&dest->tcbState);;
@@ -233,6 +236,11 @@ void receiveIPC(tcb_t *thread, cap_t cap, bool_t isBlocking)
             do_call = thread_state_ptr_get_blockingIPCIsCall(&sender->tcbState);
 
 #ifdef CONFIG_KERNEL_MCS
+            if (sc_sporadic(sender->tcbSchedContext)) {
+                assert(sender->tcbSchedContext != NODE_STATE(ksCurSC));
+                refill_unblock_check(sender->tcbSchedContext);
+            }
+
             if (do_call ||
                 seL4_Fault_get_seL4_FaultType(sender->tcbFault) != seL4_Fault_NullFault) {
                 if ((canGrant || canGrantReply) && replyPtr != NULL) {
@@ -385,6 +393,10 @@ void cancelAllIPC(endpoint_t *epptr)
             }
             if (seL4_Fault_get_seL4_FaultType(thread->tcbFault) == seL4_Fault_NullFault) {
                 setThreadState(thread, ThreadState_Restart);
+                if (sc_sporadic(thread->tcbSchedContext)) {
+                    assert(thread->tcbSchedContext != NODE_STATE(ksCurSC));
+                    refill_unblock_check(thread->tcbSchedContext);
+                }
                 possibleSwitchTo(thread);
             } else {
                 setThreadState(thread, ThreadState_Inactive);
@@ -430,6 +442,10 @@ void cancelBadgedSends(endpoint_t *epptr, word_t badge)
                 if (seL4_Fault_get_seL4_FaultType(thread->tcbFault) ==
                     seL4_Fault_NullFault) {
                     setThreadState(thread, ThreadState_Restart);
+                    if (sc_sporadic(thread->tcbSchedContext)) {
+                        assert(thread->tcbSchedContext != NODE_STATE(ksCurSC));
+                        refill_unblock_check(thread->tcbSchedContext);
+                    }
                     possibleSwitchTo(thread);
                 } else {
                     setThreadState(thread, ThreadState_Inactive);

--- a/src/object/notification.c
+++ b/src/object/notification.c
@@ -45,14 +45,6 @@ static inline void maybeDonateSchedContext(tcb_t *tcb, notification_t *ntfnPtr)
         sched_context_t *sc = SC_PTR(notification_ptr_get_ntfnSchedContext(ntfnPtr));
         if (sc != NULL && sc->scTcb == NULL) {
             schedContext_donate(sc, tcb);
-            if (sc != NODE_STATE(ksCurSC)) {
-                /* refill_unblock_check should not be called on the
-                 * current SC as it is already running. The current SC
-                 * may have been bound to a notificaiton object if the
-                 * current thread was deleted in a long-running deletion
-                 * that became preempted. */
-                refill_unblock_check(sc);
-            }
             schedContext_resume(sc);
         }
     }

--- a/src/object/schedcontext.c
+++ b/src/object/schedcontext.c
@@ -286,7 +286,7 @@ void schedContext_bindTCB(sched_context_t *sc, tcb_t *tcb)
 
     SMP_COND_STATEMENT(migrateTCB(tcb, sc->scCore));
 
-    if (sc_sporadic(sc) && sc_active(sc)) {
+    if (sc_sporadic(sc) && sc_active(sc) && sc != NODE_STATE(ksCurSC)) {
         refill_unblock_check(sc);
     }
     schedContext_resume(sc);

--- a/src/object/schedcontext.c
+++ b/src/object/schedcontext.c
@@ -181,7 +181,6 @@ static exception_t invokeSchedContext_YieldTo(sched_context_t *sc, word_t *buffe
 
     bool_t return_now = true;
     if (isSchedulable(sc->scTcb)) {
-        refill_unblock_check(sc);
         if (SMP_COND_STATEMENT(sc->scCore != getCurrentCPUIndex() ||)
             sc->scTcb->tcbPriority < NODE_STATE(ksCurThread)->tcbPriority) {
             tcbSchedDequeue(sc->scTcb);

--- a/src/object/schedcontext.c
+++ b/src/object/schedcontext.c
@@ -286,6 +286,9 @@ void schedContext_bindTCB(sched_context_t *sc, tcb_t *tcb)
 
     SMP_COND_STATEMENT(migrateTCB(tcb, sc->scCore));
 
+    if (sc_sporadic(sc) && sc_active(sc)) {
+        refill_unblock_check(sc);
+    }
     schedContext_resume(sc);
     if (isSchedulable(tcb)) {
         SCHED_ENQUEUE(tcb);


### PR DESCRIPTION
This PR is a variant of https://github.com/seL4/seL4/pull/312 that only focuses on the changes to introduce a flag on scheduling context objects to control sporadic refill behavior.  The new option allows a sporadic SC to accumulate any time missed while it is preempted by a higher priority task. 

