### PR TITLE
Correctly invalidate I-cache on aarch64 SMP [SELFOUR-2830]

### DIFF
--- a/include/arch/arm/arch/64/mode/machine.h
+++ b/include/arch/arm/arch/64/mode/machine.h
@@ -304,7 +304,11 @@ static inline void invalidateByVA_I(vptr_t vaddr, paddr_t paddr)
 
 static inline void invalidate_I_PoU(void)
 {
+#if CONFIG_MAX_NUM_NODES > 1
+    asm volatile("ic ialluis");
+#else
     asm volatile("ic iallu");
+#endif
     isb();
 }
 


### PR DESCRIPTION
See: [SELFOUR-2830] for details.

On SMP configuration the `ic ialluis` instruction must be used
to ensure the I-cache on all cores is invalidated.

Signed-off-by: Ben Leslie <benno@brkawy.com>

[SELFOUR-2830]: https://sel4.atlassian.net/browse/SELFOUR-2830