### PR TITLE
define generic debug_capDL() function

### DIFF
--- a/include/arch/arm/arch/machine/capdl.h
+++ b/include/arch/arm/arch/machine/capdl.h
@@ -6,7 +6,10 @@
 
 #pragma once
 
+#include <config.h>
 #include <machine/capdl.h>
+
+#ifdef CONFIG_PRINTING
 
 #ifdef CONFIG_TK1_SMMU
 static inline void arm_obj_iospace_print_attrs(cap_t iospace_cap)
@@ -20,4 +23,4 @@ static inline void obj_asidpool_print_attrs(cap_t asid_cap)
     printf("(asid_high: 0x%lx)\n", (long unsigned int)ASID_HIGH(cap_asid_pool_cap_get_capASIDBase(asid_cap)));
 }
 
-void capDL(void);
+#endif /* CONFIG_PRINTING */

--- a/include/arch/riscv/arch/machine/capdl.h
+++ b/include/arch/riscv/arch/machine/capdl.h
@@ -6,5 +6,4 @@
 
 #pragma once
 
-void capDL(void);
-
+#include <machine/capdl.h>

--- a/include/arch/x86/arch/machine/capdl.h
+++ b/include/arch/x86/arch/machine/capdl.h
@@ -6,7 +6,10 @@
 
 #pragma once
 
+#include <config.h>
 #include <machine/capdl.h>
+
+#ifdef CONFIG_PRINTING
 
 void x86_obj_ioports_print_attrs(cap_t ioports_cap);
 
@@ -15,4 +18,4 @@ void x86_obj_iospace_print_attrs(cap_t iospace_cap);
 void x86_obj_iopt_print_attrs(cap_t iopt_cap);
 #endif
 
-void capDL(void);
+#endif /* CONFIG_PRINTING */

--- a/include/machine/capdl.h
+++ b/include/machine/capdl.h
@@ -14,8 +14,15 @@ void reset_seen_list(void);
 bool_t seen(cap_t c);
 bool_t same_cap(cap_t a, cap_t b);
 bool_t root_or_idle_tcb(tcb_t *tcb);
+word_t get_tcb_sp(tcb_t *tcb);
 
 /* common */
+void debug_capDL(void);
+
+#endif /* CONFIG_DEBUG_BUILD */
+
+#if defined(CONFIG_DEBUG_BUILD) && defined(CONFIG_PRINTING)
+
 void obj_tcb_print_cnodes(cap_t cnode, tcb_t *tcb);
 void print_caps(void);
 void print_objects(void);
@@ -42,9 +49,9 @@ void print_ipc_buffer_slot(tcb_t *tcb);
  * However, frames can be mapped into multiple locations but sould only be declared once.
  */
 void obj_vtable_print_slots(tcb_t *tcb);
-word_t get_tcb_sp(tcb_t *tcb);
+
 void print_cap_arch(cap_t cap);
 void print_object_arch(cap_t cap);
 void obj_tcb_print_vtable(tcb_t *tcb);
 
-#endif
+#endif /* defined(CONFIG_DEBUG_BUILD) && defined(CONFIG_PRINTING) */

