### PR TITLE
Fastpath for signalling a notification on MCS kernel

### DIFF
--- a/config.cmake
+++ b/config.cmake
@@ -255,13 +255,11 @@ config_string(
     UNQUOTE
 )
 
-
 config_string(
     KernelSignalFastpath SIGNAL_FASTPATH
     "Enable notification signal fastpath"
     DEFAULT OFF
     DEPENDS "KernelIsMCS" UNDEF_DISABLED
-    DEPENDS "${KernelNumDomains} EQUAL 1"
 )
 
 find_file(

--- a/config.cmake
+++ b/config.cmake
@@ -248,6 +248,7 @@ config_string(
     UNQUOTE
 )
 config_option(KernelFastpath FASTPATH "Enable IPC fastpath" DEFAULT ON)
+config_option(KernelSignalFastpath SIGNAL_FASTPATH "Enable notification signal fastpath" DEFAULT OFF)
 
 config_string(
     KernelNumDomains NUM_DOMAINS "The number of scheduler domains in the system"

--- a/config.cmake
+++ b/config.cmake
@@ -248,12 +248,20 @@ config_string(
     UNQUOTE
 )
 config_option(KernelFastpath FASTPATH "Enable IPC fastpath" DEFAULT ON)
-config_option(KernelSignalFastpath SIGNAL_FASTPATH "Enable notification signal fastpath" DEFAULT OFF)
 
 config_string(
     KernelNumDomains NUM_DOMAINS "The number of scheduler domains in the system"
     DEFAULT 1
     UNQUOTE
+)
+
+
+config_string(
+    KernelSignalFastpath SIGNAL_FASTPATH
+    "Enable notification signal fastpath"
+    DEFAULT OFF
+    DEPENDS "KernelIsMCS" UNDEF_DISABLED
+    DEPENDS "${KernelNumDomains} EQUAL 1"
 )
 
 find_file(

--- a/include/arch/arm/arch/fastpath/fastpath.h
+++ b/include/arch/arm/arch/fastpath/fastpath.h
@@ -15,7 +15,7 @@ void slowpath(syscall_t syscall)
 NORETURN;
 
 static inline
-void fastpath_signal(cap_t cap)
+void fastpath_signal(word_t cptr)
 NORETURN;
 
 static inline

--- a/include/arch/arm/arch/fastpath/fastpath.h
+++ b/include/arch/arm/arch/fastpath/fastpath.h
@@ -15,7 +15,7 @@ void slowpath(syscall_t syscall)
 NORETURN;
 
 static inline
-void fastpath_signal(word_t cptr)
+void fastpath_signal(word_t cptr, word_t msgInfo)
 NORETURN;
 
 static inline

--- a/include/arch/arm/arch/fastpath/fastpath.h
+++ b/include/arch/arm/arch/fastpath/fastpath.h
@@ -15,6 +15,10 @@ void slowpath(syscall_t syscall)
 NORETURN;
 
 static inline
+void fastpath_signal(cap_t cap)
+NORETURN;
+
+static inline
 void fastpath_call(word_t cptr, word_t r_msgInfo)
 NORETURN;
 

--- a/include/arch/arm/arch/kernel/traps.h
+++ b/include/arch/arm/arch/kernel/traps.h
@@ -29,7 +29,7 @@ VISIBLE SECTION(".vectors.text");
 void c_handle_fastpath_call(word_t cptr, word_t msgInfo)
 VISIBLE SECTION(".vectors.text");
 
-void c_handle_fastpath_signal(word_t cptr, word_t msgInfo, syscall_t syscall)
+void c_handle_fastpath_signal(word_t cptr, word_t msgInfo)
 VISIBLE SECTION(".vectors.text");
 
 #ifdef CONFIG_KERNEL_MCS

--- a/include/arch/arm/arch/kernel/traps.h
+++ b/include/arch/arm/arch/kernel/traps.h
@@ -29,6 +29,9 @@ VISIBLE SECTION(".vectors.text");
 void c_handle_fastpath_call(word_t cptr, word_t msgInfo)
 VISIBLE SECTION(".vectors.text");
 
+void c_handle_fastpath_signal(word_t cptr, word_t msgInfo, syscall_t syscall)
+VISIBLE SECTION(".vectors.text");
+
 #ifdef CONFIG_KERNEL_MCS
 void c_handle_fastpath_reply_recv(word_t cptr, word_t msgInfo, word_t reply)
 #else

--- a/include/arch/x86/arch/fastpath/fastpath.h
+++ b/include/arch/x86/arch/fastpath/fastpath.h
@@ -18,6 +18,9 @@ static inline int fastpath_reply_cap_check(cap_t cap)
 void slowpath(syscall_t syscall)
 NORETURN;
 
+void fastpath_signal(word_t cptr, word_t r_msgInfo)
+NORETURN;
+
 void fastpath_call(word_t cptr, word_t r_msgInfo)
 NORETURN;
 

--- a/include/object/endpoint.h
+++ b/include/object/endpoint.h
@@ -19,6 +19,12 @@ static inline tcb_queue_t PURE ep_ptr_get_queue(endpoint_t *epptr)
     return queue;
 }
 
+static inline void ep_ptr_set_queue(endpoint_t *epptr, tcb_queue_t queue)
+{
+    endpoint_ptr_set_epQueue_head(epptr, (word_t)queue.head);
+    endpoint_ptr_set_epQueue_tail(epptr, (word_t)queue.end);
+}
+
 #ifdef CONFIG_KERNEL_MCS
 void sendIPC(bool_t blocking, bool_t do_call, word_t badge,
              bool_t canGrant, bool_t canGrantReply, bool_t canDonate, tcb_t *thread,

--- a/include/object/notification.h
+++ b/include/object/notification.h
@@ -8,6 +8,7 @@
 
 #include <types.h>
 #include <object/structures.h>
+#include <object/schedcontext.h>
 
 void sendSignal(notification_t *ntfnPtr, word_t badge);
 void receiveSignal(tcb_t *thread, cap_t cap, bool_t isBlocking);
@@ -36,4 +37,31 @@ static inline void maybeReturnSchedContext(notification_t *ntfnPtr, tcb_t *tcb)
 }
 #endif
 
+#ifdef CONFIG_KERNEL_MCS
+static inline void maybeDonateSchedContext(tcb_t *tcb, notification_t *ntfnPtr)
+{
+    if (tcb->tcbSchedContext == NULL) {
+        sched_context_t *sc = SC_PTR(notification_ptr_get_ntfnSchedContext(ntfnPtr));
+        if (sc != NULL && sc->scTcb == NULL) {
+            schedContext_donate(sc, tcb);
+            if (sc != NODE_STATE(ksCurSC)) {
+                /* refill_unblock_check should not be called on the
+                 * current SC as it is already running. The current SC
+                 * may have been bound to a notificaiton object if the
+                 * current thread was deleted in a long-running deletion
+                 * that became preempted. */
+                refill_unblock_check(sc);
+            }
+            schedContext_resume(sc);
+        }
+    }
+}
 
+static inline void ntfn_set_active(notification_t *ntfnPtr, word_t badge)
+{
+    notification_ptr_set_state(ntfnPtr, NtfnState_Active);
+    notification_ptr_set_ntfnMsgIdentifier(ntfnPtr, badge);
+}
+
+
+#endif

--- a/src/arch/arm/32/traps.S
+++ b/src/arch/arm/32/traps.S
@@ -88,6 +88,8 @@ BEGIN_FUNC(arm_swi_syscall)
 #ifdef CONFIG_FASTPATH
     cmp r7, #SYSCALL_CALL
     beq c_handle_fastpath_call
+    cmp r7, #SYSCALL_SEND
+    beq c_handle_fastpath_signal
     cmp r7, #SYSCALL_REPLY_RECV
 #ifdef CONFIG_KERNEL_MCS
     moveq r2, r6
@@ -96,8 +98,6 @@ BEGIN_FUNC(arm_swi_syscall)
 #endif
 
     mov r2, r7
-    cmp r7, #SYSCALL_SEND
-    beq c_handle_fastpath_signal
     b c_handle_syscall
 
 END_FUNC(arm_swi_syscall)

--- a/src/arch/arm/32/traps.S
+++ b/src/arch/arm/32/traps.S
@@ -96,6 +96,8 @@ BEGIN_FUNC(arm_swi_syscall)
 #endif
 
     mov r2, r7
+    cmp r7, #SYSCALL_SEND
+    beq c_handle_fastpath_signal
     b c_handle_syscall
 
 END_FUNC(arm_swi_syscall)

--- a/src/arch/arm/32/traps.S
+++ b/src/arch/arm/32/traps.S
@@ -88,8 +88,12 @@ BEGIN_FUNC(arm_swi_syscall)
 #ifdef CONFIG_FASTPATH
     cmp r7, #SYSCALL_CALL
     beq c_handle_fastpath_call
+#ifdef CONFIG_KERNEL_MCS
+#ifdef CONFIG_SIGNAL_FASTPATH
     cmp r7, #SYSCALL_SEND
     beq c_handle_fastpath_signal
+#endif /* CONFIG_SIGNAL_FASTPATH */
+#endif /* CONFIG_KERNEL_MCS */
     cmp r7, #SYSCALL_REPLY_RECV
 #ifdef CONFIG_KERNEL_MCS
     moveq r2, r6

--- a/src/arch/arm/64/traps.S
+++ b/src/arch/arm/64/traps.S
@@ -200,8 +200,12 @@ lel_syscall:
 #ifdef CONFIG_FASTPATH
     cmp     x7, #SYSCALL_CALL
     b.eq    c_handle_fastpath_call
+#ifdef CONFIG_KERNEL_MCS
+#ifdef CONFIG_SIGNAL_FASTPATH
     cmp     r7, #SYSCALL_SEND
     beq     c_handle_fastpath_signal
+#endif /* CONFIG_SIGNAL_FASTPATH */
+#endif /* CONFIG_KERNEL_MCS */
     cmp     x7, #SYSCALL_REPLY_RECV
 #ifdef CONFIG_KERNEL_MCS
     mov     x2, x6

--- a/src/arch/arm/64/traps.S
+++ b/src/arch/arm/64/traps.S
@@ -202,7 +202,7 @@ lel_syscall:
     b.eq    c_handle_fastpath_call
 #ifdef CONFIG_KERNEL_MCS
 #ifdef CONFIG_SIGNAL_FASTPATH
-    cmp     r7, #SYSCALL_SEND
+    cmp     x7, #SYSCALL_SEND
     beq     c_handle_fastpath_signal
 #endif /* CONFIG_SIGNAL_FASTPATH */
 #endif /* CONFIG_KERNEL_MCS */

--- a/src/arch/arm/64/traps.S
+++ b/src/arch/arm/64/traps.S
@@ -200,6 +200,8 @@ lel_syscall:
 #ifdef CONFIG_FASTPATH
     cmp     x7, #SYSCALL_CALL
     b.eq    c_handle_fastpath_call
+    cmp     r7, #SYSCALL_SEND
+    beq     c_handle_fastpath_signal
     cmp     x7, #SYSCALL_REPLY_RECV
 #ifdef CONFIG_KERNEL_MCS
     mov     x2, x6

--- a/src/arch/arm/c_traps.c
+++ b/src/arch/arm/c_traps.c
@@ -133,6 +133,14 @@ void VISIBLE c_handle_syscall(word_t cptr, word_t msgInfo, syscall_t syscall)
     ksKernelEntry.is_fastpath = 0;
 #endif /* DEBUG */
 
+    /* TODO: Add checks from fastpath (e.g. valid VTable, etc.) */
+    cap_t cap = lookupCap(NODE_STATE(ksCurThread), cptr).cap;
+    if (syscall == (syscall_t)SysSend && cap_get_capType(cap) == cap_notification_cap) {
+        /* signalling a notification */
+        fastpath_signal(cap);
+        UNREACHABLE();
+    }
+
     slowpath(syscall);
     UNREACHABLE();
 }

--- a/src/arch/arm/c_traps.c
+++ b/src/arch/arm/c_traps.c
@@ -164,7 +164,7 @@ void VISIBLE c_handle_fastpath_signal(word_t cptr, word_t msgInfo)
     ksKernelEntry.is_fastpath = 1;
 #endif /* DEBUG */
 
-    fastpath_signal(cptr);
+    fastpath_signal(cptr, msgInfo);
     UNREACHABLE();
 }
 

