### PR TITLE
Add support for iMX LP UART

### DIFF
--- a/src/drivers/serial/config.cmake
+++ b/src/drivers/serial/config.cmake
@@ -24,6 +24,11 @@ register_driver(
     CFILES "imx.c"
 )
 register_driver(
+    compatibility_strings "fsl,imx8qxp-lpuart"
+    PREFIX src/drivers/serial
+    CFILES "imx-lpuart.c"
+)
+register_driver(
     compatibility_strings "samsung,exynos4210-uart"
     PREFIX src/drivers/serial
     CFILES "exynos4210-uart.c"

--- a/src/drivers/serial/imx-lpuart.c
+++ b/src/drivers/serial/imx-lpuart.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021, Breakaway Consulting Pty. Ltd.
+ *
+ * A simple output only UART driver for the NXP i.MX Low Power UART.
+ *
+ * Technical Reference:
+ *   i.MX 8DualX/8DualXPlus/8QuadXPlus Applications Processor Reference Manual
+ *   Revision 0 (IMX8DQXPRM.pdf)
+ *   Chapter 16.13 (page 7908)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#include <config.h>
+#include <stdint.h>
+#include <util.h>
+#include <machine/io.h>
+#include <plat/machine/devices_gen.h>
+
+#define STAT 0x14
+#define TRANSMIT 0x1c
+
+#define STAT_TDRE (1 << 23)
+
+#define UART_REG(x) ((volatile uint32_t *)(UART_PPTR + (x)))
+
+#if defined(CONFIG_DEBUG_BUILD) || defined(CONFIG_PRINTING)
+void uart_drv_putchar(unsigned char c)
+{
+    while (!(*UART_REG(STAT) & STAT_TDRE)) { }
+    *UART_REG(TRANSMIT) = c;
+}
+#endif
+
+#ifdef CONFIG_DEBUG_BUILD
+unsigned char uart_drv_getchar(void)
+{
+    return 0;
+}
+#endif /* CONFIG_DEBUG_BUILD */

--- a/tools/hardware.yml
+++ b/tools/hardware.yml
@@ -226,6 +226,7 @@ devices:
       - brcm,bcm2835-aux-uart
       - fsl,imx31-uart
       - fsl,imx6q-uart
+      - fsl,imx8qxp-lpuart
       - fsl,imx6sx-uart
       - nvidia,tegra124-hsuart
       - nvidia,tegra20-uart


### PR DESCRIPTION
Add support the i.MX low-power UART. This is available on
chipsets such as i.MX8QXP.

Note: This is a preliminary patch in advance of providing
full support for the i.MX8QXP platform.

Signed-off-by: Ben Leslie <benno@brkawy.com>