### PR TITLE
prefer macro CURRENT_CPU_INDEX()

### DIFF
--- a/include/api/types.h
+++ b/include/api/types.h
@@ -125,14 +125,14 @@ extern struct debug_syscall_error current_debug_error;
  * kernel is not performing their requested operation.
  */
 #define userError(M, ...) \
-    do {                                                                     \
-        out_error(ANSI_DARK "<<" ANSI_GREEN "seL4(CPU %lu)" ANSI_DARK        \
-                " [%s/%d T%p \"%s\" @%lx]: " M ">>" ANSI_RESET "\n",         \
-                SMP_TERNARY(getCurrentCPUIndex(), 0lu),                      \
-                __func__, __LINE__, NODE_STATE(ksCurThread),                 \
-                THREAD_NAME,                                                 \
-                (word_t)getRestartPC(NODE_STATE(ksCurThread)),               \
-                ## __VA_ARGS__);                                             \
+    do {                                                                       \
+        out_error(ANSI_DARK "<<" ANSI_GREEN "seL4(CPU %" SEL4_PRIu_word ")"    \
+                ANSI_DARK " [%s/%d T%p \"%s\" @%lx]: " M ">>" ANSI_RESET "\n", \
+                CURRENT_CPU_INDEX(),                                           \
+                __func__, __LINE__, NODE_STATE(ksCurThread),                   \
+                THREAD_NAME,                                                   \
+                (word_t)getRestartPC(NODE_STATE(ksCurThread)),                 \
+                ## __VA_ARGS__);                                               \
     } while (0)
 #else /* !CONFIG_PRINTING */
 #define userError(...)

--- a/include/arch/arm/arch/32/mode/machine/fpu.h
+++ b/include/arch/arm/arch/32/mode/machine/fpu.h
@@ -166,13 +166,13 @@ static inline void enableFpu(void)
 #else
     setEnFPEXC();
 #endif
-    isFPUEnabledCached[SMP_TERNARY(getCurrentCPUIndex(), 0)] = true;
+    isFPUEnabledCached[CURRENT_CPU_INDEX()] = true;
 }
 
 /* Check if FPU is enable */
 static inline bool_t isFpuEnable(void)
 {
-    return isFPUEnabledCached[SMP_TERNARY(getCurrentCPUIndex(), 0)];
+    return isFPUEnabledCached[CURRENT_CPU_INDEX()];
 }
 
 /* Load FPU state from memory into the FPU registers. */
@@ -223,6 +223,6 @@ static inline void disableFpu(void)
     } else {
         clearEnFPEXC();
     }
-    isFPUEnabledCached[SMP_TERNARY(getCurrentCPUIndex(), 0)] = false;
+    isFPUEnabledCached[CURRENT_CPU_INDEX()] = false;
 }
 

--- a/include/arch/arm/arch/64/mode/machine/fpu.h
+++ b/include/arch/arm/arch/64/mode/machine/fpu.h
@@ -127,12 +127,12 @@ static inline void enableFpu(void)
     } else {
         enableFpuEL01();
     }
-    isFPUEnabledCached[SMP_TERNARY(getCurrentCPUIndex(), 0)] = true;
+    isFPUEnabledCached[CURRENT_CPU_INDEX()] = true;
 }
 
 static inline bool_t isFpuEnable(void)
 {
-    return isFPUEnabledCached[SMP_TERNARY(getCurrentCPUIndex(), 0)];
+    return isFPUEnabledCached[CURRENT_CPU_INDEX()];
 }
 #endif /* CONFIG_HAVE_FPU */
 
@@ -144,6 +144,6 @@ static inline void disableFpu(void)
     } else {
         disableFpuEL0();
     }
-    isFPUEnabledCached[SMP_TERNARY(getCurrentCPUIndex(), 0)] = false;
+    isFPUEnabledCached[CURRENT_CPU_INDEX()] = false;
 }
 