--- a/src/arch/arm/c_traps.c
+++ b/src/arch/arm/c_traps.c
@@ -154,7 +154,7 @@ void VISIBLE c_handle_fastpath_call(word_t cptr, word_t msgInfo)
 }
 
 ALIGN(L1_CACHE_LINE_SIZE)
-void VISIBLE c_handle_fastpath_signal(word_t cptr, word_t msgInfo, syscall_t syscall)
+void VISIBLE c_handle_fastpath_signal(word_t cptr, word_t msgInfo)
 {
     NODE_LOCK_SYS;
 
@@ -164,15 +164,7 @@ void VISIBLE c_handle_fastpath_signal(word_t cptr, word_t msgInfo, syscall_t sys
     ksKernelEntry.is_fastpath = 1;
 #endif /* DEBUG */
 
-    /* We land up in here on every SYSCALL_SEND, so we need to check that we are
-     * actually signalling a notification */
-    cap_t cap = lookupCap(NODE_STATE(ksCurThread), cptr).cap;
-    if (cap_get_capType(cap) != cap_notification_cap) {
-        slowpath(syscall);
-        UNREACHABLE();
-    }
-
-    fastpath_signal(cap);
+    fastpath_signal(cptr);
     UNREACHABLE();
 }
 

--- a/src/arch/arm/c_traps.c
+++ b/src/arch/arm/c_traps.c
@@ -153,6 +153,8 @@ void VISIBLE c_handle_fastpath_call(word_t cptr, word_t msgInfo)
     UNREACHABLE();
 }
 
