### PR TITLE
Introduce banked IRQ addressing

### DIFF
--- a/include/api/types.h
+++ b/include/api/types.h
@@ -90,6 +90,19 @@ static inline word_t CONST wordFromMessageInfo(seL4_MessageInfo_t mi)
     return mi.words[0];
 }
 
+static inline seL4_BankedIRQ_t CONST bankedIrqFromWord(word_t w)
+{
+    seL4_BankedIRQ_t irq;
+
+    irq.words[0] = w;
+    return irq;
+}
+
+static inline word_t CONST wordFromBankedIrq(seL4_BankedIRQ_t irq)
+{
+    return irq.words[0];
+}
+
 #ifdef CONFIG_PRINTING
 #ifdef CONFIG_COLOUR_PRINTING
 #define ANSI_RESET "\033[0m"

--- a/libsel4/mode_include/32/sel4/shared_types.bf
+++ b/libsel4/mode_include/32/sel4/shared_types.bf
@@ -8,6 +8,12 @@
 
 base 32
 
+block seL4_BankedIRQ {
+    field interrupt_controller 20
+    field bank 3
+    field irq 9
+}
+
 block seL4_MessageInfo {
     field label 20
     field capsUnwrapped 3

--- a/libsel4/mode_include/64/sel4/shared_types.bf
+++ b/libsel4/mode_include/64/sel4/shared_types.bf
@@ -8,6 +8,12 @@
 
 base 64
 
+block seL4_BankedIRQ {
+    field interrupt_controller 52
+    field bank 3
+    field irq 9
+}
+
 block seL4_MessageInfo {
     field label 52
     field capsUnwrapped 3

--- a/src/arch/arm/object/interrupt.c
+++ b/src/arch/arm/object/interrupt.c
@@ -34,6 +34,10 @@ exception_t Arch_decodeIRQControlInvocation(word_t invLabel, word_t length,
         }
 
         word_t irq_w = getSyscallArg(0, buffer);
+#if defined BANKED_IRQ_TO_IRQ
+        seL4_BankedIRQ_t banked_irq = bankedIrqFromWord(irq_w);
+        irq_w = BANKED_IRQ_TO_IRQ(banked_irq);
+#endif
         irq_t irq = (irq_t) CORE_IRQ_TO_IRQT(0, irq_w);
         bool_t trigger = !!getSyscallArg(1, buffer);
         word_t index = getSyscallArg(2, buffer);
@@ -85,6 +89,10 @@ exception_t Arch_decodeIRQControlInvocation(word_t invLabel, word_t length,
         seL4_Word target = getSyscallArg(4, buffer);
         cap_t cnodeCap = current_extra_caps.excaprefs[0]->cap;
         exception_t status = Arch_checkIRQ(irq_w);
+#if defined BANKED_IRQ_TO_IRQ
+        seL4_BankedIRQ_t banked_irq = bankedIrqFromWord(irq_w);
+        irq_w = BANKED_IRQ_TO_IRQ(banked_irq);
+#endif
         irq_t irq = CORE_IRQ_TO_IRQT(target, irq_w);
 
         if (status != EXCEPTION_NONE) {

--- a/src/object/interrupt.c
+++ b/src/object/interrupt.c
@@ -25,6 +25,9 @@ exception_t decodeIRQControlInvocation(word_t invLabel, word_t length,
 {
     if (invLabel == IRQIssueIRQHandler) {
         word_t index, depth, irq_w;
+#if defined BANKED_IRQ_TO_IRQ
+        seL4_BankedIRQ_t banked_irq;
+#endif
         irq_t irq;
         cte_t *destSlot;
         cap_t cnodeCap;
@@ -36,6 +39,10 @@ exception_t decodeIRQControlInvocation(word_t invLabel, word_t length,
             return EXCEPTION_SYSCALL_ERROR;
         }
         irq_w = getSyscallArg(0, buffer);
+#if defined BANKED_IRQ_TO_IRQ
+        banked_irq = bankedIrqFromWord(irq_w);
+        irq_w = BANKED_IRQ_TO_IRQ(banked_irq);
+#endif
         irq = CORE_IRQ_TO_IRQT(0, irq_w);
         index = getSyscallArg(1, buffer);
         depth = getSyscallArg(2, buffer);


### PR DESCRIPTION
Currently, kernel interrupt controller drivers expose a linear space
of IRQ numbers which the kernel and userspace uses to address specific
IRQs.

Some platform uses multi-stage interrupt controllers and / or banked
IRQs where IRQ indices are relevant only to the relevant interrupt
controller and / or IRQ bank within a controller.

An example of such is the bcm2837 / rpi3 platform which uses two
interrupt controllers in tandem and the second stage interrupt
controller contains 3 differently sized banks of IRQs.

Currently, the IRQ spaces that those controller and banks represent
must be mapped into a single linear space. In the case of bcm2837
/ rpi3, they are mapped sequentially after one another.

This mapping is in fact arbritrary. In userspace, interrupts as
parsed from the device tree are addressed relative a specific
parent interrupt controller device and optional bank. Drivers
must somehow know how the kernel driver maps this to the linear
IRQ space as used by the kernel. This creates an implicit API
between userspace and the kernel interrupt controller driver
for a particular platform interrupt controller.

This commit implements a generic explicit API for handling this
by introducing the shared type seL4_BankedIRQ and the macro
BANKED_IRQ_TO_IRQ.

seL4_BankedIRQ encodes an interrupt controller device, an IRQ bank
and IRQ within a word. It can be used in place of IRQ numbers wherever
currently used in the seL4 API. This is similar to how seL4_CapRights
or seL4_MessageInfo are used. The controller device value is large
enough to address a physical memory page used by a interrupt controller.
The bank value supports 8 banks per interrupt controller and the IRQ
value can represent up to 512 IRQs per bank.

The BANKED_IRQ_TO_IRQ should be implemented by platform IRQ
drivers to map seL4_BankedIRQ:s to the linear IRQ space used
internally by the kernel. The IRQ driver may do that mapping
at its discretion in a way which makes sense according to what
addressing is used in device trees for that platform. This is
similar to how PPIs (in practice per core banking) is supported
using the CORE_IRQ_TO_IRQT macro.

This change should be completely backwards compatible, platforms
which do not care about staged interrupt controllers or banked
irqs do not need to implement the BANKED_IRQ_TO_IRQ macro and
can continue to rely on the existing implicit mapping.
Non-seL4_BankedIRQ values can still be used with the existing
APIs.

Signed-off-by: Viktor Sannum <sannum.viktor@gmail.com>