### PR TITLE
C proof check for labelled PR

### DIFF
--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -1,0 +1,37 @@
+# Copyright 2021 Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+name: Proofs
+
+on:
+  pull_request_target:
+    types: [labeled, synchronize]
+
+jobs:
+  cproof:
+    name: C Proofs
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'proof-test')
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [ARM, ARM_HYP, RISCV64, X64]
+    steps:
+    - name: Proofs
+      uses: seL4/ci-actions/aws-proofs@master
+      with:
+        L4V_ARCH: ${{ matrix.arch }}
+        isa_branch: ts-2020
+        session: CRefine SimplExportAndRefine
+        manifest: default.xml
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_SSH: ${{ secrets.AWS_SSH }}
+        GH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+    - name: Upload logs
+      uses: actions/upload-artifact@v2
+      with:
+        name: logs-${{ matrix.arch }}
+        path: logs.tar.xz


### PR DESCRIPTION
This action will run the C proofs when the label `proof-test` is added to a pull request. Intended to be used when the preprocess test has failed and the PR is ready to check proofs.

The idea is that this replaces the ssrg-bamboo bot for proofs.

This test should run much faster than a full proof test board, with the same predictive power. It will likely need a bit longer on the first run, but after that use cached proof images for things that have not changed. 
 