### PR TITLE
Nitrogen6SX: align name C define name

### DIFF
--- a/src/plat/imx6/config.cmake
+++ b/src/plat/imx6/config.cmake
@@ -38,7 +38,7 @@ if(KernelPlatImx6)
         config_set(KernelPlatImx6dq PLAT_IMX6DQ ON)
 
     elseif(KernelARMPlatform STREQUAL "nitrogen6sx")
-        config_set(KernelPlatformNitrogen6SX PLAT_NITROGENSX ON)
+        config_set(KernelPlatformNitrogen6SX PLAT_NITROGEN6SX ON)
         config_set(KernelPlatImx6sx PLAT_IMX6SX ON)
 
     else()


### PR DESCRIPTION
Unfortunately, the "6" in platform name's C define name got lost somewhere in some merges. This create a nasty misalignment in the names now. So far, this is not used anywhere in the seL4 codebase, but for merging https://github.com/seL4/util_libs/pull/78 the name must be fixed.