--- a/src/api/syscall.c
+++ b/src/api/syscall.c
@@ -87,13 +87,10 @@ exception_t handleUnknownSyscall(word_t w)
         halt();
     }
     if (w == SysDebugSnapshot) {
-#if defined CONFIG_ARCH_ARM || defined CONFIG_ARCH_X86_64 || defined CONFIG_ARCH_RISCV32
         tcb_t *UNUSED tptr = NODE_STATE(ksCurThread);
-        printf("Debug snapshot syscall from user thread %p \"%s\"\n", tptr, TCB_PTR_DEBUG_PTR(tptr)->tcbName);
-        capDL();
-#else
-        printf("Debug snapshot syscall not supported for the current arch\n");
-#endif
+        printf("Debug snapshot syscall from user thread %p \"%s\"\n",
+               tptr, TCB_PTR_DEBUG_PTR(tptr)->tcbName);
+        debug_capDL();
         return EXCEPTION_NONE;
     }
     if (w == SysDebugCapIdentify) {

--- a/src/arch/arm/32/config.cmake
+++ b/src/arch/arm/32/config.cmake
@@ -11,6 +11,7 @@ add_sources(
     PREFIX src/arch/arm/32
     CFILES
         object/objecttype.c
+        machine/capdl.c
         machine/registerset.c
         machine/fpu.c
         model/statedata.c
@@ -20,5 +21,3 @@ add_sources(
         kernel/vspace.c
     ASMFILES head.S traps.S hyp_traps.S
 )
-
-add_sources(DEP "KernelSel4ArchAarch32;KernelDebugBuild" CFILES src/arch/arm/32/machine/capdl.c)

--- a/src/arch/arm/32/machine/capdl.c
+++ b/src/arch/arm/32/machine/capdl.c
@@ -5,15 +5,23 @@
  */
 
 #include <config.h>
+
+#ifdef CONFIG_DEBUG_BUILD
+
 #include <arch/machine/capdl.h>
 #include <string.h>
 #include <kernel/cspace.h>
 
-#ifdef CONFIG_DEBUG_BUILD
-
 #define MAX_UL          0xffffffff
 #define PT_INDEX(vptr)  ((vptr >> PAGE_BITS) & MASK(PT_INDEX_BITS))
 #define PD_INDEX(vptr)  (vptr >> (PAGE_BITS + PT_INDEX_BITS))
+
+word_t get_tcb_sp(tcb_t *tcb)
+{
+    return tcb->tcbArch.tcbContext.registers[SP];
+}
+
+#ifdef CONFIG_PRINTING
 
 static void obj_frame_print_attrs(resolve_ret_t ret);
 static void cap_frame_print_attrs_pt(pte_t *pte);
@@ -25,10 +33,6 @@ static void arm32_cap_pt_print_slots(pte_t *pt);
 /*
  * Caps
  */
-word_t get_tcb_sp(tcb_t *tcb)
-{
-    return tcb->tcbArch.tcbContext.registers[SP];
-}
 
 /*
  * AP   S   R   Privileged permissions  User permissions
@@ -496,7 +500,9 @@ void obj_tcb_print_vtable(tcb_t *tcb)
     }
 }
 
-void capDL(void)
+#endif /* CONFIG_PRINTING */
+
+void debug_capDL(void)
 {
     printf("arch aarch32\n");
     printf("objects {\n");
@@ -508,10 +514,13 @@ void capDL(void)
     /* reset the seen list */
     reset_seen_list();
 
+#ifdef CONFIG_PRINTING
     print_caps();
     printf("}\n");
 
     obj_irq_print_maps();
+#endif /* CONFIG_PRINTING */
 }
+
 
 #endif /* CONFIG_DEBUG_BUILD */

--- a/src/arch/arm/64/config.cmake
+++ b/src/arch/arm/64/config.cmake
@@ -11,6 +11,7 @@ add_sources(
     PREFIX src/arch/arm/64
     CFILES
         object/objecttype.c
+        machine/capdl.c
         machine/registerset.c
         machine/fpu.c
         model/statedata.c
@@ -20,5 +21,3 @@ add_sources(
         kernel/vspace.c
     ASMFILES head.S traps.S
 )
-
-add_sources(DEP "KernelSel4ArchAarch64;KernelDebugBuild" CFILES src/arch/arm/64/machine/capdl.c)

--- a/src/arch/arm/64/machine/capdl.c
+++ b/src/arch/arm/64/machine/capdl.c
@@ -5,11 +5,19 @@
  */
 
 #include <config.h>
+
+#ifdef CONFIG_DEBUG_BUILD
+
 #include <arch/machine/capdl.h>
 #include <string.h>
 #include <kernel/cspace.h>
 
-#ifdef CONFIG_DEBUG_BUILD
+word_t get_tcb_sp(tcb_t *tcb)
+{
+    return tcb->tcbArch.tcbContext.registers[SP_EL0];
+}
+
+#ifdef CONFIG_PRINTING
 
 static void obj_frame_print_attrs(lookupFrame_ret_t ret);
 static void cap_frame_print_attrs_pud(pude_t *pudSlot);
@@ -27,11 +35,6 @@ static void arm64_obj_pud_print_slots(void *pgdSlot_or_vspace);
 static void arm64_cap_pt_print_slots(pde_t *pdSlot, vptr_t vptr);
 static void arm64_cap_pd_print_slots(pude_t *pudSlot, vptr_t vptr);
 static void arm64_cap_pud_print_slots(void *pgdSlot_or_vspace, vptr_t vptr);
-
-word_t get_tcb_sp(tcb_t *tcb)
-{
-    return tcb->tcbArch.tcbContext.registers[SP_EL0];
-}
 
 /* Stage-1 access permissions:
  * AP[2:1]  higer EL        EL0
@@ -534,7 +537,9 @@ void obj_tcb_print_vtable(tcb_t *tcb)
     }
 }
 
-void capDL(void)
+#endif /* CONFIG_PRINTING */
+
+void debug_capDL(void)
 {
     printf("arch aarch64\n");
     printf("objects {\n");
@@ -546,10 +551,12 @@ void capDL(void)
     /* reset the seen list */
     reset_seen_list();
 
+#ifdef CONFIG_PRINTING
     print_caps();
     printf("}\n");
 
     obj_irq_print_maps();
+#endif /* CONFIG_PRINTING */
 }
 
 #endif /* CONFIG_DEBUG_BUILD */

--- a/src/arch/riscv/config.cmake
+++ b/src/arch/riscv/config.cmake
@@ -90,6 +90,7 @@ add_sources(
         kernel/boot.c
         kernel/thread.c
         kernel/vspace.c
+        machine/capdl.c
         machine/hardware.c
         machine/registerset.c
         machine/io.c
@@ -101,7 +102,5 @@ add_sources(
         smp/ipi.c
     ASMFILES halt.S head.S traps.S
 )
-
-add_sources(DEP "KernelDebugBuild;KernelSel4ArchRiscV32" CFILES src/arch/riscv/machine/capdl.c)
 
 add_bf_source_old("KernelArchRiscV" "structures.bf" "include/arch/riscv" "arch/object")

--- a/src/arch/riscv/machine/capdl.c
+++ b/src/arch/riscv/machine/capdl.c
@@ -11,6 +11,13 @@
 #include <machine/capdl.h>
 #include <arch/machine/capdl.h>
 
+word_t get_tcb_sp(tcb_t *tcb)
+{
+    return tcb->tcbArch.tcbContext.registers[SP];
+}
+
+#ifdef CONFIG_PRINTING
+
 static void obj_asidpool_print_attrs(cap_t asid_cap);
 static void obj_frame_print_attrs(paddr_t paddr);
 static void riscv_obj_pt_print_slots(pte_t *lvl1pt, pte_t *pt, int level);
@@ -80,11 +87,6 @@ void obj_vtable_print_slots(tcb_t *tcb)
         add_to_seen(TCB_PTR_CTE_PTR(tcb, tcbVTable)->cap);
         riscv_cap_pt_print_slots(lvl1pt, 0, CONFIG_PT_LEVELS);
     }
-}
-
-word_t get_tcb_sp(tcb_t *tcb)
-{
-    return tcb->tcbArch.tcbContext.registers[SP];
 }
 
 static void cap_frame_print_attrs_pt(pte_t *ptSlot)
@@ -221,9 +223,11 @@ void obj_tcb_print_vtable(tcb_t *tcb)
     }
 }
 
