### PR TITLE
github: CI action to lint seL4 IDL files

### DIFF
--- a/.github/workflows/xml_lint.yml
+++ b/.github/workflows/xml_lint.yml
@@ -1,0 +1,30 @@
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+# xmllint for seL4 IDL files
+
+name: XML
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'libsel4/**/sel4*.xml'
+  pull_request:
+    paths:
+      - 'libsel4/**/sel4*.xml'
+
+jobs:
+  xmllint:
+    name: XML Lint
+    runs-on: ubuntu-latest
+    steps:
+    - name: install xmllint
+      run: sudo apt-get install libxml2-utils
+    - uses: actions/checkout@v2
+    - name: run xmllint
+      run: |
+        find libsel4 -name "sel4*.xml" | \
+        xargs xmllint --dtdvalid libsel4/tools/sel4_idl.dtd --noout


### PR DESCRIPTION
This will lint everything called `sel4*.xml` in `libsel4` and should trigger only on changes to those files.

Closes seL4/ci-actions#70