### PR TITLE
mcs: Don't move head past max time on unblock

### DIFF
--- a/src/kernel/sporadic.c
+++ b/src/kernel/sporadic.c
@@ -327,7 +327,7 @@ void refill_unblock_check(sched_context_t *sc)
     /* advance earliest activation time to now */
     REFILL_SANITY_START(sc);
     if (refill_ready(sc)) {
-        refill_head(sc)->rTime = NODE_STATE_ON_CORE(ksCurTime, sc->scCore);
+        refill_head(sc)->rTime = MIN(MAX_RELEASE_TIME, NODE_STATE_ON_CORE(ksCurTime, core));
         NODE_STATE(ksReprogram) = true;
 
         /* merge available replenishments */

--- a/src/kernel/sporadic.c
+++ b/src/kernel/sporadic.c
@@ -167,7 +167,7 @@ void refill_new(sched_context_t *sc, word_t max_refills, ticks_t budget, ticks_t
     /* full budget available */
     refill_head(sc)->rAmount = budget;
     /* budget can be used from now */
-    refill_head(sc)->rTime = NODE_STATE_ON_CORE(ksCurTime, core);
+    refill_head(sc)->rTime = MIN(MAX_RELEASE_TIME, NODE_STATE_ON_CORE(ksCurTime, core));
     maybe_add_empty_tail(sc);
     REFILL_SANITY_CHECK(sc, budget);
 }
@@ -194,7 +194,7 @@ void refill_update(sched_context_t *sc, ticks_t new_period, ticks_t new_budget, 
     sc->scPeriod = new_period;
 
     if (refill_ready(sc)) {
-        refill_head(sc)->rTime = NODE_STATE_ON_CORE(ksCurTime, sc->scCore);
+        refill_head(sc)->rTime = MIN(MAX_RELEASE_TIME, NODE_STATE_ON_CORE(ksCurTime, core));
     }
 
     if (refill_head(sc)->rAmount >= new_budget) {


### PR DESCRIPTION
`refill_unblock_check` didn't preserve the property that the head release of a scheduling context was always less than the `MAX_RELEASE_TIME`. This aborts delaying releases once the system time has passed `MAX_RELEASE_TIME`.