### PR TITLE
Assume seperate distinct kernel ELF mapping on all platforms

### DIFF
--- a/include/arch/arm/armv/armv7-a/armv/context_switch.h
+++ b/include/arch/arm/armv/armv7-a/armv/context_switch.h
@@ -38,7 +38,7 @@ static inline void armv_contextSwitch_HWASID(pde_t *cap_pd, hw_asid_t hw_asid)
      * do does not need a DSB
      */
     dsb();
-    writeTTBR0Ptr(addrFromPPtr(armKSGlobalPD));
+    writeTTBR0Ptr(addrFromKPPtr(armKSGlobalPD));
     isb();
     setHardwareASID(hw_asid);
     writeTTBR0Ptr(addrFromPPtr(cap_pd));

--- a/include/arch/riscv/arch/machine.h
+++ b/include/arch/riscv/arch/machine.h
@@ -248,20 +248,7 @@ void plat_invalidateL2Range(paddr_t start, paddr_t end);
 
 void plat_cleanInvalidateL2Range(paddr_t start, paddr_t end);
 
-static inline void *CONST paddr_to_kpptr(paddr_t paddr)
-{
-    assert(paddr < KERNEL_ELF_PADDR_TOP);
-    assert(paddr >= KERNEL_ELF_PADDR_BASE);
-    return (void *)(paddr + KERNEL_ELF_BASE_OFFSET);
-}
-
-static inline paddr_t CONST kpptr_to_paddr(void *pptr)
-{
-    assert((word_t)pptr >= KERNEL_ELF_BASE);
-    return (paddr_t)pptr - KERNEL_ELF_BASE_OFFSET;
-}
-
-/* Update the value of the actual register to hold the expected value */
+/* Update the value of the actual regsiter to hold the expected value */
 static inline void Arch_setTLSRegister(word_t tls_base)
 {
     /* The register is always reloaded upon return from kernel. */

--- a/include/machine.h
+++ b/include/machine.h
@@ -26,6 +26,15 @@ static inline paddr_t CONST addrFromPPtr(void *pptr)
     return (paddr_t)pptr - PPTR_BASE_OFFSET;
 }
 
