### PR TITLE
README: add badge for simulation test

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The seL4 microkernel
 
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/5003/badge)](https://bestpractices.coreinfrastructure.org/projects/5003)
 [![CI](https://github.com/seL4/seL4/actions/workflows/push.yml/badge.svg)](https://github.com/seL4/seL4/actions/workflows/push.yml)
+[![Simulation](https://github.com/seL4/seL4/actions/workflows/sel4test-sim.yml/badge.svg)](https://github.com/seL4/seL4/actions/workflows/sel4test-sim.yml)
 [![C Parser](https://github.com/seL4/seL4/actions/workflows/cparser.yml/badge.svg)](https://github.com/seL4/seL4/actions/workflows/cparser.yml)
 [![Kernel](https://github.com/seL4/seL4/actions/workflows/compilation-checks.yml/badge.svg)](https://github.com/seL4/seL4/actions/workflows/compilation-checks.yml)
 [![RefMan](https://github.com/seL4/seL4/actions/workflows/manual.yml/badge.svg)](https://github.com/seL4/seL4/actions/workflows/manual.yml)


### PR DESCRIPTION
The badge name shows as `seL4Test`, which would imply also the hardware tests. We do intend to include them in that job group in the future, so I'd say it's fine to leave as is for a few weeks until that is done.