### PR TITLE
boot/risc-v: grab BKL on primary core for SMP

### DIFF
--- a/src/arch/arm/kernel/boot.c
+++ b/src/arch/arm/kernel/boot.c
@@ -563,7 +563,11 @@ static BOOT_CODE bool_t try_init_kernel(
     SMP_COND_STATEMENT(clh_lock_init());
     SMP_COND_STATEMENT(release_secondary_cpus());
 
-    /* grab BKL before leaving the kernel */
+    /* All cores are up now, so there can be concurrency. The kernel booting is
+     * supposed to be finished before the secondary cores are released, all the
+     * primary has to do now is schedule the initial thread. Currently there is
+     * nothing that touches any global data structures, nevertheless we grab the
+     * BKL here to play safe. It is released when the kernel is left. */
     NODE_LOCK_SYS;
 
     printf("Booting all finished, dropped to user space\n");

--- a/src/arch/riscv/kernel/boot.c
+++ b/src/arch/riscv/kernel/boot.c
@@ -405,6 +405,13 @@ static BOOT_CODE bool_t try_init_kernel(
     SMP_COND_STATEMENT(clh_lock_init());
     SMP_COND_STATEMENT(release_secondary_cores());
 
+    /* All cores are up now, so there can be concurrency. The kernel booting is
+     * supposed to be finished before the secondary cores are released, all the
+     * primary has to do now is schedule the initial thread. Currently there is
+     * nothing that touches any global data structures, nevertheless we grab the
+     * BKL here to play safe. It is released when the kernel is left. */
+    NODE_LOCK_SYS;
+
     printf("Booting all finished, dropped to user space\n");
     return true;
 }


### PR DESCRIPTION
Comparing the RISC-V and ARM code, it seems on RISC-V the BKL should also be taken once all cores are up - just to play safe.
