### PR TITLE
CMake: cleanup KernelSel4ArchArmHyp

### DIFF
--- a/configs/seL4Config.cmake
+++ b/configs/seL4Config.cmake
@@ -34,25 +34,24 @@ macro(declare_seL4_arch sel4_arch)
         "ia32;KernelSel4ArchIA32;ARCH_IA32"
     )
 
+    if(KernelSel4ArchArmHyp)
+        # arm-hyp is basically aarch32. This should be cleaned up and aligned
+        # with other architectures, where hypervisor support is an additional
+        # flag. The main blocker here is updating the verification flow.
+        config_set(KernelSel4ArchAarch32 ARCH_AARCH32 ON)
+    endif()
+
     config_choice(
         KernelArch
         ARCH
         "Architecture to use when building the kernel"
-        "arm;KernelArchARM;ARCH_ARM;KernelSel4ArchAarch32 OR KernelSel4ArchAarch64 OR KernelSel4ArchArmHyp"
+        "arm;KernelArchARM;ARCH_ARM;KernelSel4ArchAarch32 OR KernelSel4ArchAarch64"
         "riscv;KernelArchRiscV;ARCH_RISCV;KernelSel4ArchRiscV32 OR KernelSel4ArchRiscV64"
         "x86;KernelArchX86;ARCH_X86;KernelSel4ArchX86_64 OR KernelSel4ArchIA32"
     )
 
-    # arm-hyp masquerades as an aarch32 build
-    if(KernelSel4ArchArmHyp)
-        config_set(KernelSel4ArmHypAarch32 ARCH_AARCH32 ON)
-        set(KernelSel4ArchAarch32 ON CACHE INTERNAL "" FORCE)
-    else()
-        config_set(KernelSel4ArmHypAarch32 ARCH_AARCH32 OFF)
-    endif()
-
     # Set kernel mode options
-    if(KernelSel4ArchAarch32 OR KernelSel4ArchArmHyp OR KernelSel4ArchRiscV32 OR KernelSel4ArchIA32)
+    if(KernelSel4ArchAarch32 OR KernelSel4ArchRiscV32 OR KernelSel4ArchIA32)
         config_set(KernelWordSize WORD_SIZE 32)
         set(Kernel64 OFF CACHE INTERNAL "")
         set(Kernel32 ON CACHE INTERNAL "")

--- a/src/arch/arm/config.cmake
+++ b/src/arch/arm/config.cmake
@@ -79,15 +79,19 @@ config_option(
     DEFAULT OFF
     DEPENDS "KernelArchARM"
 )
-if(KernelSel4ArchArmHyp)
-    set(default_hyp_support ON)
-else()
-    set(default_hyp_support OFF)
+
+if(NOT DEFINED KernelSel4ArchArmHyp)
+    # the current CMake scripts ensure that KernelSel4ArchArmHyp is always set
+    # to either ON or OFF. If it is not set, something is either broken or the
+    # CMake files are used wrongly. Or support for KernelSel4ArchArmHyp has
+    # finally been removed - and then this check here should be removed and the
+    # KernelArmHypervisorSupport below can be OFF by default.
+    message(FATAL_ERROR "KernelSel4ArchArmHyp must be ON or OFF")
 endif()
 config_option(
     KernelArmHypervisorSupport ARM_HYPERVISOR_SUPPORT
     "Build as Hypervisor. Utilise ARM virtualisation extensions to build the kernel as a hypervisor"
-    DEFAULT ${default_hyp_support}
+    DEFAULT ${KernelSel4ArchArmHyp}
     DEPENDS
         "KernelArmCortexA15 OR KernelArmCortexA35 OR KernelArmCortexA57 OR KernelArmCortexA53 OR KernelArmCortexA72"
 )
@@ -100,7 +104,7 @@ config_option(
     and trap them instead, and have the VCPUs' accesses to CP14 \
     intercepted and delivered to the VM Monitor as fault messages"
     DEFAULT ON
-    DEPENDS "KernelSel4ArmHypAarch32;NOT KernelVerificationBuild"
+    DEPENDS "KernelSel4ArchArmHyp;NOT KernelVerificationBuild"
     DEFAULT_DISABLED OFF
 )
 


### PR DESCRIPTION
- Don't create `CONFIG_ARCH_AARCH32` on every platform and architecture (even if it is off, it is quite confusing to see it)
- Remove `KernelSel4ArmHypAarch32`, seems there is no special need for it and `KernelSel4ArchArmHyp` can also be used