### PR TITLE
risc-v: reorganise traps.S

### DIFF
--- a/src/arch/riscv/traps.S
+++ b/src/arch/riscv/traps.S
@@ -98,49 +98,35 @@ trap_entry:
   csrr x1,  sepc
   STORE   x1, (33*REGBYTES)(t0)
 
-#ifdef CONFIG_FASTPATH
-  li t3, SYSCALL_REPLY_RECV
-  beq a7, t3, fp_reply_recv
-
-  li t3, SYSCALL_CALL
-  beq a7, t3, fp_call
-#endif
-
   /* Check if it's an interrupt */
   bltz s0, interrupt
 
-  li   s4, 8       /* ratified priv has value 8 for ecall exception */
+  /* ratified priv has value 8 for ecall from U-mode exception */
+  li   s4, 8
   bne  s0, s4, exception
 
-syscall:
+handle_syscall:
   /* Set the return address to sepc + 4 in the case of a system/environment call */
   addi x1, x1, 4
   /* Save NextIP */
   STORE   x1, (34*REGBYTES)(t0)
 
+#ifdef CONFIG_FASTPATH
+  li t3, SYSCALL_CALL
+  beq a7, t3, c_handle_fastpath_call
+
+  li t3, SYSCALL_REPLY_RECV
+#ifdef CONFIG_KERNEL_MCS
+  /* move reply to 3rd argument */
+  mv a2, a6
+#endif
+  beq a7, t3, c_handle_fastpath_reply_recv
+#endif
+
+  /* move syscall number to 3rd argument */
   mv a2, a7
 
   j c_handle_syscall
-
-fp_reply_recv:
-
-  addi x1, x1, 4
-  /* Save NextIP */
-  STORE   x1, (34*REGBYTES)(t0)
-
-#ifdef CONFIG_KERNEL_MCS
-  mv a2, a6
-#endif
-
-  j c_handle_fastpath_reply_recv
-
-fp_call:
-
-  addi x1, x1, 4
-  /* Save NextIP */
-  STORE   x1, (34*REGBYTES)(t0)
-
-  j c_handle_fastpath_call
 
 /* Not an interrupt or a syscall */
 exception:


### PR DESCRIPTION
Move syscall and fastpath checks after interrupt and exceptions.
Exceptions were being interpreted as null-syscalls.
Remove duplication for return address.

Signed-off-by: Oliver Scott <Oliver.Scott@data61.csiro.au>