### PR TITLE
add CII badge + CI badges + some README cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,16 @@ seL4 Basics
 Community
 ---------
 
-- Mailing lists
+- Forums:
+  - [Discourse](https://sel4.discourse.group/)
   - [seL4 Announce](https://lists.sel4.systems/postorius/lists/announce.sel4.systems)
   - [seL4 Devel](https://lists.sel4.systems/postorius/lists/devel.sel4.systems)
 - [Suggested projects](https://docs.sel4.systems/SuggestedProjects)
-- [CommunityProjects](https://docs.sel4.systems/CommunityProjects)
+- [Community projects](https://docs.sel4.systems/CommunityProjects)
+
+See the [contact] links on the seL4 website for the full list.
+
+[contact]: https://sel4.systems/contact.html
 
 Reporting security vulnerabilities
 ----------------------------------

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ The seL4 microkernel
 ====================
 
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/5003/badge)](https://bestpractices.coreinfrastructure.org/projects/5003)
+[![CI](https://github.com/seL4/seL4/actions/workflows/push.yml/badge.svg)](https://github.com/seL4/seL4/actions/workflows/push.yml)
+[![C Parser](https://github.com/seL4/seL4/actions/workflows/cparser.yml/badge.svg)](https://github.com/seL4/seL4/actions/workflows/cparser.yml)
+[![Kernel](https://github.com/seL4/seL4/actions/workflows/compilation-checks.yml/badge.svg)](https://github.com/seL4/seL4/actions/workflows/compilation-checks.yml)
+[![RefMan](https://github.com/seL4/seL4/actions/workflows/manual.yml/badge.svg)](https://github.com/seL4/seL4/actions/workflows/manual.yml)
+[![XML](https://github.com/seL4/seL4/actions/workflows/xml_lint.yml/badge.svg)](https://github.com/seL4/seL4/actions/workflows/xml_lint.yml)
 
 This project contains the source code of seL4 microkernel.
 

--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ correctness proof, please see the [`sel4.systems`][1] website and associated
 [FAQ][2].
 
 DOIs for citing recent releases of this repository:
-  * [![DOI][4]](https://doi.org/10.5281/zenodo.591727)
+
+- [![DOI][4]](https://doi.org/10.5281/zenodo.591727)
 
 We welcome contributions to seL4. Please see the website for information
 on [how to contribute][3].
 
 This repository is usually not used in isolation, but as part of the build
 system in a larger project.
-
 
   [1]: http://sel4.systems/
   [2]: https://docs.sel4.systems/projects/sel4/frequently-asked-questions
@@ -52,7 +52,6 @@ seL4 Basics
 - [Host Build Dependencies](https://docs.sel4.systems/projects/buildsystem/host-dependencies.html)
 - [Porting seL4](https://docs.sel4.systems/projects/sel4/porting)
 
-
 Community
 ---------
 
@@ -62,7 +61,6 @@ Community
 - [Suggested projects](https://docs.sel4.systems/SuggestedProjects)
 - [CommunityProjects](https://docs.sel4.systems/CommunityProjects)
 
-
 Reporting security vulnerabilities
 ----------------------------------
 
@@ -70,7 +68,6 @@ If you believe you have found a security vulnerability in seL4 or related
 software, we ask you to follow our [vulnerability disclosure policy][VDP].
 
 [VDP]: https://github.com/seL4/seL4/blob/master/SECURITY.md
-
 
 Manual
 ------
@@ -82,17 +79,15 @@ A web version of the API can be found [here][8]
 Repository Overview
 -------------------
 
-  * `include` and `src`: C and ASM source code of seL4
-  * `tools`: build tools
-  * `libsel4`: C bindings for the seL4 ABI
-  * `manual`: LaTeX sources of the seL4 reference manual
-
+- `include` and `src`: C and ASM source code of seL4
+- `tools`: build tools
+- `libsel4`: C bindings for the seL4 ABI
+- `manual`: LaTeX sources of the seL4 reference manual
 
 Build Instructions
 ------------------
 
 See the seL4 website for [build instructions][6].
-
 
 Status
 ------
@@ -101,7 +96,8 @@ A list of releases and current project status can be found under [seL4 releases]
 
 - [Roadmap](https://docs.sel4.systems/projects/roadmap): new features in development
 - [Hardware Support](https://docs.sel4.systems/Hardware): information about hardware platform ports
-- [Kernel Features]((https://docs.sel4.systems/projects/sel4/status)): information about available kernel features
-- [Userland Components and Drivers](https://docs.sel4.systems/projects/available-user-components.html): available device drivers and
-      userland components
-
+- [Kernel Features]((https://docs.sel4.systems/projects/sel4/status)): information about available
+  kernel features
+- [Userland Components and
+      Drivers](https://docs.sel4.systems/projects/available-user-components.html): available device
+      drivers and userland components

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 The seL4 microkernel
 ====================
 
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/5003/badge)](https://bestpractices.coreinfrastructure.org/projects/5003)
+
 This project contains the source code of seL4 microkernel.
 
 For details about the seL4 microkernel, including details about its formal


### PR DESCRIPTION
The CII best practise badge must be displayed for the crowd funding platform.

The other badges are there to make CI status easier to see at a glance. They will become more useful once more test are on GitHub Actions.