### PR TITLE
trivial: Make the branch easier to understand.

### DIFF
--- a/src/kernel/cspace.c
+++ b/src/kernel/cspace.c
@@ -171,7 +171,7 @@ resolveAddressBits_ret_t resolveAddressBits(cap_t nodeCap, cptr_t capptr, word_t
         offset = (capptr >> (n_bits - levelBits)) & MASK(radixBits);
         slot = CTE_PTR(cap_cnode_cap_get_capCNodePtr(nodeCap)) + offset;
 
-        if (likely(n_bits <= levelBits)) {
+        if (likely(n_bits == levelBits)) {
             ret.status = EXCEPTION_NONE;
             ret.slot = slot;
             ret.bitsRemaining = 0;


### PR DESCRIPTION
It's impossible for "n_bits < levelBits", because a few lines above, it
has already judged this case and would have returned with error:

        if (unlikely(levelBits > n_bits)) {
            current_lookup_fault =
                lookup_fault_depth_mismatch_new(levelBits, n_bits);
            ret.status = EXCEPTION_LOOKUP_FAULT;
            return ret;
        }

Signed-off-by: Bao Haojun <baohaojun@lixiang.com>