+#ifdef CONFIG_KERNEL_MCS
+#ifdef CONFIG_SIGNAL_FASTPATH
 ALIGN(L1_CACHE_LINE_SIZE)
 void VISIBLE c_handle_fastpath_signal(word_t cptr, word_t msgInfo)
 {
@@ -167,6 +169,8 @@ void VISIBLE c_handle_fastpath_signal(word_t cptr, word_t msgInfo)
     fastpath_signal(cptr, msgInfo);
     UNREACHABLE();
 }
+#endif /* CONFIG_SIGNAL_FASTPATH */
+#endif /* CONFIG_KERNEL_MCS */
 
 ALIGN(L1_CACHE_LINE_SIZE)
 #ifdef CONFIG_KERNEL_MCS

--- a/src/arch/riscv/c_traps.c
+++ b/src/arch/riscv/c_traps.c
@@ -176,6 +176,12 @@ void VISIBLE NORETURN c_handle_syscall(word_t cptr, word_t msgInfo, word_t unuse
 #endif
         UNREACHABLE();
     }
+#ifdef CONFIG_KERNEL_MCS
+    else if (syscall == (syscall_t)SysSend) {
+        fastpath_signal(cptr, msgInfo);
+        UNREACHABLE();
+    }
+#endif /* CONFIG_KERNEL_MCS */
 #endif /* CONFIG_FASTPATH */
     slowpath(syscall);
     UNREACHABLE();

