### PR TITLE
add GitHub action for hardware builds

### DIFF
--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -12,7 +12,11 @@ jobs:
   cproof:
     name: C Proofs
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'proof-test')
+    # run on any normal trigger when the label exists, and run when the label is added
+    # don't run again when other labels are added
+    if: ${{ github.event.action != 'labeled' &&
+              contains(github.event.pull_request.labels.*.name, 'proof-test') ||
+            github.event.action == 'labeled' && github.event.label == 'proof-test' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/sel4test-sim.yml
+++ b/.github/workflows/sel4test-sim.yml
@@ -13,6 +13,10 @@ on:
     branches: [master]
   pull_request:
     types: [opened, reopened, synchronize, labeled]
+    paths-ignore:
+      - 'manual/**'
+      - 'LICENSES/**'
+      - '*.md'
 
 jobs:
   sim:

--- a/.github/workflows/sel4test-sim.yml
+++ b/.github/workflows/sel4test-sim.yml
@@ -12,9 +12,10 @@ on:
   push:
     branches: [master]
   pull_request:
+    types: [opened, reopened, synchronize, labeled]
 
 jobs:
-  cparser:
+  sim:
     name: Simulation
     runs-on: ubuntu-latest
     strategy:
@@ -31,3 +32,28 @@ jobs:
       with:
         march: ${{ matrix.march }}
         compiler: ${{ matrix.compiler }}
+
+  hw-build:
+    name: HW Build
+    runs-on: ubuntu-latest
+    if: ${{ github.event.name == 'push' ||
+            contains(github.event.pull_request.labels.*.name, 'hw-build') }}
+    strategy:
+      fail-fast: false
+      matrix:
+        march: [armv6a, armv7a, armv8a, nehalem]
+        compiler: [gcc, clang]
+        include:
+          - march: rv64imac
+            compiler: gcc
+    steps:
+    - name: Build
+      uses: seL4/ci-actions/sel4test-hw@master
+      with:
+        march: ${{ matrix.march }}
+        compiler: ${{ matrix.compiler }}
+    - name: Upload images
+      uses: actions/upload-artifact@v2
+      with:
+        name: images-${{ matrix.march }}-${{ matrix.compiler }}
+        path: '*-images.tar.gz'

--- a/.github/workflows/sel4test-sim.yml
+++ b/.github/workflows/sel4test-sim.yml
@@ -18,6 +18,8 @@ jobs:
   sim:
     name: Simulation
     runs-on: ubuntu-latest
+    # do not re-run on PR labelling (already runs on other triggers):
+    if: ${{ github.event_name != 'pull_request' || github.event.action != 'labeled' }}
     strategy:
       matrix:
         march: [armv6a, armv7a, armv8a, nehalem, rv32imac, rv64imac]
@@ -36,8 +38,13 @@ jobs:
   hw-build:
     name: HW Build
     runs-on: ubuntu-latest
-    if: ${{ github.event.name == 'push' ||
-            contains(github.event.pull_request.labels.*.name, 'hw-build') }}
+    if: ${{ github.event_name == 'push' ||
+            github.event_name == 'pull_request' &&
+              github.event.action != 'labeled' &&
+              contains(github.event.pull_request.labels.*.name, 'hw-build') ||
+            github.event_name == 'pull_request' &&
+              github.event.action == 'labeled' &&
+              github.event.label == 'hw-build' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The action builds `sel4test` for all hardware platforms currently tested in bamboo, and leaves generated images as artifacts that a later test run stage can pick up.

As for the other sel4test actions, the main configuration is in [seL4/ci-actions](https://github.com/seL4/ci-actions/blob/master/seL4-platforms/platforms.yml), that build matrix in here only determines what gets built in parallel, and potentially which combinations to leave out completely.

At the moment, we do all armv8 in one sequential run, which takes about 30min. If that is too annoying in the longer run, I can look at splitting these up as we have on Bamboo into 2 or three parallel runs. This is not necessarily faster, since GH is currently restricted to 20 parallel builds per repo.

The action  is triggered on push to master or when the label "hw-build" is present on pull requests.
