### PR TITLE
CMake: don't enforce std channels

### DIFF
--- a/config.cmake
+++ b/config.cmake
@@ -159,7 +159,7 @@ if(DEFINED KernelDTSList AND (NOT "${KernelDTSList}" STREQUAL ""))
     check_outfile_stale(regen ${device_dest} deps ${CMAKE_CURRENT_BINARY_DIR}/gen_header.cmd)
     if(regen)
         # Generate devices_gen header based on DTB
-        message(STATUS "${device_dest} is out of date. Regenerating...")
+        message(STATUS "${device_dest} is out of date. Regenerating from DTB...")
         file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/gen_headers/plat/machine/")
         execute_process(
             COMMAND
@@ -171,7 +171,7 @@ if(DEFINED KernelDTSList AND (NOT "${KernelDTSList}" STREQUAL ""))
             RESULT_VARIABLE error
         )
         if(error)
-            message(FATAL_ERROR "Failed to generate: ${device_dest}")
+            message(FATAL_ERROR "Failed to generate from DTB: ${device_dest}")
         endif()
     endif()
     file(READ "${compatibility_outfile}" compatibility_strings)

--- a/config.cmake
+++ b/config.cmake
@@ -168,9 +168,6 @@ if(DEFINED KernelDTSList AND (NOT "${KernelDTSList}" STREQUAL ""))
                 "${device_dest}" --hardware-config "${config_file}" --hardware-schema
                 "${config_schema}" --yaml --yaml-out "${platform_yaml}" --arch "${KernelArch}"
                 --addrspace-max "${KernelPaddrUserTop}"
-            INPUT_FILE /dev/stdin
-            OUTPUT_FILE /dev/stdout
-            ERROR_FILE /dev/stderr
             RESULT_VARIABLE error
         )
         if(error)


### PR DESCRIPTION
Enforcing the std channels seems to conflict with Jenkins CI, we don't see any error messages then. I remember that we had a discussion here before that on some other systems this enforced redirectin is needed - but this make me wonder why the std channels do not work there and if this is the issue to be resolved then. 