### PR TITLE
risc-v: adapt to OpenSBI post v0.9

### DIFF
--- a/src/plat/hifive/config.cmake
+++ b/src/plat/hifive/config.cmake
@@ -13,7 +13,7 @@ if(KernelPlatformHifive)
     declare_seL4_arch(riscv64)
     config_set(KernelRiscVPlatform RISCV_PLAT "hifive")
     config_set(KernelPlatformFirstHartID FIRST_HART_ID 1)
-    config_set(KernelOpenSBIPlatform OPENSBI_PLATFORM "sifive/fu540")
+    config_set(KernelOpenSBIPlatform OPENSBI_PLATFORM "generic")
     list(APPEND KernelDTSList "tools/dts/hifive.dts")
     list(APPEND KernelDTSList "src/plat/hifive/overlay-hifive.dts")
     declare_default_headers(


### PR DESCRIPTION
- risc-v/hifive: adapt to post-v0.9 OpenSBI
- riscv: provide wrapper for new (extended) SBI interface

Test with seL4/sel4test-manifest#13

It seems `sifive/fu540` is no longer a valid OpenSBI platform, all this is generic now? Does anybody have access to a hifive or polarfire to test what works here? Seems there is QEMU support also, has anybody tested this?