### PR TITLE
Fix d-cache flush on aarch32

### DIFF
--- a/include/arch/arm/arch/32/mode/machine.h
+++ b/include/arch/arm/arch/32/mode/machine.h
@@ -366,14 +366,12 @@ static inline void cleanByVA_PoU(vptr_t vaddr, paddr_t paddr)
     /* Erratum 586324 -- perform a dummy cached load before flushing. */
     asm volatile("ldr r0, [sp]" : : : "r0");
     asm volatile("mcr p15, 0, %0, c7, c11, 1" : : "r"(vaddr));
-#elif defined(CONFIG_PLAT_EXYNOS5)
+#elif defined(CONFIG_ARCH_ARM_V6)
+    /* V6 doesn't distinguish PoU and PoC, so use the basic flush. */
+    asm volatile("mcr p15, 0, %0, c7, c10, 1" : : "r"(vaddr));
+#elif defined(CONFIG_ARM_CORTEX_A7) || defined(CONFIG_ARM_CORTEX_A15) || \
+    defined(CONFIG_ARM_CORTEX_A53)
     /* Flush to coherency for table walks... Why? */
-    asm volatile("mcr p15, 0, %0, c7, c10, 1" : : "r"(vaddr));
-#elif defined(CONFIG_PLAT_IMX7)
-    asm volatile("mcr p15, 0, %0, c7, c10, 1" : : "r"(vaddr));
-#elif defined(CONFIG_PLAT_TK1)
-    asm volatile("mcr p15, 0, %0, c7, c10, 1" : : "r"(vaddr));
-#elif defined(CONFIG_ARM_CORTEX_A53)
     asm volatile("mcr p15, 0, %0, c7, c10, 1" : : "r"(vaddr));
 #else
     asm volatile("mcr p15, 0, %0, c7, c11, 1" : : "r"(vaddr));

--- a/include/arch/arm/arch/32/mode/machine.h
+++ b/include/arch/arm/arch/32/mode/machine.h
@@ -351,10 +351,8 @@ static inline void cleanByVA(vptr_t vaddr, paddr_t paddr)
     asm volatile("ldr r0, [sp]" : : : "r0");
     /* Erratum 586320 -- clean twice with interrupts disabled. */
     asm volatile("mcr p15, 0, %0, c7, c10, 1" : : "r"(vaddr));
-    asm volatile("mcr p15, 0, %0, c7, c10, 1" : : "r"(vaddr));
-#else
-    asm volatile("mcr p15, 0, %0, c7, c10, 1" : : "r"(vaddr));
 #endif
+    asm volatile("mcr p15, 0, %0, c7, c10, 1" : : "r"(vaddr));
     /* Erratum 586323 - end with DMB to ensure the write goes out. */
     dmb();
 }
@@ -386,10 +384,8 @@ static inline void invalidateByVA(vptr_t vaddr, paddr_t paddr)
 #ifdef CONFIG_ARM_CORTEX_A8
     /* Erratum 586324 -- perform a dummy cached load before flushing. */
     asm volatile("ldr r0, [sp]" : : : "r0");
-    asm volatile("mcr p15, 0, %0, c7, c6, 1" : : "r"(vaddr));
-#else
-    asm volatile("mcr p15, 0, %0, c7, c6, 1" : : "r"(vaddr));
 #endif
+    asm volatile("mcr p15, 0, %0, c7, c6, 1" : : "r"(vaddr));
     dmb();
 }
 
@@ -424,10 +420,8 @@ static inline void cleanInvalByVA(vptr_t vaddr, paddr_t paddr)
     asm volatile("ldr r0, [sp]" : : : "r0");
     /* Erratum 586320 -- clean twice with interrupts disabled. */
     asm volatile("mcr p15, 0, %0, c7, c14, 1" : : "r"(vaddr));
-    asm volatile("mcr p15, 0, %0, c7, c14, 1" : : "r"(vaddr));
-#else
-    asm volatile("mcr p15, 0, %0, c7, c14, 1" : : "r"(vaddr));
 #endif
+    asm volatile("mcr p15, 0, %0, c7, c14, 1" : : "r"(vaddr));
     dsb();
 }
 


### PR DESCRIPTION
I had trouble boot with allwinner A20 (Cortex-A7) and got it fixed by cleaning to PoC.
It seems all Cortex-A7 (I.MX7, AllwinnerA20), Cortex-A15 (Exynos5, Tk1), and Cortex-A53 boards require to flush to coherency.