### PR TITLE
Fixes for accounting time in MCS

### DIFF
--- a/config.cmake
+++ b/config.cmake
@@ -78,7 +78,7 @@ if(DEFINED CONFIGURE_MAX_IRQ)
         math(EXPR BITS "${BITS} + 1")
     endif()
     set(CONFIGURE_IRQ_SLOT_BITS "${BITS}" CACHE INTERNAL "")
-    if(NOT DEFINED ${CONFIGURE_TIMER_PRECISION})
+    if(NOT DEFINED CONFIGURE_TIMER_PRECISION)
         set(CONFIGURE_TIMER_PRECISION "0")
     endif()
     configure_file(

--- a/src/object/schedcontext.c
+++ b/src/object/schedcontext.c
@@ -363,7 +363,7 @@ time_t schedContext_updateConsumed(sched_context_t *sc)
     ticks_t consumed = sc->scConsumed;
     if (consumed >= getMaxTicksToUs()) {
         sc->scConsumed -= getMaxTicksToUs();
-        return getMaxTicksToUs();
+        return ticksToUs(getMaxTicksToUs());
     } else {
         sc->scConsumed = 0;
         return ticksToUs(consumed);

--- a/src/plat/odroidc2/config.cmake
+++ b/src/plat/odroidc2/config.cmake
@@ -25,6 +25,7 @@ if(KernelPlatformOdroidc2)
         CLK_MAGIC 375299969u
         CLK_SHIFT 53u
         KERNEL_WCET 10u
+        TIMER_PRECISION 1u
     )
 endif()
 


### PR DESCRIPTION
Fixes for the `TIMER_PRECISION` and consumed time returned via the syscalls reporting consumed time.