### PR TITLE
Set KernelPaddrUserTop correctly on RISC-V platforms

### DIFF
--- a/src/arch/riscv/config.cmake
+++ b/src/arch/riscv/config.cmake
@@ -57,14 +57,14 @@ if(KernelPTLevels EQUAL 2)
         # so limit the maximum paddr to 32-bits.
         math(EXPR KernelPaddrUserTop "(1 << 32) - 1")
     else()
-        math(EXPR KernelPaddrUserTop "(1 << 34) - 1")
+        math(EXPR KernelPaddrUserTop "1 << 34")
     endif()
 elseif(KernelPTLevels EQUAL 3)
     # RISC-V technically supports 56-bit paddrs,
     # but structures.bf limits us to using 39 of those bits.
-    math(EXPR KernelPaddrUserTop "(1 << 39) - 1")
+    math(EXPR KernelPaddrUserTop "1 << 39")
 elseif(KernelPTLevels EQUAL 4)
-    math(EXPR KernelPaddrUserTop "(1 << 56) - 1")
+    math(EXPR KernelPaddrUserTop "1 << 56")
 endif()
 
 if(KernelRiscvExtD)


### PR DESCRIPTION
The top phys addr is exclusive, not inclusive. On 64-bit platforms there is a trivial way to fix this as long as the whole address space is never used. For 32-bit platforms the fix will be more complicated, so this is postponed.

See also https://github.com/seL4/seL4/pull/376 where this got fixed on ARM platforms.