### PR TITLE
risc-v: add COMMON section to linker script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,6 +182,15 @@ add_compile_options(
     -Wpointer-arith
     -Wno-nonnull
     -ffreestanding
+    # GCC < 10 and clang < 11 put uninitialized global variables into a 'COMMON'
+    # section unless '-fno-common' is specified. The linker will put anything
+    # from 'COMMON' as the end of the '.bss' it nothing else is specified in the
+    # linker script. Besides making the variable placement look odd, this also
+    # tends to waste a page because we puts large aligned block at the end.
+    # Eventually, GCC 10 and clang 11 made '-fno-common' the default, see
+    # - https://gcc.gnu.org/gcc-10/changes.html
+    # - https://releases.llvm.org/11.0.0/tools/clang/docs/ReleaseNotes.html
+    -fno-common
 )
 
 # Add all the common flags to the linker args

--- a/src/arch/arm/common_arm.lds
+++ b/src/arch/arm/common_arm.lds
@@ -62,6 +62,7 @@ SECTIONS
     .bss . : AT(ADDR(.bss) - KERNEL_OFFSET)
     {
         *(.bss)
+        *(COMMON) /* fallback in case '-fno-common' is not used */
 
         /* 4k breakpoint stack */
         _breakpoint_stack_bottom = .;

--- a/src/arch/riscv/common_riscv.lds
+++ b/src/arch/riscv/common_riscv.lds
@@ -70,6 +70,7 @@ SECTIONS
     .bss . : AT(ADDR(.bss) - KERNEL_OFFSET)
     {
         *(.bss)
+        *(COMMON) /* fallback in case '-fno-common' is not used */
         *(.sbss)
 
         /* 4k breakpoint stack */

--- a/src/plat/pc99/linker.lds
+++ b/src/plat/pc99/linker.lds
@@ -131,7 +131,7 @@ SECTIONS
     .bss . (NOLOAD) : AT(ADDR(.bss) - KERNEL_OFFSET)
     {
         *(.bss)
-        *(COMMON)
+        *(COMMON) /* fallback in case '-fno-common' is not used */
     } :virt
 
     . = ALIGN(4K);


### PR DESCRIPTION
Follow up from a comment from @kent-mcleod at https://github.com/seL4/seL4/pull/421#issuecomment-874375725

With gcc < v10, global variables defined but not initialized get put into the COMMON section. If this section is not declared explicitly, these variables end up at the end of the .bss, which wasts a page.
