### PR TITLE
risc-v: don't add 8 bytes space at end of bss

### DIFF
--- a/src/arch/riscv/common_riscv.lds
+++ b/src/arch/riscv/common_riscv.lds
@@ -1,6 +1,7 @@
 /*
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  * Copyright 2015, 2016 Hesham Almatary <heshamelmatary@gmail.com>
+ * Copyright 2021, HENSOLDT Cyber
  *
  * SPDX-License-Identifier: GPL-2.0-only
  */
@@ -80,7 +81,6 @@ SECTIONS
 
         /* large data such as the globals frame and global PD */
         *(.bss.aligned)
-        . = . + 8;
     }
 
     . = ALIGN(4K);


### PR DESCRIPTION
Is there any explanation what this is for?