### PR TITLE
ARM/RISC-V: boot documentation improvements and cleanup

### DIFF
--- a/src/arch/arm/32/head.S
+++ b/src/arch/arm/32/head.S
@@ -1,5 +1,6 @@
 /*
  * Copyright 2014, General Dynamics C4 Systems
+ * Copyright 2021, HENSOLDT Cyber
  *
  * SPDX-License-Identifier: GPL-2.0-only
  */
@@ -160,10 +161,25 @@ BEGIN_FUNC(_start)
 
     /* Put the DTB address back on the new stack for init_kernel. */
     push {r7, r8}
-    /* Call bootstrapping implemented in C */
+
+    /* Call bootstrapping implemented in C with parameters:
+     *   r0: user image physical start address
+     *   r1: user image physical end address
+     *   r2: physical/virtual offset
+     *   r3: user image virtual entry address
+     *   sp[0]: DTB physical address (0 if there is none)
+     *   sp[1]: DTB size (0 if there is none)
+     */
     blx init_kernel
 
-    /* Restore the initial thread */
+    /* Restore the initial thread. Note that the function restore_user_context()
+     * could technically also be called at the end of init_kernel() directly,
+     * there is no need to return to the assembly code here at all. However, for
+     * verification things are a lot easier when init_kernel() is a normal C
+     * function that returns. The function restore_user_context() is not a
+     * normal C function and thus handled specially in verification, it does
+     * highly architecture specific things to exit to user mode.
+     */
     b restore_user_context
 
 END_FUNC(_start)

--- a/src/arch/arm/64/head.S
+++ b/src/arch/arm/64/head.S
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ * Copyright 2021, HENSOLDT Cyber
  *
  * SPDX-License-Identifier: GPL-2.0-only
  */
@@ -113,9 +114,24 @@ BEGIN_FUNC(_start)
     ldp     x2, x3, [sp], #16
     ldp     x0, x1, [sp], #16
 
-    /* Call bootstrapping implemented in C */
+    /* Call bootstrapping implemented in C with parameters:
+     *  x0: user image physical start address
+     *  x1: user image physical end address
+     *  x2: physical/virtual offset
+     *  x3: user image virtual entry address
+     *  x4: DTB physical address (0 if there is none)
+     *  x5: DTB size (0 if there is none)
+     */
     bl      init_kernel
 
-    /* Restore the initial thread */
+    /* Restore the initial thread. Note that the function restore_user_context()
+     * could technically also be called at the end of init_kernel() directly,
+     * there is no need to return to the assembly code here at all. However, for
+     * verification things are a lot easier when init_kernel() is a normal C
+     * function that returns. The function restore_user_context() is not a
+     * normal C function and thus handled specially in verification, it does
+     * highly architecture specific things to exit to user mode.
+     */
     b restore_user_context
+
 END_FUNC(_start)

--- a/src/arch/riscv/head.S
+++ b/src/arch/riscv/head.S
@@ -1,6 +1,7 @@
 /*
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  * Copyright 2015, 2016 Hesham Almatary <heshamelmatary@gmail.com>
+ * Copyright 2021, HENSOLDT Cyber
  *
  * SPDX-License-Identifier: GPL-2.0-only
  */
@@ -38,7 +39,25 @@ _start:
   csrw sscratch, sp
 #endif
 
+  /* Call bootstrapping implemented in C with parameters:
+   *    a0/x10: user image physical start address
+   *    a1/x11: user image physical end address
+   *    a2/x12: physical/virtual offset
+   *    a3/x13: user image virtual entry address
+   *    a4/x14: DTB physical address (0 if there is none)
+   *    a5/x15: DTB size (0 if there is none)
+   *    a6/x16: hart ID (SMP only, unused on non-SMP)
+   *    a7/x17: core ID (SMP only, unused on non-SMP)
+   */
   jal init_kernel
 
+  /* Restore the initial thread. Note that the function restore_user_context()
+   * could technically also be called at the end of init_kernel() directly,
+   * there is no need to return to the assembly code here at all. However, for
+   * verification things are a lot easier when init_kernel() is a normal C
+   * function that returns. The function restore_user_context() is not a
+   * normal C function and thus handled specially in verification, it does
+   * highly architecture specific things to exit to user mode.
+   */
   la ra, restore_user_context
   jr ra

--- a/src/arch/riscv/head.S
+++ b/src/arch/riscv/head.S
@@ -14,7 +14,6 @@
 .extern kernel_stack_alloc
 .extern __global_pointer$
 .extern restore_user_context
-.extern trap_entry
 
 /*
  * When SMP is enabled, the elfloader passes the hart ID in a6

--- a/src/arch/riscv/traps.S
+++ b/src/arch/riscv/traps.S
@@ -22,7 +22,6 @@
 .extern c_handle_fastpath_call
 .extern c_handle_interrupt
 .extern c_handle_exception
-.extern restore_user_context
 
 trap_entry:
 


### PR DESCRIPTION
* remove unused references
* don't return to asm code during boot