-void capDL(void)
+#endif /* CONFIG_PRINTING */
+
+void debug_capDL(void)
 {
-    printf("arch riscv32\n");
+    printf("arch riscv\n");
     printf("objects {\n");
     print_objects();
     printf("}\n");
@@ -233,10 +237,12 @@ void capDL(void)
     /* reset the seen list */
     reset_seen_list();
 
+#ifdef CONFIG_PRINTING
     print_caps();
     printf("}\n");
 
     obj_irq_print_maps();
+#endif /* CONFIG_PRINTING */
 }
 
 #endif /* CONFIG_DEBUG_BUILD */

--- a/src/arch/x86/32/machine/capdl.c
+++ b/src/arch/x86/32/machine/capdl.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021, Axel Heider <axelheider@gmx.de>
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include <config.h>
+
+#ifdef CONFIG_DEBUG_BUILD
+
+#include <machine/capdl.h>
+#include <arch/machine/capdl.h>
+
+void debug_capDL(void)
+{
+#ifdef CONFIG_PRINTING
+    printf("Debug CapDL snapshot not full implemented for IA32\n");
+#endif /* CONFIG_PRINTING */
+    /* reset the seen list */
+    reset_seen_list();
+}
+
+#endif /* CONFIG_DEBUG_BUILD */

--- a/src/arch/x86/64/config.cmake
+++ b/src/arch/x86/64/config.cmake
@@ -17,9 +17,8 @@ add_sources(
         kernel/elf.c
         model/statedata.c
         model/smp.c
+        machine/capdl.c
         machine/registerset.c
         smp/ipi.c
     ASMFILES machine_asm.S traps.S head.S
 )
-
-add_sources(DEP "KernelDebugBuild;KernelSel4ArchX86_64" CFILES src/arch/x86/64/machine/capdl.c)

--- a/src/arch/x86/64/machine/capdl.c
+++ b/src/arch/x86/64/machine/capdl.c
@@ -5,11 +5,19 @@
  */
 
 #include <config.h>
+
+#ifdef CONFIG_DEBUG_BUILD
+
 #include <arch/machine/capdl.h>
 #include <string.h>
 #include <kernel/cspace.h>
 
-#ifdef CONFIG_DEBUG_BUILD
+word_t get_tcb_sp(tcb_t *tcb)
+{
+    return tcb->tcbArch.tcbContext.registers[RSP];
+}
+
+#ifdef CONFIG_PRINTING
 
 static void obj_frame_print_attrs(paddr_t paddr, word_t page_size);
 static void _cap_frame_print_attrs_vptr(word_t vptr, vspace_root_t *vspace);
