### PR TITLE
boot: move create_untypeds() to generic code

### DIFF
--- a/include/kernel/boot.h
+++ b/include/kernel/boot.h
@@ -48,8 +48,7 @@ bool_t provide_cap(cap_t root_cnode_cap, cap_t cap);
 cap_t create_it_asid_pool(cap_t root_cnode_cap);
 void write_it_pd_pts(cap_t root_cnode_cap, cap_t it_pd_cap);
 bool_t create_idle_thread(void);
-bool_t create_device_untypeds(cap_t root_cnode_cap, seL4_SlotPos slot_pos_before);
-bool_t create_kernel_untypeds(cap_t root_cnode_cap, region_t boot_mem_reuse_reg, seL4_SlotPos first_untyped_slot);
+bool_t create_untypeds(cap_t root_cnode_cap, region_t boot_mem_reuse_reg);
 void bi_finalise(void);
 void create_domain_cap(cap_t root_cnode_cap);
 

--- a/src/arch/arm/kernel/boot.c
+++ b/src/arch/arm/kernel/boot.c
@@ -136,23 +136,6 @@ BOOT_CODE static void init_smmu(cap_t root_cnode_cap)
 
 #endif
 
-BOOT_CODE static bool_t create_untypeds(cap_t root_cnode_cap, region_t boot_mem_reuse_reg)
-{
-    seL4_SlotPos   slot_pos_before;
-    seL4_SlotPos   slot_pos_after;
-
-    slot_pos_before = ndks_boot.slot_pos_cur;
-    create_device_untypeds(root_cnode_cap, slot_pos_before);
-    create_kernel_untypeds(root_cnode_cap, boot_mem_reuse_reg, slot_pos_before);
-
-    slot_pos_after = ndks_boot.slot_pos_cur;
-    ndks_boot.bi_frame->untyped = (seL4_SlotRegion) {
-        slot_pos_before, slot_pos_after
-    };
-    return true;
-
-}
-
 /** This and only this function initialises the CPU.
  *
  * It does NOT initialise any kernel state.

--- a/src/arch/riscv/kernel/boot.c
+++ b/src/arch/riscv/kernel/boot.c
@@ -26,23 +26,6 @@ BOOT_BSS static volatile word_t node_boot_lock;
 #define MAX_RESERVED 3
 BOOT_BSS static region_t res_reg[MAX_RESERVED];
 
-BOOT_CODE static bool_t create_untypeds(cap_t root_cnode_cap, region_t boot_mem_reuse_reg)
-{
-    seL4_SlotPos   slot_pos_before;
-    seL4_SlotPos   slot_pos_after;
-
-    slot_pos_before = ndks_boot.slot_pos_cur;
-    create_device_untypeds(root_cnode_cap, slot_pos_before);
-    bool_t res = create_kernel_untypeds(root_cnode_cap, boot_mem_reuse_reg, slot_pos_before);
-
-    slot_pos_after = ndks_boot.slot_pos_cur;
-    ndks_boot.bi_frame->untyped = (seL4_SlotRegion) {
-        slot_pos_before, slot_pos_after
-    };
-    return res;
-
-}
-
 BOOT_CODE cap_t create_mapped_it_frame_cap(cap_t pd_cap, pptr_t pptr, vptr_t vptr, asid_t asid, bool_t
                                            use_large, bool_t executable)
 {

--- a/src/arch/x86/kernel/boot.c
+++ b/src/arch/x86/kernel/boot.c
@@ -67,24 +67,6 @@ BOOT_CODE static void init_irqs(cap_t root_cnode_cap)
     write_slot(SLOT_PTR(pptr_of_cap(root_cnode_cap), seL4_CapIRQControl), cap_irq_control_cap_new());
 }
 
-BOOT_CODE static bool_t create_untypeds(
-    cap_t root_cnode_cap,
-    region_t boot_mem_reuse_reg)
-{
-    seL4_SlotPos     slot_pos_before;
-    seL4_SlotPos     slot_pos_after;
-
-    slot_pos_before = ndks_boot.slot_pos_cur;
-    create_device_untypeds(root_cnode_cap, slot_pos_before);
-    create_kernel_untypeds(root_cnode_cap, boot_mem_reuse_reg, slot_pos_before);
-
-    slot_pos_after = ndks_boot.slot_pos_cur;
-    ndks_boot.bi_frame->untyped = (seL4_SlotRegion) {
-        slot_pos_before, slot_pos_after
-    };
-    return true;
-}
-
 BOOT_CODE static bool_t arch_init_freemem(p_region_t ui_p_reg, v_region_t v_reg,
                                           mem_p_regs_t *mem_p_regs,
                                           word_t extra_bi_size_bits)


### PR DESCRIPTION
- move `create_untypeds()` to generic code.
- merge `create_device_untypeds()` and `create_kernel_untypeds()` into `create_untypeds()` to simplify the code.