### PR TITLE
ia32: Fix linker errors with capDL printing

### DIFF
--- a/src/arch/x86/32/config.cmake
+++ b/src/arch/x86/32/config.cmake
@@ -18,6 +18,7 @@ add_sources(
         kernel/elf.c
         model/statedata.c
         machine/registerset.c
+        machine/capdl.c
         smp/ipi.c
     ASMFILES machine_asm.S traps.S head.S
 )

--- a/src/arch/x86/32/machine/capdl.c
+++ b/src/arch/x86/32/machine/capdl.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2021, Axel Heider <axelheider@gmx.de>
- * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ * Copyright 2021, Data61, CSIRO (ABN 41 687 119 230)
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
@@ -12,11 +12,39 @@
 #include <machine/capdl.h>
 #include <arch/machine/capdl.h>
 
+word_t get_tcb_sp(tcb_t *tcb)
+{
+    return tcb->tcbArch.tcbContext.registers[ESP];
+}
+
+void print_ipc_buffer_slot(tcb_t *tcb)
+{
+    printf("print_ipc_buffer_slot not implemented for IA32\n");
+}
+
+void obj_vtable_print_slots(tcb_t *tcb)
+{
+    printf("obj_vtable_print_slots not implemented for IA32\n");
+}
+
+void print_cap_arch(cap_t cap)
+{
+    printf("print_cap_arch not implemented for IA32\n");
+}
+
+void print_object_arch(cap_t cap)
+{
+    printf("print_object_arch not implemented for IA32\n");
+}
+
+void obj_tcb_print_vtable(tcb_t *tcb)
+{
+    printf("obj_tcb_print_vtable not implemented for IA32\n");
+}
+
 void debug_capDL(void)
 {
-#ifdef CONFIG_PRINTING
     printf("Debug CapDL snapshot not full implemented for IA32\n");
-#endif /* CONFIG_PRINTING */
     /* reset the seen list */
     reset_seen_list();
 }


### PR DESCRIPTION
This is a quick bug-fix to fix a red build in CI.

Although the functions aren't implemented properly, this is a stop gap
issue to prevent the linker from raising problems about missing
references to various platform-specific capDL printing functions.

Signed-off-by: Damon Lee <Damon.Lee@data61.csiro.au>