### PR TITLE
pc99: Remove PT_PHDR segment from linker script

### DIFF
--- a/src/plat/pc99/linker.lds
+++ b/src/plat/pc99/linker.lds
@@ -28,7 +28,6 @@ nodeSkimScratchOffset = nodeSkimScratch - node_info;
 KERNEL_OFFSET = KLOAD_VADDR - KLOAD_PADDR;
 
 PHDRS {
-    headers PT_PHDR PHDRS ;
     phys PT_LOAD FILEHDR PHDRS ;
     boot PT_LOAD ;
     virt PT_LOAD ;


### PR DESCRIPTION
This is to work around an issue in a variant of syslinux that treats a
PHDR segment as distinct from a PT_LOAD segment and rejects an ELF if
the two segments are overlapping.

Signed-off-by: Kent McLeod <kent@kry10.com>