### PR TITLE
mcs: Only unbind extant donated ntfn sc

### DIFF
--- a/include/object/notification.h
+++ b/include/object/notification.h
@@ -24,7 +24,7 @@ static inline void maybeReturnSchedContext(notification_t *ntfnPtr, tcb_t *tcb)
 {
 
     sched_context_t *sc = SC_PTR(notification_ptr_get_ntfnSchedContext(ntfnPtr));
-    if (sc == tcb->tcbSchedContext) {
+    if (sc != NULL && sc == tcb->tcbSchedContext) {
         tcb->tcbSchedContext = NULL;
         sc->scTcb = NULL;
         /* If the current thread returns its sched context then it should not


### PR DESCRIPTION
When determining whether a SC donated from the notification should be
returned, we must ensure not to try and return a NULL SC to a
notification with not bound SC.

This could occur when a passive server performs a NBSendWait/NBSendRecv
with a notification in the receive phase, where the SC for the receiver
was returned in the send phase and the notification has no bound SC.

Signed-off-by: Curtis Millar <curtis.millar@data61.csiro.au>