### PR TITLE
cleanup: comment empty functions, remove obsolete functions

### DIFF
--- a/include/arch/arm/arch/machine.h
+++ b/include/arch/arm/arch/machine.h
@@ -83,4 +83,3 @@ static inline exception_t Arch_setTLSRegister(word_t tls_base)
 }
 
 #endif /* __ASSEMBLER__ */
-

--- a/include/arch/riscv/arch/kernel/traps.h
+++ b/include/arch/riscv/arch/kernel/traps.h
@@ -12,10 +12,12 @@
 
 static inline void arch_c_entry_hook(void)
 {
+    /* Nothing architecture specific to be done. */
 }
 
 static inline void arch_c_exit_hook(void)
 {
+    /* Nothing architecture specific to be done. */
 }
 
 #ifdef CONFIG_KERNEL_MCS

--- a/include/arch/riscv/arch/machine.h
+++ b/include/arch/riscv/arch/machine.h
@@ -221,7 +221,6 @@ int get_num_dev_p_regs(void);
 p_region_t get_dev_p_reg(word_t i);
 void map_kernel_devices(void);
 
-static inline void setInterruptMode(irq_t irq, bool_t levelTrigger, bool_t polarityLow) { }
 /** MODIFIES: [*] */
 void initTimer(void);
 /* L2 cache control */

--- a/include/arch/riscv/arch/machine.h
+++ b/include/arch/riscv/arch/machine.h
@@ -256,5 +256,3 @@ static inline void Arch_setTLSRegister(word_t tls_base)
 }
 
 #endif // __ASSEMBLER__
-
-

--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -274,7 +274,6 @@ create_domain_cap(cap_t root_cnode_cap)
     write_slot(SLOT_PTR(pptr_of_cap(root_cnode_cap), seL4_CapDomain), cap);
 }
 
-
 BOOT_CODE cap_t create_ipcbuf_frame_cap(cap_t root_cnode_cap, cap_t pd_cap, vptr_t vptr)
 {
     clearMemory((void *)rootserver.ipc_buf, PAGE_BITS);


### PR DESCRIPTION
Some code clenup:
- trivial: add comments about empty functions: Add a comment to clearly state the functions are empty on purpose, but they still need to be provided to support the generic code flow.
- arm: remove obsolete function setInterruptMode(). The function setInterruptMode() is no longer in use, setIRQTrigger() is used instead.
- trivial: remove superfluous empty lines