--- a/src/arch/riscv/c_traps.c
+++ b/src/arch/riscv/c_traps.c
@@ -177,10 +177,12 @@ void VISIBLE NORETURN c_handle_syscall(word_t cptr, word_t msgInfo, word_t unuse
         UNREACHABLE();
     }
 #ifdef CONFIG_KERNEL_MCS
+#ifdef CONFIG_SIGNAL_FASTPATH
     else if (syscall == (syscall_t)SysSend) {
         fastpath_signal(cptr, msgInfo);
         UNREACHABLE();
     }
+#endif /* CONFIG_SIGNAL_FASTPATH */
 #endif /* CONFIG_KERNEL_MCS */
 #endif /* CONFIG_FASTPATH */
     slowpath(syscall);

--- a/src/arch/x86/c_traps.c
+++ b/src/arch/x86/c_traps.c
@@ -179,6 +179,12 @@ void VISIBLE NORETURN c_handle_syscall(word_t cptr, word_t msgInfo, syscall_t sy
 #endif
         UNREACHABLE();
     }
+#ifdef CONFIG_KERNEL_MCS
+    else if (syscall == (syscall_t)SysSend) {
+        fastpath_signal(cptr, msgInfo);
+        UNREACHABLE();
+    }
+#endif /* CONFIG_KERNEL_MCS */
 #endif /* CONFIG_FASTPATH */
     slowpath(syscall);
     UNREACHABLE();

