### PR TITLE
riscv: print same kernel boot message as on ARM

### DIFF
--- a/src/arch/riscv/kernel/boot.c
+++ b/src/arch/riscv/kernel/boot.c
@@ -251,6 +251,8 @@ static BOOT_CODE bool_t try_init_kernel(
     /* initialise the CPU */
     init_cpu();
 
+    printf("Bootstrapping kernel\n");
+
     /* initialize the platform */
     init_plat();
 


### PR DESCRIPTION
Align the boot output on RISC-V and ARM. This simplifies test automation, because the boot phase is identical for all ARM and RISC-V boards. No special handling is needed then to detect if the kernel started properly.