### PR TITLE
trivial: use proper naming in comment

### DIFF
--- a/src/arch/riscv/kernel/boot.c
+++ b/src/arch/riscv/kernel/boot.c
@@ -391,7 +391,7 @@ static BOOT_CODE bool_t try_init_kernel(
         return false;
     }
 
-    /* no shared-frame caps (RISCV has no multikernel support) */
+    /* no shared-frame caps (RISC-V has no multikernel support) */
     ndks_boot.bi_frame->sharedFrames = S_REG_EMPTY;
 
     /* finalise the bootinfo frame */


### PR DESCRIPTION
"RISCV" -> "RISC-V"