### PR TITLE
Defer charging budget after preemption points

### DIFF
--- a/include/kernel/thread.h
+++ b/include/kernel/thread.h
@@ -237,6 +237,16 @@ static inline void updateTimestamp(void)
     NODE_STATE(ksConsumed) += (NODE_STATE(ksCurTime) - prev);
 }
 
+/* if the budget isn't enough, the timeslice for this SC is over. For
+ * round robin threads this is sufficient, however for periodic threads
+ * we also need to check there is space to schedule the replenishment - if the refill
+ * is full then the timeslice is also over as the rest of the budget is forfeit. */
+static inline bool_t isSufficientAndSplittable(void)
+{
+    return refill_sufficient(NODE_STATE(ksCurSC), NODE_STATE(ksConsumed)) && (isRoundRobin(NODE_STATE(ksCurSC))
+                                                                              || !refill_full(NODE_STATE(ksCurSC)));
+}
+
 /* Check if the current thread/domain budget has expired.
  * if it has, bill the thread, add it to the scheduler and
  * set up a reschedule.
@@ -249,13 +259,7 @@ static inline bool_t checkBudget(void)
     /* currently running thread must have available capacity */
     assert(refill_ready(NODE_STATE(ksCurSC)));
 
-    ticks_t capacity = refill_capacity(NODE_STATE(ksCurSC), NODE_STATE(ksConsumed));
-    /* if the budget isn't enough, the timeslice for this SC is over. For
-     * round robin threads this is sufficient, however for periodic threads
-     * we also need to check there is space to schedule the replenishment - if the refill
-     * is full then the timeslice is also over as the rest of the budget is forfeit. */
-    if (likely(capacity >= MIN_BUDGET && (isRoundRobin(NODE_STATE(ksCurSC)) ||
-                                          !refill_full(NODE_STATE(ksCurSC))))) {
+    if (likely(isSufficientAndSplittable())) {
         if (unlikely(isCurDomainExpired())) {
             NODE_STATE(ksReprogram) = true;
             rescheduleRequired();

--- a/src/api/syscall.c
+++ b/src/api/syscall.c
@@ -588,8 +588,13 @@ static inline void mcsPreemptionPoint(irq_t irq)
     } else if (NODE_STATE(ksCurSC)->scRefillMax) {
         /* otherwise, if the thread is not schedulable, the SC could be valid - charge it if so */
         chargeBudget(NODE_STATE(ksConsumed), false, CURRENT_CPU_INDEX(), true);
+    } else {
+        /* If the current SC is no longer configured the time can no
+         * longer be charged to it. Simply dropping the consumed time
+         * here is equivalent to having charged the consumed time and
+         * then having cleared the SC. */
+        NODE_STATE(ksConsumed) = 0;
     }
-
 }
 #else
 #define handleRecv(isBlocking, canReply) handleRecv(isBlocking)

--- a/src/api/syscall.c
+++ b/src/api/syscall.c
@@ -629,8 +629,8 @@ exception_t handleSyscall(syscall_t syscall)
             ret = handleInvocation(false, true, false, false, getRegister(NODE_STATE(ksCurThread), capRegister));
             if (unlikely(ret != EXCEPTION_NONE)) {
                 irq = getActiveIRQ();
+                mcsIRQ(irq);
                 if (IRQT_TO_IRQ(irq) != IRQT_TO_IRQ(irqInvalid)) {
-                    mcsIRQ(irq);
                     handleInterrupt(irq);
                     Arch_finaliseInterrupt();
                 }
@@ -642,8 +642,8 @@ exception_t handleSyscall(syscall_t syscall)
             ret = handleInvocation(false, false, false, false, getRegister(NODE_STATE(ksCurThread), capRegister));
             if (unlikely(ret != EXCEPTION_NONE)) {
                 irq = getActiveIRQ();
+                mcsIRQ(irq);
                 if (IRQT_TO_IRQ(irq) != IRQT_TO_IRQ(irqInvalid)) {
-                    mcsIRQ(irq);
                     handleInterrupt(irq);
                     Arch_finaliseInterrupt();
                 }
@@ -654,8 +654,8 @@ exception_t handleSyscall(syscall_t syscall)
             ret = handleInvocation(true, true, true, false, getRegister(NODE_STATE(ksCurThread), capRegister));
             if (unlikely(ret != EXCEPTION_NONE)) {
                 irq = getActiveIRQ();
+                mcsIRQ(irq);
                 if (IRQT_TO_IRQ(irq) != IRQT_TO_IRQ(irqInvalid)) {
-                    mcsIRQ(irq);
                     handleInterrupt(irq);
                     Arch_finaliseInterrupt();
                 }
@@ -697,8 +697,8 @@ exception_t handleSyscall(syscall_t syscall)
             ret = handleInvocation(false, false, true, true, dest);
             if (unlikely(ret != EXCEPTION_NONE)) {
                 irq = getActiveIRQ();
+                mcsIRQ(irq);
                 if (IRQT_TO_IRQ(irq) != IRQT_TO_IRQ(irqInvalid)) {
-                    mcsIRQ(irq);
                     handleInterrupt(irq);
                     Arch_finaliseInterrupt();
                 }
@@ -712,8 +712,8 @@ exception_t handleSyscall(syscall_t syscall)
             ret = handleInvocation(false, false, true, true, getRegister(NODE_STATE(ksCurThread), replyRegister));
             if (unlikely(ret != EXCEPTION_NONE)) {
                 irq = getActiveIRQ();
+                mcsIRQ(irq);
                 if (IRQT_TO_IRQ(irq) != IRQT_TO_IRQ(irqInvalid)) {
-                    mcsIRQ(irq);
                     handleInterrupt(irq);
                     Arch_finaliseInterrupt();
                 }

--- a/src/model/preemption.c
+++ b/src/model/preemption.c
@@ -28,15 +28,13 @@ exception_t preemptionPoint(void)
      */
     if (ksWorkUnitsCompleted >= CONFIG_MAX_NUM_WORK_UNITS_PER_PREEMPTION) {
         ksWorkUnitsCompleted = 0;
-        if (isIRQPending()) {
-            return EXCEPTION_PREEMPTED;
 #ifdef CONFIG_KERNEL_MCS
-        } else {
-            updateTimestamp();
-            if (!(sc_active(NODE_STATE(ksCurSC)) && isSufficientAndSplittable()) || isCurDomainExpired()) {
-                return EXCEPTION_PREEMPTED;
-            }
+        updateTimestamp();
+        if (!(sc_active(NODE_STATE(ksCurSC)) && isSufficientAndSplittable()) || isCurDomainExpired() || isIRQPending()) {
+#else
+        if (isIRQPending()) {
 #endif
+            return EXCEPTION_PREEMPTED;
         }
     }
 

--- a/src/model/preemption.c
+++ b/src/model/preemption.c
@@ -33,7 +33,7 @@ exception_t preemptionPoint(void)
 #ifdef CONFIG_KERNEL_MCS
         } else {
             updateTimestamp();
-            if (!(sc_active(NODE_STATE(ksCurSC)) && checkBudget())) {
+            if (!(sc_active(NODE_STATE(ksCurSC)) && isSufficientAndSplittable()) || isCurDomainExpired()) {
                 return EXCEPTION_PREEMPTED;
             }
 #endif

--- a/src/model/preemption.c
+++ b/src/model/preemption.c
@@ -33,7 +33,7 @@ exception_t preemptionPoint(void)
 #ifdef CONFIG_KERNEL_MCS
         } else {
             updateTimestamp();
-            if (!checkBudget()) {
+            if (!(sc_active(NODE_STATE(ksCurSC)) && checkBudget())) {
                 return EXCEPTION_PREEMPTED;
             }
 #endif


### PR DESCRIPTION
This introduces a fix from verification, ensuring that we don't charge time to an unconfigured SC, and a change to ease verification efforts.

Rather than perform an `checkBudget` inside a preemption point, we only check whether `checkBudget` would fail and raise an exception if it would. To ensure the check is the same in both `preemptionPoint` and `checkBudget`, the check has been moved to its own function.

If we do move ahead with #312, which would employ only tail merging for splitting rather than merging at the head in some cases, the need to check for a head split would be removed and `isSufficientAndSplittable` can be replaced with a `refill_sufficient` check in both locations.