+/* When obtaining a physical address from a reference to an address from
+ * the kernel ELF mapping, this function must be used. */
+static inline paddr_t CONST addrFromKPPtr(void *pptr)
+{
+    assert((paddr_t)(pptr) >= KERNEL_ELF_BASE);
+    assert((paddr_t)(pptr) <= KERNEL_ELF_TOP);
+    return (paddr_t)pptr - KERNEL_ELF_BASE_OFFSET;
+}
+
 static inline region_t CONST paddr_to_pptr_reg(p_region_t p_reg)
 {
     return (region_t) {
@@ -41,6 +50,7 @@ static inline p_region_t CONST pptr_to_paddr_reg(region_t reg)
 }
 
 #define paddr_to_pptr ptrFromPAddr
-#define pptr_to_paddr(x) addrFromPPtr(x)
+#define pptr_to_paddr addrFromPPtr
+#define kpptr_to_paddr addrFromKPPtr
 
 #include <mode/machine.h>

--- a/include/plat/pc99/plat/32/plat_mode/machine/hardware.h
+++ b/include/plat/pc99/plat/32/plat_mode/machine/hardware.h
@@ -82,8 +82,3 @@
 /* The base address in virtual memory to use for the kernel device
  * mapping region. These are mapped in the kernel page table. */
 #define KDEV_BASE KERNEL_PT_BASE
-
-/* For a 32-bit system there is no difference in how we translates
- * physical address for the kernel symbols or anything else */
-#define paddr_to_kpptr(x) paddr_to_pptr(x)
-#define kpptr_to_paddr(x) pptr_to_paddr(x)

--- a/include/plat/pc99/plat/64/plat_mode/machine/hardware.h
+++ b/include/plat/pc99/plat/64/plat_mode/machine/hardware.h
@@ -116,23 +116,5 @@
 compile_assert(user_top_tlbbitmap_no_overlap, GET_PML4_INDEX(USER_TOP) != GET_PML4_INDEX(TLBBITMAP_PPTR))
 #endif
 
-/* since we have two kernel VM windows, we have two pptr to paddr
- * conversion functions.
- * paddr_to_kpptr converts physical address to the second small kernel
- * window which locates at the top 2GiB.
- */
-static inline void *CONST
-paddr_to_kpptr(paddr_t paddr)
-{
-    assert(paddr < KERNEL_ELF_PADDR_TOP);
-    return (void *)(paddr + KERNEL_ELF_BASE_OFFSET);
-}
-
-static inline paddr_t CONST kpptr_to_paddr(void *pptr)
-{
-    assert((word_t)pptr >= KERNEL_ELF_BASE);
-    return (paddr_t)pptr - KERNEL_ELF_BASE_OFFSET;
-}
-
 #endif /* __ASSEMBLER__ */
 

--- a/src/arch/arm/32/kernel/vspace.c
+++ b/src/arch/arm/32/kernel/vspace.c
@@ -257,7 +257,7 @@ BOOT_CODE void map_kernel_window(void)
     /* map log buffer page table. PTEs to be filled by user later by calling seL4_BenchmarkSetLogBuffer() */
     armKSGlobalPD[idx] =
         pde_pde_coarse_new(
-            addrFromPPtr(armKSGlobalLogPT), /* address */
+            addrFromKPPtr(armKSGlobalLogPT), /* address */
             true,                           /* P       */
             0                               /* Domain  */
         );
@@ -271,7 +271,7 @@ BOOT_CODE void map_kernel_window(void)
     /* map page table covering last 1M of virtual address space to page directory */
     armKSGlobalPD[idx] =
         pde_pde_coarse_new(
-            addrFromPPtr(armKSGlobalPT), /* address */
+            addrFromKPPtr(armKSGlobalPT), /* address */
             true,                        /* P       */
             0                            /* Domain  */
         );
@@ -281,7 +281,7 @@ BOOT_CODE void map_kernel_window(void)
 
     /* map vector table */
     map_kernel_frame(
-        addrFromPPtr(arm_vector_table),
+        addrFromKPPtr(arm_vector_table),
         PPTR_VECTOR_TABLE,
         VMKernelOnly,
         vm_attributes_new(
@@ -294,7 +294,7 @@ BOOT_CODE void map_kernel_window(void)
 #ifdef CONFIG_KERNEL_GLOBALS_FRAME
     /* map globals frame */
     map_kernel_frame(
-        addrFromPPtr(armKSGlobalsFrame),
+        addrFromKPPtr(armKSGlobalsFrame),
         seL4_GlobalsFrame,
         VMReadOnly,
         vm_attributes_new(
@@ -322,7 +322,7 @@ BOOT_CODE void map_kernel_window(void)
         pde = pdeS1_pdeS1_invalid_new();
         armHSGlobalPGD[idx] = pde;
     }
-    pde = pdeS1_pdeS1_coarse_new(0, 0, 0, 0, addrFromPPtr(armHSGlobalPD));
+    pde = pdeS1_pdeS1_coarse_new(0, 0, 0, 0, addrFromKPPtr(armHSGlobalPD));
     armHSGlobalPGD[3] = pde;
 
     /* Initialise PMD */
@@ -351,7 +351,7 @@ BOOT_CODE void map_kernel_window(void)
         phys += BIT(PT_INDEX_BITS + PAGE_BITS);
     }
     /* map page table covering last 2M of virtual address space */
-    pde = pdeS1_pdeS1_coarse_new(0, 0, 0, 0, addrFromPPtr(armHSGlobalPT));
+    pde = pdeS1_pdeS1_coarse_new(0, 0, 0, 0, addrFromKPPtr(armHSGlobalPT));
     armHSGlobalPD[idx] = pde;
 
     /* now start initialising the page table */
@@ -375,7 +375,7 @@ BOOT_CODE void map_kernel_window(void)
     }
     /* map vector table */
     map_kernel_frame(
-        addrFromPPtr(arm_vector_table),
+        addrFromKPPtr(arm_vector_table),
         PPTR_VECTOR_TABLE,
         VMKernelOnly,
         vm_attributes_new(
@@ -388,7 +388,7 @@ BOOT_CODE void map_kernel_window(void)
 #ifdef CONFIG_KERNEL_GLOBALS_FRAME
     /* map globals frame */
     map_kernel_frame(
-        addrFromPPtr(armKSGlobalsFrame),
+        addrFromKPPtr(armKSGlobalsFrame),
         seL4_GlobalsFrame,
         VMReadOnly,
         vm_attributes_new(
@@ -401,7 +401,7 @@ BOOT_CODE void map_kernel_window(void)
     pteS2 = pte_pte_small_new(
                 1, /* Not Executeable */
                 0, /* Not contiguous */
-                addrFromPPtr(armKSGlobalsFrame),
+                addrFromKPPtr(armKSGlobalsFrame),
                 1, /* AF -- always set */
                 0, /* Not shared */
                 HAPFromVMRights(VMReadOnly),
@@ -589,7 +589,7 @@ BOOT_CODE void activate_global_pd(void)
        that everything we've written (particularly the kernel page tables)
        is committed. */
     cleanInvalidateL1Caches();
-    setCurrentPD(addrFromPPtr(armKSGlobalPD));
+    setCurrentPD(addrFromKPPtr(armKSGlobalPD));
     invalidateLocalTLB();
     lockTLBEntry(PPTR_BASE);
     lockTLBEntry(PPTR_VECTOR_TABLE);
@@ -606,7 +606,7 @@ BOOT_CODE void activate_global_pd(void)
     cleanInvalidateL1Caches();
     /* Setup the memory attributes: We use 2 indicies (cachable/non-cachable) */
     setHMAIR((ATTRINDX_NONCACHEABLE << 0) | (ATTRINDX_CACHEABLE << 8), 0);
-    setCurrentHypPD(addrFromPPtr(armHSGlobalPGD));
+    setCurrentHypPD(addrFromKPPtr(armHSGlobalPGD));
     invalidateHypTLB();
 #if 0 /* Can't lock entries on A15 */
     lockTLBEntry(PPTR_BASE);
@@ -1050,9 +1050,9 @@ void setVMRoot(tcb_t *tcb)
     if (cap_get_capType(threadRoot) != cap_page_directory_cap ||
         !cap_page_directory_cap_get_capPDIsMapped(threadRoot)) {
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
-        setCurrentPD(addrFromPPtr(armUSGlobalPD));
+        setCurrentPD(addrFromKPPtr(armUSGlobalPD));
 #else
-        setCurrentPD(addrFromPPtr(armKSGlobalPD));
+        setCurrentPD(addrFromKPPtr(armKSGlobalPD));
 #endif
         return;
     }
@@ -1062,9 +1062,9 @@ void setVMRoot(tcb_t *tcb)
     find_ret = findPDForASID(asid);
     if (unlikely(find_ret.status != EXCEPTION_NONE || find_ret.pd != pd)) {
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
-        setCurrentPD(addrFromPPtr(armUSGlobalPD));
+        setCurrentPD(addrFromKPPtr(armUSGlobalPD));
 #else
-        setCurrentPD(addrFromPPtr(armKSGlobalPD));
+        setCurrentPD(addrFromKPPtr(armKSGlobalPD));
 #endif
         return;
     }
@@ -1248,7 +1248,7 @@ void copyGlobalMappings(pde_t *newPD)
     /* Kernel and user MMUs are completely independent, however,
      * we still need to share the globals page. */
     pde_t pde;
-    pde = pde_pde_coarse_new(addrFromPPtr(armUSGlobalPT));
+    pde = pde_pde_coarse_new(addrFromKPPtr(armUSGlobalPT));
     newPD[BIT(PD_INDEX_BITS) - 1] = pde;
 #endif /* CONFIG_KERNEL_GLOBALS_FRAME */
 #endif
@@ -2765,7 +2765,7 @@ exception_t benchmark_arch_map_logBuffer(word_t frame_cptr)
                 0  /* executable */
             );
 
-        cleanByVA_PoU((vptr_t)&armKSGlobalLogPT[idx], pptr_to_paddr(&armKSGlobalLogPT[idx]));
+        cleanByVA_PoU((vptr_t)&armKSGlobalLogPT[idx], addrFromKPPtr(&armKSGlobalLogPT[idx]));
         invalidateTranslationSingle(KS_LOG_PPTR + (idx * BIT(seL4_PageBits)));
     }
 

--- a/src/arch/arm/32/object/objecttype.c
+++ b/src/arch/arm/32/object/objecttype.c
@@ -199,7 +199,7 @@ finaliseCap_ret_t Arch_finaliseCap(cap_t cap, bool_t final)
 
                     cleanCacheRange_PoU((pptr_t) &armKSGlobalLogPT[0],
                                         (pptr_t) &armKSGlobalLogPT[0] + BIT(seL4_PageTableBits),
-                                        addrFromPPtr((void *)&armKSGlobalLogPT[0]));
+                                        addrFromKPPtr((void *)&armKSGlobalLogPT[0]));
 
                     for (int idx = 0; idx < BIT(PT_INDEX_BITS); idx++) {
                         invalidateTranslationSingle(KS_LOG_PPTR + (idx << seL4_PageBits));

--- a/src/arch/arm/64/kernel/thread.c
+++ b/src/arch/arm/64/kernel/thread.c
@@ -30,7 +30,7 @@ void Arch_switchToIdleThread(void)
     if (config_set(CONFIG_ARM_HYPERVISOR_SUPPORT)) {
         vcpu_switch(NULL);
     }
-    setCurrentUserVSpaceRoot(ttbr_new(0, pptr_to_paddr(armKSGlobalUserVSpace)));
+    setCurrentUserVSpaceRoot(ttbr_new(0, addrFromKPPtr(armKSGlobalUserVSpace)));
 }
 
 void Arch_activateIdleThread(tcb_t *tcb)

--- a/src/arch/arm/64/kernel/vspace.c
+++ b/src/arch/arm/64/kernel/vspace.c
@@ -249,12 +249,12 @@ BOOT_CODE void map_kernel_window(void)
 
     /* place the PUD into the PGD */
     armKSGlobalKernelPGD[GET_PGD_INDEX(PPTR_BASE)] = pgde_pgde_pud_new(
-                                                         pptr_to_paddr(armKSGlobalKernelPUD));
+                                                         addrFromKPPtr(armKSGlobalKernelPUD));
 
     /* place all PDs except the last one in PUD */
     for (idx = GET_PUD_INDEX(PPTR_BASE); idx < GET_PUD_INDEX(PPTR_TOP); idx++) {
         armKSGlobalKernelPUD[idx] = pude_pude_pd_new(
-                                        pptr_to_paddr(&armKSGlobalKernelPDs[idx][0])
+                                        addrFromKPPtr(&armKSGlobalKernelPDs[idx][0])
                                     );
     }
 
@@ -279,12 +279,12 @@ BOOT_CODE void map_kernel_window(void)
 
     /* put the PD into the PUD for device window */
     armKSGlobalKernelPUD[GET_PUD_INDEX(PPTR_TOP)] = pude_pude_pd_new(
-                                                        pptr_to_paddr(&armKSGlobalKernelPDs[BIT(PUD_INDEX_BITS) - 1][0])
+                                                        addrFromKPPtr(&armKSGlobalKernelPDs[BIT(PUD_INDEX_BITS) - 1][0])
                                                     );
 
     /* put the PT into the PD for device window */
     armKSGlobalKernelPDs[BIT(PUD_INDEX_BITS) - 1][BIT(PD_INDEX_BITS) - 1] = pde_pde_small_new(
-                                                                                pptr_to_paddr(armKSGlobalKernelPT)
+                                                                                addrFromKPPtr(armKSGlobalKernelPT)
                                                                             );
 
     map_kernel_devices();
@@ -534,10 +534,10 @@ BOOT_CODE cap_t create_mapped_it_frame_cap(cap_t pd_cap, pptr_t pptr, vptr_t vpt
 BOOT_CODE void activate_kernel_vspace(void)
 {
     cleanInvalidateL1Caches();
-    setCurrentKernelVSpaceRoot(ttbr_new(0, pptr_to_paddr(armKSGlobalKernelPGD)));
+    setCurrentKernelVSpaceRoot(ttbr_new(0, addrFromKPPtr(armKSGlobalKernelPGD)));
 
     /* Prevent elf-loader address translation to fill up TLB */
-    setCurrentUserVSpaceRoot(ttbr_new(0, pptr_to_paddr(armKSGlobalUserVSpace)));
+    setCurrentUserVSpaceRoot(ttbr_new(0, addrFromKPPtr(armKSGlobalUserVSpace)));
 
     invalidateLocalTLB();
     lockTLBEntry(KERNEL_ELF_BASE);
@@ -991,7 +991,7 @@ void setVMRoot(tcb_t *tcb)
     threadRoot = TCB_PTR_CTE_PTR(tcb, tcbVTable)->cap;
 
     if (!isValidNativeRoot(threadRoot)) {
-        setCurrentUserVSpaceRoot(ttbr_new(0, pptr_to_paddr(armKSGlobalUserVSpace)));
+        setCurrentUserVSpaceRoot(ttbr_new(0, addrFromKPPtr(armKSGlobalUserVSpace)));
         return;
     }
 
@@ -999,7 +999,7 @@ void setVMRoot(tcb_t *tcb)
     asid = cap_vtable_root_get_mappedASID(threadRoot);
     find_ret = findVSpaceForASID(asid);
     if (unlikely(find_ret.status != EXCEPTION_NONE || find_ret.vspace_root != vspaceRoot)) {
-        setCurrentUserVSpaceRoot(ttbr_new(0, pptr_to_paddr(armKSGlobalUserVSpace)));
+        setCurrentUserVSpaceRoot(ttbr_new(0, addrFromKPPtr(armKSGlobalUserVSpace)));
         return;
     }
 
@@ -2560,7 +2560,7 @@ exception_t benchmark_arch_map_logBuffer(word_t frame_cptr)
                              0,                         /* VMKernelOnly */
                              NORMAL);
 
-    cleanByVA_PoU((vptr_t)armKSGlobalLogPDE, pptr_to_paddr(armKSGlobalLogPDE));
+    cleanByVA_PoU((vptr_t)armKSGlobalLogPDE, addrFromKPPtr(armKSGlobalLogPDE));
     invalidateTranslationSingle(KS_LOG_PPTR);
     return EXCEPTION_NONE;
 }

--- a/src/arch/x86/32/kernel/vspace.c
+++ b/src/arch/x86/32/kernel/vspace.c
@@ -245,7 +245,7 @@ BOOT_CODE bool_t map_kernel_window(
 #ifdef CONFIG_KERNEL_LOG_BUFFER
     /* Map global page table for the log buffer */
     pde = pde_pde_pt_new(
-              pptr_to_paddr(ia32KSGlobalLogPT), /* pt_base_address  */
+              kpptr_to_paddr(ia32KSGlobalLogPT), /* pt_base_address  */
               0,                 /* avl              */
               0,                 /* accessed         */
               0,                 /* cache_disabled   */
@@ -271,7 +271,7 @@ BOOT_CODE bool_t map_kernel_window(
 
     /* map page table of last 4M of virtual address space to page directory */
     pde = pde_pde_pt_new(
-              pptr_to_paddr(ia32KSGlobalPT), /* pt_base_address  */
+              kpptr_to_paddr(ia32KSGlobalPT), /* pt_base_address  */
               0,                 /* avl              */
               0,                 /* accessed         */
               0,                 /* cache_disabled   */
@@ -597,7 +597,7 @@ void setVMRoot(tcb_t *tcb)
     vspace_root = getValidNativeRoot(threadRoot);
     if (!vspace_root) {
         SMP_COND_STATEMENT(tlb_bitmap_unset(paddr_to_pptr(getCurrentPD()), getCurrentCPUIndex());)
-        setCurrentPD(pptr_to_paddr(ia32KSGlobalPD));
+        setCurrentPD(kpptr_to_paddr(ia32KSGlobalPD));
         return;
     }
 
@@ -605,7 +605,7 @@ void setVMRoot(tcb_t *tcb)
     find_ret = findVSpaceForASID(asid);
     if (find_ret.status != EXCEPTION_NONE || find_ret.vspace_root != vspace_root) {
         SMP_COND_STATEMENT(tlb_bitmap_unset(paddr_to_pptr(getCurrentPD()), getCurrentCPUIndex());)
-        setCurrentPD(pptr_to_paddr(ia32KSGlobalPD));
+        setCurrentPD(kpptr_to_paddr(ia32KSGlobalPD));
         return;
     }
 

--- a/src/plat/tk1/machine/smmu.c
+++ b/src/plat/tk1/machine/smmu.c
@@ -85,7 +85,7 @@ static inline void smmu_disable(void)
     if (config_set(CONFIG_ARM_HYPERVISOR_SUPPORT)) {
         /* in hyp mode, we need call the hook in monitor mode */
         /* we need physical address here */
-        paddr_t addr = addrFromPPtr(&do_smmu_disable);
+        paddr_t addr = addrFromKPPtr(&do_smmu_disable);
         asm(".arch_extension sec\n");
         asm volatile("mov r0, %0\n\t"
                      "dsb\nisb\n"
@@ -102,7 +102,7 @@ static inline void smmu_disable(void)
 static inline void smmu_enable(void)
 {
     if (config_set(CONFIG_ARM_HYPERVISOR_SUPPORT)) {
-        paddr_t addr = addrFromPPtr(&do_smmu_enable);
+        paddr_t addr = addrFromKPPtr(&do_smmu_enable);
         asm(".arch_extension sec\n");
         asm volatile("mov r0, %0\n\t"
                      "dsb\nisb\n"


### PR DESCRIPTION
This updates the code such that it assumes that the kernel ELF is not accessed via the physical memory window and instead has a dedicated region into which it is mapped. This has the most noticeable impact for aarch32 which has a verified configuration that *does* access the kernel via the physical memory window.

This will allow configurations with the kernel imaging API to function correctly but will not allow the API to be configured without a dedicated mapping window.