### PR TITLE
CMake: Add support for `cmake install <dir>` cmd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -583,3 +583,49 @@ target_link_libraries(kernel.elf PRIVATE kernel_Config kernel_autoconf)
 set_property(TARGET kernel.elf APPEND_STRING PROPERTY LINK_FLAGS " -Wl,-T ${linker_lds_path} ")
 set_target_properties(kernel.elf PROPERTIES LINK_DEPENDS "${linker_lds_path}")
 add_dependencies(kernel.elf circular_includes)
+
+# The following commands setup the install target for copying generated files and
+# compilation outputs to an install location: CMAKE_INSTALL_PREFIX.
+# CMAKE_INSTALL_PREFIX can be set on the cmake command line.
+#
+# The current installation outputs are:
+# - ${CMAKE_INSTALL_PREFIX}/bin/kernel.elf: Location of kernel.elf binary
+# - ${CMAKE_INSTALL_PREFIX}/libsel4/include: The include root for libsel4
+# - ${CMAKE_INSTALL_PREFIX}/libsel4/src: The c source files for the libsel4 library
+#
+# The install target is only created if this is the top level project.
+# We don't currently support creating install targets if the kernel is
+# imported in another project.
+if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
+
+    # Import libsel4 to get access to generation targets
+    add_subdirectory(libsel4)
+    # Add a default target that builds kernel.elf and generates all libsel4 headers
+    add_custom_target(single-project ALL DEPENDS sel4_generated kernel.elf)
+    # Disable the libsel4.a target as we don't intend to build the libsel4 sources
+    set_target_properties(sel4 PROPERTIES EXCLUDE_FROM_ALL ON)
+    # Install kernel.elf to bin/kernel.elf
+    install(TARGETS kernel.elf RUNTIME DESTINATION bin)
+    # Install all libsel4 headers to libsel4/include
+    install(
+        DIRECTORY
+            "${CMAKE_CURRENT_SOURCE_DIR}/libsel4/include/"
+            "${CMAKE_CURRENT_SOURCE_DIR}/libsel4/arch_include/${KernelArch}/"
+            "${CMAKE_CURRENT_SOURCE_DIR}/libsel4/sel4_arch_include/${KernelSel4Arch}/"
+            "${CMAKE_CURRENT_SOURCE_DIR}/libsel4/sel4_plat_include/${KernelPlatform}/"
+            "${CMAKE_CURRENT_SOURCE_DIR}/libsel4/mode_include/${KernelWordSize}/"
+            "${CMAKE_CURRENT_BINARY_DIR}/libsel4/include/"
+            "${CMAKE_CURRENT_BINARY_DIR}/libsel4/arch_include/${KernelArch}/"
+            "${CMAKE_CURRENT_BINARY_DIR}/libsel4/sel4_arch_include/${KernelSel4Arch}/"
+            # The following directories install the autoconf headers
+            "${CMAKE_CURRENT_BINARY_DIR}/gen_config/"
+            "${CMAKE_CURRENT_BINARY_DIR}/libsel4/gen_config/"
+            "${CMAKE_CURRENT_BINARY_DIR}/libsel4/autoconf/"
+        DESTINATION libsel4/include
+        FILES_MATCHING
+        PATTERN "*.h"
+    )
+    # Install libsel4 sources to libsel4/src
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/libsel4/src/" DESTINATION libsel4/src)
+
+endif()

--- a/gcc.cmake
+++ b/gcc.cmake
@@ -12,7 +12,6 @@ set(CMAKE_SYSTEM_NAME Generic)
 set(CMAKE_SYSTEM_PROCESSOR seL4CPU)
 
 set(CMAKE_SYSROOT "${CMAKE_BINARY_DIR}")
-set(CMAKE_STAGING_PREFIX "${CMAKE_BINARY_DIR}/staging")
 
 # When this file is passed to configure_file in cmake, these variables get set to
 # the kernel platform configuration.


### PR DESCRIPTION
When using CMake to only build the kernel, an install target is now
provided to copy important outputs into an installation directory.

Currently only the following files are installed:
- ./bin/kernel.elf: Location of kernel.elf binary
- ./kernel_Config/include: The include root for the kernel_Config
  interface library
- ./libsel4/include: The include root for libsel4
- ./libsel4/src: The c source files for the libsel4 library
- ./libsel4/sel4_Config/include: The include root for the sel4_Config
  interface library
- ./libsel4/autoconf/include: The include root for the autoconf interface
  library

To build and install this project to an installation directory should
now only require the following from a clean build directory:
```
cmake -G Ninja -DCMAKE_INSTALL_PREFIX=<path-to-install> -DOption=val <src-dir>;
cmake --build .;
cmake --install .;
```
