### PR TITLE
cleanup explicit function Arch_finaliseInterrupt()

### DIFF
--- a/include/arch/arm/arch/machine.h
+++ b/include/arch/arm/arch/machine.h
@@ -65,11 +65,6 @@ static inline void arch_pause(void)
 }
 #endif /* ENABLE_SMP_SUPPORT */
 
-static inline void Arch_finaliseInterrupt(void)
-{
-    /* Nothing architecture specific to be done. */
-}
-
 /* Update the value of the actual regsiter to hold the expected value */
 static inline exception_t Arch_setTLSRegister(word_t tls_base)
 {

--- a/include/arch/riscv/arch/machine.h
+++ b/include/arch/riscv/arch/machine.h
@@ -254,11 +254,6 @@ static inline void setVSpaceRoot(paddr_t addr, asid_t asid)
 #endif
 }
 
-static inline void Arch_finaliseInterrupt(void)
-{
-    /* Nothing architecture specific to be done. */
-}
-
 void map_kernel_devices(void);
 
 /** MODIFIES: [*] */

--- a/include/arch/x86/arch/machine.h
+++ b/include/arch/x86/arch/machine.h
@@ -361,7 +361,7 @@ static inline unsigned long getFaultAddr(void)
 
 static inline void Arch_finaliseInterrupt(void)
 {
-    ARCH_NODE_STATE(x86KScurInterrupt) = int_invalid;
+    /* Nothing architecture specific to be done. */
 }
 
 static inline void x86_set_tls_segment_base(word_t tls_base);

--- a/include/arch/x86/arch/machine.h
+++ b/include/arch/x86/arch/machine.h
@@ -359,11 +359,6 @@ static inline unsigned long getFaultAddr(void)
     return read_cr2();
 }
 
-static inline void Arch_finaliseInterrupt(void)
-{
-    /* Nothing architecture specific to be done. */
-}
-
 static inline void x86_set_tls_segment_base(word_t tls_base);
 
 /* Update the value of the actual register to hold the expected value */

--- a/include/plat/pc99/plat/machine/interrupt.h
+++ b/include/plat/pc99/plat/machine/interrupt.h
@@ -96,6 +96,8 @@ static inline void ackInterrupt(irq_t irq)
     } else {
         apic_ack_active_interrupt();
     }
+
+    ARCH_NODE_STATE(x86KScurInterrupt) = int_invalid;
 }
 
 static inline void handleSpuriousIRQ(void)

--- a/src/api/syscall.c
+++ b/src/api/syscall.c
@@ -46,7 +46,6 @@ exception_t handleInterruptEntry(void)
 
     if (IRQT_TO_IRQ(irq) != IRQT_TO_IRQ(irqInvalid)) {
         handleInterrupt(irq);
-        Arch_finaliseInterrupt();
     } else {
 #ifdef CONFIG_IRQ_REPORTING
         userError("Spurious interrupt!");
@@ -628,7 +627,6 @@ exception_t handleSyscall(syscall_t syscall)
                 mcsPreemptionPoint(irq);
                 if (IRQT_TO_IRQ(irq) != IRQT_TO_IRQ(irqInvalid)) {
                     handleInterrupt(irq);
-                    Arch_finaliseInterrupt();
                 }
             }
 
@@ -641,7 +639,6 @@ exception_t handleSyscall(syscall_t syscall)
                 mcsPreemptionPoint(irq);
                 if (IRQT_TO_IRQ(irq) != IRQT_TO_IRQ(irqInvalid)) {
                     handleInterrupt(irq);
-                    Arch_finaliseInterrupt();
                 }
             }
             break;
@@ -653,7 +650,6 @@ exception_t handleSyscall(syscall_t syscall)
                 mcsPreemptionPoint(irq);
                 if (IRQT_TO_IRQ(irq) != IRQT_TO_IRQ(irqInvalid)) {
                     handleInterrupt(irq);
-                    Arch_finaliseInterrupt();
                 }
             }
             break;
@@ -696,7 +692,6 @@ exception_t handleSyscall(syscall_t syscall)
                 mcsPreemptionPoint(irq);
                 if (IRQT_TO_IRQ(irq) != IRQT_TO_IRQ(irqInvalid)) {
                     handleInterrupt(irq);
-                    Arch_finaliseInterrupt();
                 }
                 break;
             }
@@ -711,7 +706,6 @@ exception_t handleSyscall(syscall_t syscall)
                 mcsPreemptionPoint(irq);
                 if (IRQT_TO_IRQ(irq) != IRQT_TO_IRQ(irqInvalid)) {
                     handleInterrupt(irq);
-                    Arch_finaliseInterrupt();
                 }
                 break;
             }


### PR DESCRIPTION
PC99 is the only platform that uses `Arch_finaliseInterrupt()`. There seems no need to have this explicit function, the necessary things can be done in `ackInterrupt()` also, which is architecture or platform specific anyway.
