### PR TITLE
risc-v/boot: verbosely log boot errors

### DIFF
--- a/src/arch/arm/kernel/boot.c
+++ b/src/arch/arm/kernel/boot.c
@@ -360,7 +360,7 @@ static BOOT_CODE bool_t try_init_kernel(
     it_v_reg.end = extra_bi_frame_vptr + BIT(extra_bi_size_bits);
 
     if (it_v_reg.end >= USER_TOP) {
-        printf("Userland image virtual end address too high\n");
+        printf("ERROR: userland image virtual end address too high\n");
         return false;
     }
 
@@ -369,6 +369,7 @@ static BOOT_CODE bool_t try_init_kernel(
 
     /* initialise the CPU */
     if (!init_cpu()) {
+        printf("ERROR: CPU init failed\n");
         return false;
     }
 
@@ -386,6 +387,7 @@ static BOOT_CODE bool_t try_init_kernel(
     /* create the root cnode */
     root_cnode_cap = create_root_cnode();
     if (cap_get_capType(root_cnode_cap) == cap_null_cap) {
+        printf("ERROR: root c-node creation failed\n");
         return false;
     }
 
@@ -424,6 +426,7 @@ static BOOT_CODE bool_t try_init_kernel(
         ndks_boot.bi_frame->ioSpaceCaps = create_iospace_caps(root_cnode_cap);
         if (ndks_boot.bi_frame->ioSpaceCaps.start == 0 &&
             ndks_boot.bi_frame->ioSpaceCaps.end == 0) {
+            printf("ERROR: SMMU I/O space creation failed\n");
             return false;
         }
     } else {
@@ -434,6 +437,7 @@ static BOOT_CODE bool_t try_init_kernel(
      * to cover the user image + ipc buffer and bootinfo frames */
     it_pd_cap = create_it_address_space(root_cnode_cap, it_v_reg);
     if (cap_get_capType(it_pd_cap) == cap_null_cap) {
+        printf("ERROR: address space creation for initial thread failed\n");
         return false;
     }
 
@@ -459,6 +463,7 @@ static BOOT_CODE bool_t try_init_kernel(
                 pptr_to_paddr((void *)extra_bi_region.start) - extra_bi_frame_vptr
             );
         if (!extra_bi_ret.success) {
+            printf("ERROR: mapping extra boot info to initial thread failed\n");
             return false;
         }
         ndks_boot.bi_frame->extraBIPages = extra_bi_ret.region;
@@ -471,6 +476,7 @@ static BOOT_CODE bool_t try_init_kernel(
     /* create the initial thread's IPC buffer */
     ipcbuf_cap = create_ipcbuf_frame_cap(root_cnode_cap, it_pd_cap, ipcbuf_vptr);
     if (cap_get_capType(ipcbuf_cap) == cap_null_cap) {
+        printf("ERROR: could not create IPC buffer for initial thread\n");
         return false;
     }
 
@@ -484,6 +490,7 @@ static BOOT_CODE bool_t try_init_kernel(
             pv_offset
         );
     if (!create_frames_ret.success) {
+        printf("ERROR: could not create all userland image frames\n");
         return false;
     }
     ndks_boot.bi_frame->userImageFrames = create_frames_ret.region;
@@ -491,6 +498,7 @@ static BOOT_CODE bool_t try_init_kernel(
     /* create/initialise the initial thread's ASID pool */
     it_ap_cap = create_it_asid_pool(root_cnode_cap);
     if (cap_get_capType(it_ap_cap) == cap_null_cap) {
+        printf("ERROR: could not create ASID pool for initial thread\n");
         return false;
     }
     write_it_asid_pool(it_ap_cap, it_pd_cap);
@@ -501,6 +509,7 @@ static BOOT_CODE bool_t try_init_kernel(
 
     /* create the idle thread */
     if (!create_idle_thread()) {
+        printf("ERROR: could not create idle thread\n");
         return false;
     }
 
@@ -521,6 +530,7 @@ static BOOT_CODE bool_t try_init_kernel(
                      );
 
     if (initial == NULL) {
+        printf("ERROR: could not create initial thread\n");
         return false;
     }
 
@@ -533,6 +543,7 @@ static BOOT_CODE bool_t try_init_kernel(
     KERNEL_ELF_BASE, (pptr_t)ki_boot_end
     } /* reusable boot code/data */
         )) {
+        printf("ERROR: could not create untypteds for kernel image boot memory\n");
         return false;
     }
 
@@ -605,7 +616,7 @@ BOOT_CODE VISIBLE void init_kernel(
 #endif /* ENABLE_SMP_SUPPORT */
 
     if (!result) {
-        fail("Kernel init failed for some reason :(");
+        fail("ERROR: kernel init failed");
     }
 
 #ifdef CONFIG_KERNEL_MCS

--- a/src/arch/arm/kernel/boot.c
+++ b/src/arch/arm/kernel/boot.c
@@ -617,6 +617,7 @@ BOOT_CODE VISIBLE void init_kernel(
 
     if (!result) {
         fail("ERROR: kernel init failed");
+        UNREACHABLE();
     }
 
 #ifdef CONFIG_KERNEL_MCS

--- a/src/arch/riscv/kernel/boot.c
+++ b/src/arch/riscv/kernel/boot.c
@@ -260,6 +260,7 @@ static BOOT_CODE bool_t try_init_kernel(
     /* create the root cnode */
     root_cnode_cap = create_root_cnode();
     if (cap_get_capType(root_cnode_cap) == cap_null_cap) {
+        printf("ERROR: root c-node creation failed\n");
         return false;
     }
 
@@ -295,6 +296,7 @@ static BOOT_CODE bool_t try_init_kernel(
      * to cover the user image + ipc buffer and bootinfo frames */
     it_pd_cap = create_it_address_space(root_cnode_cap, it_v_reg);
     if (cap_get_capType(it_pd_cap) == cap_null_cap) {
+        printf("ERROR: address space creation for initial thread failed\n");
         return false;
     }
 
@@ -320,6 +322,7 @@ static BOOT_CODE bool_t try_init_kernel(
                 pptr_to_paddr((void *)extra_bi_region.start) - extra_bi_frame_vptr
             );
         if (!extra_bi_ret.success) {
+            printf("ERROR: mapping extra boot info to initial thread failed\n");
             return false;
         }
         ndks_boot.bi_frame->extraBIPages = extra_bi_ret.region;
@@ -332,6 +335,7 @@ static BOOT_CODE bool_t try_init_kernel(
     /* create the initial thread's IPC buffer */
     ipcbuf_cap = create_ipcbuf_frame_cap(root_cnode_cap, it_pd_cap, ipcbuf_vptr);
     if (cap_get_capType(ipcbuf_cap) == cap_null_cap) {
+        printf("ERROR: could not create IPC buffer for initial thread\n");
         return false;
     }
 
@@ -345,6 +349,7 @@ static BOOT_CODE bool_t try_init_kernel(
             pv_offset
         );
     if (!create_frames_ret.success) {
+        printf("ERROR: could not create all userland image frames\n");
         return false;
     }
     ndks_boot.bi_frame->userImageFrames = create_frames_ret.region;
@@ -352,6 +357,7 @@ static BOOT_CODE bool_t try_init_kernel(
     /* create the initial thread's ASID pool */
     it_ap_cap = create_it_asid_pool(root_cnode_cap);
     if (cap_get_capType(it_ap_cap) == cap_null_cap) {
+        printf("ERROR: could not create ASID pool for initial thread\n");
         return false;
     }
     write_it_asid_pool(it_ap_cap, it_pd_cap);
@@ -362,6 +368,7 @@ static BOOT_CODE bool_t try_init_kernel(
 
     /* create the idle thread */
     if (!create_idle_thread()) {
+        printf("ERROR: could not create idle thread\n");
         return false;
     }
 
@@ -376,6 +383,7 @@ static BOOT_CODE bool_t try_init_kernel(
                      );
 
     if (initial == NULL) {
+        printf("ERROR: could not create initial thread\n");
         return false;
     }
 
@@ -385,6 +393,7 @@ static BOOT_CODE bool_t try_init_kernel(
     if (!create_untypeds(
             root_cnode_cap,
             boot_mem_reuse_reg)) {
+        printf("ERROR: could not create untypteds for kernel image boot memory\n");
         return false;
     }
 
@@ -445,7 +454,7 @@ BOOT_CODE VISIBLE void init_kernel(
                              dtb_end_p);
 #endif
     if (!result) {
-        fail("Kernel init failed for some reason :(");
+        fail("ERROR: kernel init failed");
     }
 
 #ifdef CONFIG_KERNEL_MCS

--- a/src/arch/riscv/kernel/boot.c
+++ b/src/arch/riscv/kernel/boot.c
@@ -455,6 +455,7 @@ BOOT_CODE VISIBLE void init_kernel(
 #endif
     if (!result) {
         fail("ERROR: kernel init failed");
+        UNREACHABLE();
     }
 
 #ifdef CONFIG_KERNEL_MCS


### PR DESCRIPTION
Log an explicit error message for everything that can fail during boot. This is helpful for debugging, e.g. when porting the kernel to a new platform or changing the system configuration.