### PR TITLE
mcs: removed donator from release queue

### DIFF
--- a/src/object/schedcontext.c
+++ b/src/object/schedcontext.c
@@ -333,6 +333,7 @@ void schedContext_donate(sched_context_t *sc, tcb_t *to)
     if (from) {
         SMP_COND_STATEMENT(remoteTCBStall(from));
         tcbSchedDequeue(from);
+        tcbReleaseRemove(from);
         from->tcbSchedContext = NULL;
         if (from == NODE_STATE(ksCurThread) || from == NODE_STATE(ksSchedulerAction)) {
             rescheduleRequired();


### PR DESCRIPTION
If one thread replies on behalf of the a thread to which an SC is donated and that thread is in the release queue, that thread must be removed from the release queue when the SC is returned.