@@ -19,11 +27,6 @@ static void cap_frame_print_attrs_pdpt(pdpte_t *pdptSlot);
 static void cap_frame_print_attrs_pd(pde_t *pdSlot);
 static void cap_frame_print_attrs_pt(pte_t *ptSlot);
 static void cap_frame_print_attrs_impl(word_t super_user, word_t read_write, word_t cache_disabled, word_t xd);
-
-word_t get_tcb_sp(tcb_t *tcb)
-{
-    return tcb->tcbArch.tcbContext.registers[RSP];
-}
 
 /* use when only have access to pte of frames */
 static void cap_frame_print_attrs_pdpt(pdpte_t *pdptSlot)
@@ -474,7 +477,9 @@ void obj_vtable_print_slots(tcb_t *tcb)
     }
 }
 
-void capDL(void)
+#endif /* CONFIG_PRINTING */
+
+void debug_capDL(void)
 {
     printf("arch x86_64\n");
     printf("objects {\n");
@@ -486,10 +491,12 @@ void capDL(void)
     /* reset the seen list */
     reset_seen_list();
 
+#ifdef CONFIG_PRINTING
     print_caps();
     printf("}\n");
 
     obj_irq_print_maps();
+#endif
 }
 
 #endif /* CONFIG_DEBUG_BUILD */

--- a/src/arch/x86/config.cmake
+++ b/src/arch/x86/config.cmake
@@ -378,6 +378,7 @@ add_sources(
         kernel/ept.c
         kernel/thread.c
         model/statedata.c
+        machine/capdl.c
         machine/hardware.c
         machine/fpu.c
         machine/cpu_identification.c
@@ -387,8 +388,6 @@ add_sources(
         smp/ipi.c
     ASMFILES multiboot.S
 )
-
-add_sources(DEP "KernelArchX86;KernelDebugBuild" CFILES src/arch/x86/machine/capdl.c)
 
 add_bf_source_old("KernelArchX86" "structures.bf" "include/arch/x86" "arch/object")
 

--- a/src/arch/x86/machine/capdl.c
+++ b/src/arch/x86/machine/capdl.c
@@ -5,6 +5,9 @@
  */
 
 #include <config.h>
+
+#if defined(CONFIG_DEBUG_BUILD) && defined(CONFIG_PRINTING)
+
 #include <arch/machine/capdl.h>
 #include <string.h>
 #include <kernel/cspace.h>
@@ -33,3 +36,5 @@ void x86_obj_iopt_print_attrs(cap_t iopt_cap)
     printf("(level: %lu)\n", (long unsigned int)cap_io_page_table_cap_get_capIOPTLevel(iopt_cap));
 }
 #endif
+
+#endif /* defind(CONFIG_DEBUG_BUILD) && defined(CONFIG_PRINTING) */

--- a/src/config.cmake
+++ b/src/config.cmake
@@ -31,6 +31,7 @@ add_sources(
         src/model/statedata.c
         src/model/smp.c
         src/machine/io.c
+        src/machine/capdl.c
         src/machine/registerset.c
         src/machine/fpu.c
         src/benchmark/benchmark_track.c
@@ -45,9 +46,4 @@ add_sources(
         src/object/schedcontext.c
         src/object/schedcontrol.c
         src/kernel/sporadic.c
-)
-
-add_sources(
-    DEP "KernelDebugBuild;KernelArchARM OR KernelSel4ArchX86_64 OR KernelSel4ArchRiscV32"
-    CFILES src/machine/capdl.c
 )

--- a/src/machine/capdl.c
+++ b/src/machine/capdl.c
@@ -4,17 +4,18 @@
  * SPDX-License-Identifier: GPL-2.0-only
  */
 
+#include <config.h>
+
+#ifdef CONFIG_DEBUG_BUILD
+
 #include <machine/capdl.h>
 #include <machine/registerset.h>
 #include <machine/timer.h>
-#include <config.h>
 #include <string.h>
 #include <kernel/cspace.h>
 #ifdef CONFIG_KERNEL_MCS
 #include <kernel/sporadic.h>
 #endif
-
-#ifdef CONFIG_DEBUG_BUILD
 
 #define SEEN_SZ 256
 
@@ -75,6 +76,8 @@ bool_t root_or_idle_tcb(tcb_t *tcb)
 /*
  * Print objects
  */
+
+#ifdef CONFIG_PRINTING
 
 void obj_tcb_print_attrs(tcb_t *tcb)
 {
@@ -512,4 +515,6 @@ void print_object(cap_t cap)
     }
 }
 
-#endif
+#endif /* CONFIG_PRINTING */
+
+#endif /* CONFIG_DEBUG_BUILD */


### PR DESCRIPTION
Replace capDL() by a generic debug_capDL() where all architectures are supposed to provide an implementation or print an error.
