### PR TITLE
cmake: Apply KernelAArch64SErrorIgnore setting

### DIFF
--- a/configs/seL4Config.cmake
+++ b/configs/seL4Config.cmake
@@ -174,6 +174,7 @@ foreach(
     KernelArchArmV7ve
     KernelArchArmV8a
     KernelArmSMMU
+    KernelAArch64SErrorIgnore
 )
     unset(${var} CACHE)
     set(${var} OFF)
@@ -211,6 +212,7 @@ config_set(KernelArchArmV7a ARCH_ARM_V7A "${KernelArchArmV7a}")
 config_set(KernelArchArmV7ve ARCH_ARM_V7VE "${KernelArchArmV7ve}")
 config_set(KernelArchArmV8a ARCH_ARM_V8A "${KernelArchArmV8a}")
 config_set(KernelArmSMMU ARM_SMMU "${KernelArmSMMU}")
+config_set(KernelAArch64SErrorIgnore AARCH64_SERROR_IGNORE "${KernelAArch64SErrorIgnore}")
 set(KernelPlatformSupportsMCS "${KernelPlatformSupportsMCS}" CACHE INTERNAL "" FORCE)
 
 # Check for v7ve before v7a as v7ve is a superset and we want to set the


### PR DESCRIPTION
KernelAArch64SErrorIgnore needs to be saved into the cache in
seL4Config.cmake if it is set by any platform's config.cmake.

Signed-off-by: Kent McLeod <kent@kry10.com>