--- a/include/arch/riscv/arch/machine/fpu.h
+++ b/include/arch/riscv/arch/machine/fpu.h
@@ -150,17 +150,17 @@ static inline void loadFpuState(user_fpu_state_t *src)
 
 static inline void enableFpu(void)
 {
-    isFPUEnabledCached[SMP_TERNARY(getCurrentCPUIndex(), 0)] = true;
+    isFPUEnabledCached[CURRENT_CPU_INDEX()] = true;
 }
 
 static inline void disableFpu(void)
 {
-    isFPUEnabledCached[SMP_TERNARY(getCurrentCPUIndex(), 0)] = false;
+    isFPUEnabledCached[CURRENT_CPU_INDEX()] = false;
 }
 
 static inline bool_t isFpuEnable(void)
 {
-    return isFPUEnabledCached[SMP_TERNARY(getCurrentCPUIndex(), 0)];
+    return isFPUEnabledCached[CURRENT_CPU_INDEX()];
 }
 
 static inline void set_tcb_fs_state(tcb_t *tcb, bool_t enabled)

--- a/include/arch/x86/arch/32/mode/machine.h
+++ b/include/arch/x86/arch/32/mode/machine.h
@@ -181,7 +181,7 @@ static inline word_t x86_read_gs_base_impl(void)
 
 static inline void x86_set_tls_segment_base(word_t tls_base)
 {
-    x86_write_gs_base(tls_base, SMP_TERNARY(getCurrentCPUIndex(), 0));
+    x86_write_gs_base(tls_base, CURRENT_CPU_INDEX());
 }
 
 static inline void init_syscall_msrs(void)

--- a/include/arch/x86/arch/64/mode/machine.h
+++ b/include/arch/x86/arch/64/mode/machine.h
@@ -331,6 +331,6 @@ static inline word_t x86_read_gs_base_impl(void)
 
 static inline void x86_set_tls_segment_base(word_t tls_base)
 {
-    x86_write_fs_base(tls_base, SMP_TERNARY(getCurrentCPUIndex(), 0));
+    x86_write_fs_base(tls_base, CURRENT_CPU_INDEX());
 }
 

--- a/include/arch/x86/arch/kernel/traps.h
+++ b/include/arch/x86/arch/kernel/traps.h
@@ -13,7 +13,7 @@ static inline void arch_c_entry_hook(void)
 {
 #ifdef CONFIG_FSGSBASE_INST
     tcb_t *tcb = NODE_STATE(ksCurThread);
-    x86_save_fsgs_base(tcb, SMP_TERNARY(getCurrentCPUIndex(), 0));
+    x86_save_fsgs_base(tcb, CURRENT_CPU_INDEX());
 #endif
 }
 
@@ -21,7 +21,7 @@ static inline void arch_c_exit_hook(void)
 {
     /* Restore the values ofthe FS and GS base. */
     tcb_t *tcb = NODE_STATE(ksCurThread);
-    x86_load_fsgs_base(tcb,  SMP_TERNARY(getCurrentCPUIndex(), 0));
+    x86_load_fsgs_base(tcb,  CURRENT_CPU_INDEX());
 }
 
 #ifdef CONFIG_KERNEL_MCS

--- a/include/basic_types.h
+++ b/include/basic_types.h
@@ -14,6 +14,16 @@
 #error "missing _seL4_word_fmt"
 #endif
 
+/* Using multiple macro layers may look strange, but this is required to make
+ * the preprocessor fully evaluate all macro parameters first and then pass the
+ * result as parameter to the next macro layer. This allows passing macros as
+ * parameters also, and not just plain strings. The final concatenation will
+ * always be from the strings behind all macros then - and not the macro names
+ * that are passed as parameters.
+ */
+#define _macro_concat_helper2(x,y,z)    x ## y ## z
+#define _macro_concat_helper(x,y,z)     _macro_concat_helper2(x,y,z)
+
 #define _macro_str_concat_helper2(x)    #x
 #define _macro_str_concat_helper1(x,y)  _macro_str_concat_helper2(x ## y)
 #define _macro_str_concat(x,y)          _macro_str_concat_helper1(x,y)
@@ -21,6 +31,13 @@
 #define SEL4_PRIu_word  _macro_str_concat(_seL4_word_fmt, u)
 #define SEL4_PRIx_word  _macro_str_concat(_seL4_word_fmt, x)
 #define SEL4_PRI_word   SEL4_PRIu_word
