### PR TITLE
github: use correct label field

### DIFF
--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -16,7 +16,7 @@ jobs:
     # don't run again when other labels are added
     if: ${{ github.event.action != 'labeled' &&
               contains(github.event.pull_request.labels.*.name, 'proof-test') ||
-            github.event.action == 'labeled' && github.event.label == 'proof-test' }}
+            github.event.action == 'labeled' && github.event.label.name == 'proof-test' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/sel4test-sim.yml
+++ b/.github/workflows/sel4test-sim.yml
@@ -48,7 +48,7 @@ jobs:
               contains(github.event.pull_request.labels.*.name, 'hw-build') ||
             github.event_name == 'pull_request' &&
               github.event.action == 'labeled' &&
-              github.event.label == 'hw-build' }}
+              github.event.label.name == 'hw-build' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The trigger matched against the whole label object, not the name as it should have.
