### PR TITLE
mcs: Fix conversion of ticks to us on aarch64

### DIFF
--- a/include/arch/arm/arch/64/mode/machine/timer.h
+++ b/include/arch/arm/arch/64/mode/machine/timer.h
@@ -24,7 +24,7 @@ static inline CONST ticks_t getMaxTicksToUs(void)
 static inline CONST time_t ticksToUs(ticks_t ticks)
 {
 #if USE_KHZ
-    return (ticks * TIMER_CLOCK_KHZ) / TIMER_CLOCK_MHZ;
+    return (ticks * KHZ_IN_MHZ) / TIMER_CLOCK_KHZ;
 #else
     return ticks / TIMER_CLOCK_MHZ;
 #endif


### PR DESCRIPTION
Actually divide by KHz frequency when on a platform that uses a clock that does not have an integer MHz frequency for aarch64.