+
+/* The C parser from the verification toolchain requires declaring word_t
+ * constants without casting integer values to word_t. Since the printf() format
+ * specifiers are aligned with the C integer type suffixes, _seL4_word_fmt can
+ * be used there also.
+ */
+#define SEL4_WORD_CONST(x)  _macro_concat_helper(x, _seL4_word_fmt, u)
 
 
 enum _bool {

--- a/include/model/statedata.h
+++ b/include/model/statedata.h
@@ -48,7 +48,7 @@
 #define ARCH_NODE_STATE_ON_CORE(_state, _core) _state
 #define NODE_STATE_ON_CORE(_state, _core)      _state
 
-#define CURRENT_CPU_INDEX() 0
+#define CURRENT_CPU_INDEX() SEL4_WORD_CONST(0)
 
 #endif /* ENABLE_SMP_SUPPORT */
 

--- a/src/arch/arm/c_traps.c
+++ b/src/arch/arm/c_traps.c
@@ -95,9 +95,7 @@ void VISIBLE NORETURN c_handle_interrupt(void)
 #ifdef TRACK_KERNEL_ENTRIES
     ksKernelEntry.path = Entry_Interrupt;
     ksKernelEntry.word = IRQT_TO_IRQ(getActiveIRQ());
-#ifdef ENABLE_SMP_SUPPORT
-    ksKernelEntry.core = getCurrentCPUIndex();
-#endif
+    ksKernelEntry.core = CURRENT_CPU_INDEX();
 #endif
 
     handleInterruptEntry();

--- a/src/arch/arm/kernel/boot.c
+++ b/src/arch/arm/kernel/boot.c
@@ -170,7 +170,7 @@ BOOT_CODE static bool_t init_cpu(void)
      * On ARM SMP, the array index here is the CPU ID
      */
 #ifndef CONFIG_ARCH_ARM_V6
-    word_t stack_top = ((word_t) kernel_stack_alloc[SMP_TERNARY(getCurrentCPUIndex(), 0)]) + BIT(CONFIG_KERNEL_STACK_BITS);
+    word_t stack_top = ((word_t) kernel_stack_alloc[CURRENT_CPU_INDEX()]) + BIT(CONFIG_KERNEL_STACK_BITS);
 #if defined(ENABLE_SMP_SUPPORT) && defined(CONFIG_ARCH_AARCH64)
     /* the least 12 bits are used to store logical core ID */
     stack_top |= getCurrentCPUIndex();

--- a/src/arch/arm/machine/gic_v3.c
+++ b/src/arch/arm/machine/gic_v3.c
@@ -180,7 +180,7 @@ BOOT_CODE static void dist_init(void)
 BOOT_CODE static void gicr_locate_interface(void)
 {
     word_t offset;
-    int core_id = SMP_TERNARY(getCurrentCPUIndex(), 0);
+    int core_id = CURRENT_CPU_INDEX();
     word_t mpidr = get_current_mpidr();
     uint32_t val;
 

--- a/src/arch/x86/c_traps.c
+++ b/src/arch/x86/c_traps.c
@@ -209,7 +209,7 @@ void VISIBLE NORETURN c_handle_vmexit(void)
     tcb_t *cur_thread = NODE_STATE(ksCurThread);
     ARCH_NODE_STATE(x86KSCurrentGSBase) = -(word_t)1;
     ARCH_NODE_STATE(x86KSCurrentFSBase) = -(word_t)1;
-    x86_load_fsgs_base(cur_thread, SMP_TERNARY(getCurrentCPUIndex(), 0));
+    x86_load_fsgs_base(cur_thread, CURRENT_CPU_INDEX());
 
     c_entry_hook();
     /* NODE_LOCK will get called in handleVmexit */

--- a/src/arch/x86/object/vcpu.c
+++ b/src/arch/x86/object/vcpu.c
@@ -1005,7 +1005,7 @@ BOOT_CODE bool_t vtx_init(void)
     }
     /* Initialize the fixed values only on the boot core. All other cores
      * will just check that the fixed values are valid */
-    if (SMP_TERNARY(getCurrentCPUIndex(), 0) == 0) {
+    if (CURRENT_CPU_INDEX() == 0) {
         if (!init_vtx_fixed_values(vmx_basic_msr_get_true_msrs(vmx_basic))) {
             printf("vt-x: lack of required features\n");
             return false;


### PR DESCRIPTION
- Replace the macro `SMP_TERNARY(getCurrentCPUIndex(), 0)` by the much simpler macro `CURRENT_CPU_INDEX()` that does the same.
- define macro `SEL4_WORD_CONST()`. `CURRENT_CPU_INDEX()` is supported to return a `word_t`. The C parser from the verification toolchain requires declaring `word_t` constants without casting integer values to `word_t`.
- The field `ksKernelEntry.core` always exists, ensure it is properly set on non-SMP configurations also.