--- a/src/arch/x86/c_traps.c
+++ b/src/arch/x86/c_traps.c
@@ -180,10 +180,12 @@ void VISIBLE NORETURN c_handle_syscall(word_t cptr, word_t msgInfo, syscall_t sy
         UNREACHABLE();
     }
 #ifdef CONFIG_KERNEL_MCS
+#ifdef CONFIG_SIGNAL_FASTPATH
     else if (syscall == (syscall_t)SysSend) {
         fastpath_signal(cptr, msgInfo);
         UNREACHABLE();
     }
+#endif /* CONFIG_SIGNAL_FASTPATH */
 #endif /* CONFIG_KERNEL_MCS */
 #endif /* CONFIG_FASTPATH */
     slowpath(syscall);

--- a/src/fastpath/fastpath.c
+++ b/src/fastpath/fastpath.c
@@ -27,6 +27,7 @@ void NORETURN fastpath_signal(cap_t cap)
     notification_t *ntfnPtr = NTFN_PTR(cap_notification_cap_get_capNtfnPtr(cap));
     uint32_t ntfnState = notification_ptr_get_state(ntfnPtr);
     word_t badge = cap_notification_cap_get_capNtfnBadge(cap);
+
     switch (ntfnState) {
         case NtfnState_Active: {
             word_t badge2 = notification_ptr_get_ntfnMsgIdentifier(ntfnPtr);

--- a/src/fastpath/fastpath.c
+++ b/src/fastpath/fastpath.c
@@ -39,18 +39,13 @@ void NORETURN fastpath_signal(word_t cptr, word_t msgInfo)
     /* Lookup the cap */
     cap_t cap = lookup_fp(TCB_PTR_CTE_PTR(NODE_STATE(ksCurThread), tcbCTable)->cap, cptr);
 
-    /* Check there's no saved fault */
-    if (unlikely(fault_type != seL4_Fault_NullFault)) {
-        slowpath(SysSend);
-    }
-
     /* Check it's a notification */
     if (!cap_capType_equals(cap, cap_notification_cap)) {
         slowpath(SysSend);
     }
 
-    /* Check that we are allowed to signal this notification */
-    if (!unlikely(cap_notification_cap_get_capNtfnCanSend(cap))) {
+    /* Check there's no saved fault, and that we're allowed to signal this notification */
+    if (unlikely(fault_type != seL4_Fault_NullFault || !cap_notification_cap_get_capNtfnCanSend(cap))) {
         slowpath(SysSend);
     }
 

--- a/src/fastpath/fastpath.c
+++ b/src/fastpath/fastpath.c
@@ -33,16 +33,16 @@ void NORETURN fastpath_signal(word_t cptr, word_t msgInfo)
     /* Get fault type. */
     fault_type = seL4_Fault_get_seL4_FaultType(NODE_STATE(ksCurThread)->tcbFault);
 
-    /* Check there's no saved fault */
-    if (unlikely(fault_type != seL4_Fault_NullFault)) {
-        slowpath(SysSend);
-    }
-
     /* We land up in here on every SYSCALL_SEND, so we need to check that we are
      * actually signalling a notification */
 
     /* Lookup the cap */
     cap_t cap = lookup_fp(TCB_PTR_CTE_PTR(NODE_STATE(ksCurThread), tcbCTable)->cap, cptr);
+
+    /* Check there's no saved fault */
+    if (unlikely(fault_type != seL4_Fault_NullFault)) {
+        slowpath(SysSend);
+    }
 
     /* Check it's a notification */
     if (!cap_capType_equals(cap, cap_notification_cap)) {

--- a/src/fastpath/fastpath.c
+++ b/src/fastpath/fastpath.c
@@ -136,7 +136,7 @@ void NORETURN fastpath_signal(word_t cptr, word_t msgInfo)
 
                     thread_state_ptr_set_tsType_np(&tcb->tcbState, ThreadState_Running);
                     setRegister(tcb, badgeRegister, badge);
-                    if (ksCurThread->tcbPriority < tcb->tcbPriority) {
+                    if (NODE_STATE(ksCurThread)->tcbPriority < tcb->tcbPriority) {
                         /* switch to waiter immediately */
                         SCHED_ENQUEUE_CURRENT_TCB;
                         switchToThread_fp(tcb, cap_pd, stored_hw_asid);
@@ -253,7 +253,7 @@ void NORETURN fastpath_signal(word_t cptr, word_t msgInfo)
 
         thread_state_ptr_set_tsType_np(&dest->tcbState, ThreadState_Running);
         setRegister(dest, badgeRegister, badge);
-        if (ksCurThread->tcbPriority < dest->tcbPriority) {
+        if (NODE_STATE(ksCurThread)->tcbPriority < dest->tcbPriority) {
             /* switch to waiter immediately */
             SCHED_ENQUEUE_CURRENT_TCB;
             switchToThread_fp(dest, cap_pd, stored_hw_asid);

--- a/src/fastpath/fastpath.c
+++ b/src/fastpath/fastpath.c
@@ -149,8 +149,9 @@ void NORETURN fastpath_signal(word_t cptr, word_t msgInfo)
                 notification_ptr_set_state(ntfnPtr, NtfnState_Idle);
             }
 
-            setThreadState(dest, ThreadState_Running);
-            setRegister(dest, badgeRegister, badge);
+            /* Using thread_state_ptr_set_tsType_np instead */
+            // setThreadState(dest, ThreadState_Running);
+            // setRegister(dest, badgeRegister, badge);
 
             /* It looks like the threads in sel4bench do have scheduling contexts,
                so this path isn't taken in sel4bench */

--- a/src/fastpath/fastpath.c
+++ b/src/fastpath/fastpath.c
@@ -129,7 +129,7 @@ void NORETURN fastpath_signal(word_t cptr, word_t msgInfo)
                         NODE_STATE(ksCurSC) = NODE_STATE(ksCurThread)->tcbSchedContext;
                     } else {
                         /* continue executing signaller */
-                        SCHED_APPEND(tcb);
+                        SCHED_ENQUEUE(tcb);
                     }
                     fastpath_restore(badge, msgInfo, NODE_STATE(ksCurThread));
                     UNREACHABLE();
@@ -228,7 +228,7 @@ void NORETURN fastpath_signal(word_t cptr, word_t msgInfo)
             NODE_STATE(ksCurSC) = NODE_STATE(ksCurThread)->tcbSchedContext;
         } else {
             /* continue executing signaller */
-            SCHED_APPEND(dest);
+            SCHED_ENQUEUE(dest);
         }
         fastpath_restore(badge, msgInfo, NODE_STATE(ksCurThread));
         UNREACHABLE();

--- a/src/fastpath/fastpath.c
+++ b/src/fastpath/fastpath.c
@@ -86,6 +86,24 @@ void NORETURN fastpath_signal(word_t cptr, word_t msgInfo)
                     stored_hw_asid = cap_pd[PD_ASID_SLOT];
 #endif
 
+#ifdef CONFIG_ARCH_X86_64
+                    /* borrow the stored_hw_asid for PCID */
+                    stored_hw_asid.words[0] = cap_pml4_cap_get_capPML4MappedASID_fp(newVTable);
+#endif
+
+#ifdef CONFIG_ARCH_IA32
+                    /* stored_hw_asid is unused on ia32 fastpath, but gets passed into a function below. */
+                    stored_hw_asid.words[0] = 0;
+#endif
+#ifdef CONFIG_ARCH_AARCH64
+                    stored_hw_asid.words[0] = cap_vtable_root_get_mappedASID(newVTable);
+#endif
+
+#ifdef CONFIG_ARCH_RISCV
+                    /* Get HW ASID */
+                    stored_hw_asid.words[0] = cap_page_table_cap_get_capPTMappedASID(newVTable);
+#endif
+
                     /* Let gcc optimise this out for 1 domain */
                     dom = maxDom ? ksCurDomain : 0;
                     /* Ensure only the idle thread or lower prio threads are present in the scheduler */
@@ -183,6 +201,24 @@ void NORETURN fastpath_signal(word_t cptr, word_t msgInfo)
 #ifdef CONFIG_ARCH_AARCH32
             /* Get HW ASID */
             stored_hw_asid = cap_pd[PD_ASID_SLOT];
+#endif
+
+#ifdef CONFIG_ARCH_X86_64
+                    /* borrow the stored_hw_asid for PCID */
+                    stored_hw_asid.words[0] = cap_pml4_cap_get_capPML4MappedASID_fp(newVTable);
+#endif
+
+#ifdef CONFIG_ARCH_IA32
+                    /* stored_hw_asid is unused on ia32 fastpath, but gets passed into a function below. */
+                    stored_hw_asid.words[0] = 0;
+#endif
+#ifdef CONFIG_ARCH_AARCH64
+                    stored_hw_asid.words[0] = cap_vtable_root_get_mappedASID(newVTable);
+#endif
+
+#ifdef CONFIG_ARCH_RISCV
+                    /* Get HW ASID */
+                    stored_hw_asid.words[0] = cap_page_table_cap_get_capPTMappedASID(newVTable);
 #endif
 
             /* Let gcc optimise this out for 1 domain */

--- a/src/fastpath/fastpath.c
+++ b/src/fastpath/fastpath.c
@@ -25,17 +25,16 @@ FORCE_INLINE
 void NORETURN fastpath_signal(word_t cptr, word_t msgInfo)
 {
     seL4_MessageInfo_t info;
-    word_t length;
+    //word_t length;
     cap_t newVTable;
     vspace_root_t *cap_pd;
     pde_t stored_hw_asid;
     word_t fault_type;
     dom_t dom;
 
-
     /* Get message info, length, and fault type. */
     info = messageInfoFromWord_raw(msgInfo);
-    length = seL4_MessageInfo_get_length(info);
+    //length = seL4_MessageInfo_get_length(info);
     fault_type = seL4_Fault_get_seL4_FaultType(NODE_STATE(ksCurThread)->tcbFault);
 
     /* Check there's no extra caps, the length is ok and there's no
@@ -195,6 +194,11 @@ void NORETURN fastpath_signal(word_t cptr, word_t msgInfo)
                 slowpath(SysSend);
             }
 
+            /* Check that we are allowed to signal this notification */
+            if (!unlikely(cap_notification_cap_get_capNtfnCanSend(cap))) {
+                slowpath(SysSend);
+            }
+
 #ifdef CONFIG_ARCH_AARCH32
             if (unlikely(!pde_pde_invalid_get_stored_asid_valid(stored_hw_asid))) {
                 slowpath(SysSend);
@@ -222,7 +226,7 @@ void NORETURN fastpath_signal(word_t cptr, word_t msgInfo)
 #endif
 
             /* TODO: Probably not necessary */
-            fastpath_copy_mrs(length, NODE_STATE(ksCurThread), dest);
+            //fastpath_copy_mrs(length, NODE_STATE(ksCurThread), dest);
 
             /* TODO: Figure out why this hangs during scheduler benchmarks */
 
@@ -246,7 +250,6 @@ void NORETURN fastpath_signal(word_t cptr, word_t msgInfo)
             //restore_user_context();
         }
     }
-    /* TODO: Why does fastpath_call not need this as well? */
     UNREACHABLE();
 }
 

--- a/src/fastpath/fastpath.c
+++ b/src/fastpath/fastpath.c
@@ -6,10 +6,6 @@
 
 #include <config.h>
 #include <fastpath/fastpath.h>
-#ifdef CONFIG_KERNEL_MCS
-#include <object/reply.h>
-#include <object/notification.h>
-#endif
 
 #ifdef CONFIG_BENCHMARK_TRACK_KERNEL_ENTRIES
 #include <benchmark/benchmark_track.h>
@@ -71,7 +67,7 @@ void NORETURN fastpath_signal(word_t cptr, word_t msgInfo)
             if (tcb) {
                 if (thread_state_ptr_get_tsType(&tcb->tcbState) == ThreadState_BlockedOnReceive) {
                     /* Send and start thread running */
-                    cancelIPC(tcb);
+                    cancelIPC_fp(tcb);
                     maybeDonateSchedContext(tcb, ntfnPtr);
 
                     /* Get destination thread VTable */

--- a/src/fastpath/fastpath.c
+++ b/src/fastpath/fastpath.c
@@ -77,8 +77,6 @@ void NORETURN fastpath_signal(word_t cptr, word_t msgInfo)
                 if (thread_state_ptr_get_tsType(&tcb->tcbState) == ThreadState_BlockedOnReceive) {
                     /* Send and start thread running */
                     cancelIPC(tcb);
-                    setThreadState(tcb, ThreadState_Running);
-                    setRegister(tcb, badgeRegister, badge);
                     maybeDonateSchedContext(tcb, ntfnPtr);
 
                     /* Get destination thread VTable */

--- a/src/object/endpoint.c
+++ b/src/object/endpoint.c
@@ -16,12 +16,6 @@
 #include <object/endpoint.h>
 #include <object/tcb.h>
 
-static inline void ep_ptr_set_queue(endpoint_t *epptr, tcb_queue_t queue)
-{
-    endpoint_ptr_set_epQueue_head(epptr, (word_t)queue.head);
-    endpoint_ptr_set_epQueue_tail(epptr, (word_t)queue.end);
-}
-
 #ifdef CONFIG_KERNEL_MCS
 void sendIPC(bool_t blocking, bool_t do_call, word_t badge,
              bool_t canGrant, bool_t canGrantReply, bool_t canDonate, tcb_t *thread, endpoint_t *epptr)

--- a/src/object/notification.c
+++ b/src/object/notification.c
@@ -32,34 +32,6 @@ static inline void ntfn_ptr_set_queue(notification_t *ntfnPtr, tcb_queue_t ntfn_
     notification_ptr_set_ntfnQueue_tail(ntfnPtr, (word_t)ntfn_queue.end);
 }
 
-static inline void ntfn_set_active(notification_t *ntfnPtr, word_t badge)
-{
-    notification_ptr_set_state(ntfnPtr, NtfnState_Active);
-    notification_ptr_set_ntfnMsgIdentifier(ntfnPtr, badge);
-}
-
-#ifdef CONFIG_KERNEL_MCS
-static inline void maybeDonateSchedContext(tcb_t *tcb, notification_t *ntfnPtr)
-{
-    if (tcb->tcbSchedContext == NULL) {
-        sched_context_t *sc = SC_PTR(notification_ptr_get_ntfnSchedContext(ntfnPtr));
-        if (sc != NULL && sc->scTcb == NULL) {
-            schedContext_donate(sc, tcb);
-            if (sc != NODE_STATE(ksCurSC)) {
-                /* refill_unblock_check should not be called on the
-                 * current SC as it is already running. The current SC
-                 * may have been bound to a notificaiton object if the
-                 * current thread was deleted in a long-running deletion
-                 * that became preempted. */
-                refill_unblock_check(sc);
-            }
-            schedContext_resume(sc);
-        }
-    }
-}
-
-#endif
-
 #ifdef CONFIG_KERNEL_MCS
 #define MCS_DO_IF_SC(tcb, ntfnPtr, _block) \
     maybeDonateSchedContext(tcb, ntfnPtr); \


### PR DESCRIPTION
# Summary
Added a fastpath for signalling a notification on the MCS kernel. Benchmarks run with [sel4bench](https://github.com/seL4/sel4bench) indicate a speedup of signal operations by up to 76% in non-context-switching cases, and up to 56% in context-switching cases

---

# Results

Platform: sabre lite
* quad-core ARM Cortex A9 processor, running at 1GHz
* 1GB of DDR3 RAM @ 532Mhz

## Without Signal Fastpath
```
One way IPC microbenchmarks:
Mean: 314
StdDev: 1
Samples: 16

Signal overhead:
Mean: 7
StdDev: 0
Samples: 100

Signal to high prio thread:
Mean: 1048
StdDev: 170
Samples: 100

Signal to low prio thread:
Mean: 604
StdDev: 6
Samples: 100

Hardware null_syscall thread:
Mean: 121
StdDev: 0
Samples: 100
```

## With Signal Fastpath
```
One way IPC microbenchmarks:
Mean: 315
StdDev: 1
Samples: 16

Signal overhead:
Mean: 7
StdDev: 0
Samples: 100

Signal to high prio thread:
Mean: 485
StdDev: 298
Samples: 100

Signal to low prio thread:
Mean: 136
StdDev: 0
Samples: 100

Hardware null_syscall thread:
Mean: 121
StdDev: 0
Samples: 100
```
