### PR TITLE
trivial: Extend !__ASSEMBLER__ preprocessor flag

### DIFF
--- a/libsel4/include/sel4/constants.h
+++ b/libsel4/include/sel4/constants.h
@@ -92,7 +92,6 @@ static inline seL4_Word seL4_MaxExtraRefills(seL4_Word size)
 {
     return (LIBSEL4_BIT(size) -  seL4_CoreSchedContextBytes) / seL4_RefillSizeBytes;
 }
-#endif /* !__ASSEMBLER__ */
 
 /* Flags to be used with seL4_SchedControl_ConfigureFlags */
 typedef enum {
@@ -101,6 +100,7 @@ typedef enum {
     SEL4_FORCE_LONG_ENUM(seL4_SchedContextFlag),
 } seL4_SchedContextFlag;
 
+#endif /* !__ASSEMBLER__ */
 #endif /* CONFIG_KERNEL_MCS */
 
 #ifdef CONFIG_KERNEL_INVOCATION_REPORT_ERROR_IPC


### PR DESCRIPTION
The scheduler context flags enum should not be inside assembler-related
files.

Signed-off-by: Damon Lee <Damon.Lee@data61.csiro.au>