### PR TITLE
Set KernelPaddrUserTop correctly on RISC-V platforms

### DIFF
--- a/include/kernel/boot.h
+++ b/include/kernel/boot.h
@@ -47,6 +47,10 @@ static inline bool_t is_reg_empty(region_t reg)
     return reg.start == reg.end;
 }
 
+seL4_Word write_bootinfo(void *bi_ptr, seL4_Word bi_block_id,
+                         void const *data, seL4_Word data_len);
+seL4_Word write_bootinfo_dtb(void *bi_ptr, region_t const *dtb_reg);
+seL4_Word write_bootinfo_padding(void *bi_ptr, seL4_Word len);
 void init_freemem(word_t n_available, const p_region_t *available,
                   word_t n_reserved, region_t *reserved,
                   v_region_t it_v_reg, word_t extra_bi_size_bits);

--- a/src/arch/arm/kernel/boot.c
+++ b/src/arch/arm/kernel/boot.c
@@ -340,9 +340,11 @@ static BOOT_CODE bool_t try_init_kernel(
     bi_frame_vptr = ipcbuf_vptr + BIT(PAGE_BITS);
     extra_bi_frame_vptr = bi_frame_vptr + BIT(PAGE_BITS);
 
-    /* If no DTB was provided, skip allocating extra bootinfo */
+    /* If no DTB was provided or the DTB size is zero, skip allocating extra
+     * bootinfo. Otherwise mark the DTB region as reserved.
+     */
     region_t dtb_reg = { .start = 0, .end = 0 };
-    if (0 != dtb_addr_start) {
+    if ((0 != dtb_addr_start) && (dtb_addr_start < dtb_addr_end)) {
         dtb_reg = paddr_to_pptr_reg( (p_region_t) {
             .start = dtb_addr_start,
             .end   = ROUND_UP(dtb_addr_end, PAGE_BITS)

--- a/src/arch/riscv/common_riscv.lds
+++ b/src/arch/riscv/common_riscv.lds
@@ -1,6 +1,7 @@
 /*
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  * Copyright 2015, 2016 Hesham Almatary <heshamelmatary@gmail.com>
+ * Copyright 2021, HENSOLDT Cyber
  *
  * SPDX-License-Identifier: GPL-2.0-only
  */
@@ -79,7 +80,6 @@ SECTIONS
 
         /* large data such as the globals frame and global PD */
         *(.bss.aligned)
-        . = . + 8;
     }
 
     . = ALIGN(4K);

--- a/src/arch/riscv/kernel/boot.c
+++ b/src/arch/riscv/kernel/boot.c
@@ -18,9 +18,8 @@
 #include <plat/machine/hardware.h>
 #include <machine.h>
 
-/* pointer to the end of boot code/data in kernel image */
-/* need a fake array to get the pointer from the linker script */
-extern char ki_boot_end[1];
+/* linker symbol created at the end of boot code/data in kernel image */
+extern char ki_boot_end[];
 
 #ifdef ENABLE_SMP_SUPPORT
 BOOT_BSS static volatile word_t node_boot_lock;

--- a/src/arch/riscv/kernel/boot.c
+++ b/src/arch/riscv/kernel/boot.c
@@ -26,9 +26,12 @@ extern char ki_boot_end[];
 BOOT_BSS static volatile word_t node_boot_lock;
 #endif
 
-/* kernel image + [extra bootinfo] + user image */
-#define MAX_RESERVED 3
-BOOT_BSS static region_t res_reg[MAX_RESERVED];
+/* There are up to 3 reserved regions:
+ *   - the kernel image
+ *   - optional extra bootinfo, currently a DTB passed by a previous bootloader
+ *   - the user image
+ */
+BOOT_BSS static region_t res_reg[3];
 
 BOOT_CODE static bool_t create_untypeds(cap_t root_cnode_cap, region_t boot_mem_reuse_reg)
 {
@@ -75,6 +78,8 @@ BOOT_CODE cap_t create_mapped_it_frame_cap(cap_t pd_cap, pptr_t pptr, vptr_t vpt
 BOOT_CODE static void arch_init_freemem(region_t ui_reg, v_region_t ui_v_reg,
                                         region_t dtb_reg, word_t extra_bi_size_bits)
 {
+    SEL4_COMPILE_ASSERT(min_3_reserved_regions, ARRAY_SIZE(res_reg) >= 3);
+
     // This looks a bit awkward as our symbols are a reference in the kernel image window, but
     // we want to do all allocations in terms of the main kernel window, so we do some translation
     res_reg[0].start = (pptr_t)paddr_to_pptr(kpptr_to_paddr((void *)KERNEL_ELF_BASE));

--- a/src/arch/riscv/kernel/boot.c
+++ b/src/arch/riscv/kernel/boot.c
@@ -367,7 +367,6 @@ static BOOT_CODE bool_t try_init_kernel(
         return false;
     }
 
-
     /* create the initial thread */
     tcb_t *initial = create_initial_thread(
                          root_cnode_cap,

--- a/src/arch/riscv/kernel/boot.c
+++ b/src/arch/riscv/kernel/boot.c
@@ -213,9 +213,11 @@ static BOOT_CODE bool_t try_init_kernel(
     vptr_t  bi_frame_vptr = ipcbuf_vptr + BIT(PAGE_BITS);
     vptr_t extra_bi_frame_vptr = bi_frame_vptr + BIT(PAGE_BITS);
 
-    /* If no DTB was provided, skip allocating extra bootinfo */
+    /* If no DTB was provided or the DTB size is zero, skip allocating extra
+     * bootinfo. Otherwise mark the DTB region as reserved.
+     */
     region_t dtb_reg = { .start = 0, .end = 0 };
-    if (dtb_addr_start == 0) {
+    if ((0 != dtb_addr_start) && (dtb_addr_start < dtb_addr_end)) {
         /* convert physical address to addressable pointer */
         dtb_reg = paddr_to_pptr_reg( (p_region_t) {
             .start = dtb_addr_start,

--- a/src/arch/riscv/kernel/boot.c
+++ b/src/arch/riscv/kernel/boot.c
@@ -1,6 +1,7 @@
 /*
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  * Copyright 2015, 2016 Hesham Almatary <heshamelmatary@gmail.com>
+ * Copyright 2021, HENSOLDT Cyber
  *
  * SPDX-License-Identifier: GPL-2.0-only
  */
@@ -259,6 +260,7 @@ static BOOT_CODE bool_t try_init_kernel(
     /* create the root cnode */
     root_cnode_cap = create_root_cnode();
     if (cap_get_capType(root_cnode_cap) == cap_null_cap) {
+        printf("ERROR: root c-node creation failed\n");
         return false;
     }
 
@@ -294,6 +296,7 @@ static BOOT_CODE bool_t try_init_kernel(
      * to cover the user image + ipc buffer and bootinfo frames */
     it_pd_cap = create_it_address_space(root_cnode_cap, it_v_reg);
     if (cap_get_capType(it_pd_cap) == cap_null_cap) {
+        printf("ERROR: initial thread PD c-node creation failed\n");
         return false;
     }
 
@@ -319,6 +322,7 @@ static BOOT_CODE bool_t try_init_kernel(
                 pptr_to_paddr((void *)extra_bi_region.start) - extra_bi_frame_vptr
             );
         if (!extra_bi_ret.success) {
+            printf("ERROR: mapping extra boot info to initial thread failed\n");
             return false;
         }
         ndks_boot.bi_frame->extraBIPages = extra_bi_ret.region;
@@ -331,6 +335,7 @@ static BOOT_CODE bool_t try_init_kernel(
     /* create the initial thread's IPC buffer */
     ipcbuf_cap = create_ipcbuf_frame_cap(root_cnode_cap, it_pd_cap, ipcbuf_vptr);
     if (cap_get_capType(ipcbuf_cap) == cap_null_cap) {
+        printf("ERROR: could not create IPC buffer for initial thread\n");
         return false;
     }
 
@@ -344,6 +349,7 @@ static BOOT_CODE bool_t try_init_kernel(
             pv_offset
         );
     if (!create_frames_ret.success) {
+        printf("ERROR: could not create all userland image frames\n");
         return false;
     }
     ndks_boot.bi_frame->userImageFrames = create_frames_ret.region;
@@ -351,6 +357,7 @@ static BOOT_CODE bool_t try_init_kernel(
     /* create the initial thread's ASID pool */
     it_ap_cap = create_it_asid_pool(root_cnode_cap);
     if (cap_get_capType(it_ap_cap) == cap_null_cap) {
+        printf("ERROR: could not create ASID pool for initial thread\n");
         return false;
     }
     write_it_asid_pool(it_ap_cap, it_pd_cap);
@@ -361,6 +368,7 @@ static BOOT_CODE bool_t try_init_kernel(
 
     /* create the idle thread */
     if (!create_idle_thread()) {
+        printf("ERROR: could not create idle thread\n");
         return false;
     }
 
@@ -375,6 +383,7 @@ static BOOT_CODE bool_t try_init_kernel(
                      );
 
     if (initial == NULL) {
+        printf("ERROR: could not create initial thread\n");
         return false;
     }
 
@@ -384,6 +393,7 @@ static BOOT_CODE bool_t try_init_kernel(
     if (!create_untypeds(
             root_cnode_cap,
             boot_mem_reuse_reg)) {
+        printf("ERROR: could not create untypteds for kernel image boot memory\n");
         return false;
     }
 

--- a/src/arch/riscv/kernel/boot.c
+++ b/src/arch/riscv/kernel/boot.c
@@ -21,8 +21,6 @@
 /* pointer to the end of boot code/data in kernel image */
 /* need a fake array to get the pointer from the linker script */
 extern char ki_boot_end[1];
-/* pointer to end of kernel image */
-extern char ki_end[1];
 
 #ifdef ENABLE_SMP_SUPPORT
 BOOT_BSS static volatile word_t node_boot_lock;


### PR DESCRIPTION
The top phys addr is exclusive, not inclusive. On 64-bit platforms there is a trivial way to fix this as long as the whole address space is never used. For 32-bit platforms the fix will be more complicated, so this is postponed.

See also https://github.com/seL4/seL4/pull/376 where this got fixed on ARM platforms.