### PR TITLE
risc-v: remove unused L2 cache functions

### DIFF
--- a/include/arch/riscv/arch/machine.h
+++ b/include/arch/riscv/arch/machine.h
@@ -223,8 +223,6 @@ void map_kernel_devices(void);
 
 /** MODIFIES: [*] */
 void initTimer(void);
-/* L2 cache control */
-void initL2Cache(void);
 void initLocalIRQController(void);
 void initIRQController(void);
 void setIRQTrigger(irq_t irq, bool_t trigger);
@@ -241,11 +239,6 @@ static inline void arch_pause(void)
 }
 
 #endif
-void plat_cleanL2Range(paddr_t start, paddr_t end);
-
-void plat_invalidateL2Range(paddr_t start, paddr_t end);
-
-void plat_cleanInvalidateL2Range(paddr_t start, paddr_t end);
 
 /* Update the value of the actual register to hold the expected value */
 static inline void Arch_setTLSRegister(word_t tls_base)

--- a/src/arch/riscv/machine/hardware.c
+++ b/src/arch/riscv/machine/hardware.c
@@ -253,21 +253,6 @@ BOOT_CODE void initTimer(void)
 }
 #endif /* !CONFIG_KERNEL_MCS */
 
-void plat_cleanL2Range(paddr_t start, paddr_t end)
-{
-}
-void plat_invalidateL2Range(paddr_t start, paddr_t end)
-{
-}
-
-void plat_cleanInvalidateL2Range(paddr_t start, paddr_t end)
-{
-}
-
-BOOT_CODE void initL2Cache(void)
-{
-}
-
 BOOT_CODE void initLocalIRQController(void)
 {
     printf("Init local IRQ\n");


### PR DESCRIPTION
The L2 cache handling functions were copied from the ARM code in the initial port,but they are not used on RISC-V. Remove them from the code base, they can be brought back if a platform has an L2 cache that needs to be maintained.

Is there any seL4 RISC-V code lurking in private repos that uses this, e.g. for HiFive/Polarfire?

