### PR TITLE
Hardware tests triggered from GitHub

### DIFF
--- a/.github/workflows/sel4test-hw.yml
+++ b/.github/workflows/sel4test-hw.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: BSD-2-Clause
 
-# sel4test hardware builds
+# sel4test hardware builds and runs
 #
 # See sel4test-hw/builds.yml in the repo seL4/ci-actions for configs.
 
@@ -11,12 +11,13 @@ name: seL4Test
 on:
   push:
     branches: [master]
-  pull_request:
+  # needs PR target for secrets access; guard by requiring label
+  pull_request_target:
     types: [opened, reopened, synchronize, labeled]
-    paths-ignore:
-      - 'manual/**'
-      - 'LICENSES/**'
-      - '*.md'
+
+# downgrade permissions to read-only as you would have in a standard PR action
+permissions:
+  contents: read
 
 jobs:
   hw-build:
@@ -25,10 +26,12 @@ jobs:
     if: ${{ github.event_name == 'push' ||
             github.event_name == 'pull_request' &&
               github.event.action != 'labeled' &&
-              contains(github.event.pull_request.labels.*.name, 'hw-build') ||
+              (contains(github.event.pull_request.labels.*.name, 'hw-build') ||
+               contains(github.event.pull_request.labels.*.name, 'hw-test')) ||
             github.event_name == 'pull_request' &&
               github.event.action == 'labeled' &&
-              github.event.label.name == 'hw-build' }}
+              (github.event.label.name == 'hw-build' ||
+               github.event.label.name == 'hw-test') }}
     strategy:
       fail-fast: false
       matrix:
@@ -43,8 +46,64 @@ jobs:
       with:
         march: ${{ matrix.march }}
         compiler: ${{ matrix.compiler }}
+        sha: ${{ github.event.pull_request.head.sha }}
     - name: Upload images
       uses: actions/upload-artifact@v2
       with:
         name: images-${{ matrix.march }}-${{ matrix.compiler }}
         path: '*-images.tar.gz'
+
+  hw-run:
+    name: HW Run
+    runs-on: ubuntu-latest
+    needs: hw-build
+    if: ${{ github.event_name == 'push' ||
+            github.event_name == 'pull_request' &&
+              github.event.action != 'labeled' &&
+              contains(github.event.pull_request.labels.*.name, 'hw-test') ||
+            github.event_name == 'pull_request' &&
+              github.event.action == 'labeled' &&
+              github.event.label.name == 'hw-test' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # commented-out platforms hopefully available soon
+        platform:
+          - sabre
+          - pc99
+          # - hikey
+          # - imx8mm_evk
+          - odroid_c2
+          # - odroid_xu4
+          - am335x_boneblack
+          - rpi3
+          # - zynqmp
+        compiler: [gcc, clang]
+        # include:
+        #    - platform: hifive
+        #      compiler: gcc
+    steps:
+      - name: Get machine queue
+        uses: actions/checkout@v2
+        with:
+          repository: seL4/machine_queue
+          ref: refs/heads/cancel
+          path: machine_queue
+          token: ${{ secrets.PRIV_REPO_TOKEN }}
+      - name: Get march
+        id: plat
+        uses: seL4/ci-actions/march-of-platform@master
+        with:
+          platform: ${{ matrix.platform }}
+      - name: Download image
+        uses: actions/download-artifact@v2
+        with:
+          name: images-${{ steps.plat.outputs.march }}-${{ matrix.compiler }}
+      - name: Run
+        uses: seL4/ci-actions/sel4test-hw-run@master
+        with:
+          platform: ${{ matrix.platform }}
+          compiler: ${{ matrix.compiler }}
+          index: $${{ strategy.job-index }}
+        env:
+          HW_SSH: ${{ secrets.HW_SSH }}

--- a/.github/workflows/sel4test-hw.yml
+++ b/.github/workflows/sel4test-hw.yml
@@ -70,7 +70,6 @@ jobs:
         # commented-out platforms hopefully available soon
         platform:
           - sabre
-          - pc99
           # - hikey
           # - imx8mm_evk
           - odroid_c2
@@ -79,6 +78,19 @@ jobs:
           - rpi3
           # - zynqmp
         compiler: [gcc, clang]
+        include:
+           - platform: pc99
+             compiler: gcc
+             mode: 32
+           - platform: pc99
+             compiler: gcc
+             mode: 64
+           - platform: pc99
+             compiler: clang
+             mode: 32
+           - platform: pc99
+             compiler: clang
+             mode: 64
         # include:
         #    - platform: hifive
         #      compiler: gcc
@@ -87,7 +99,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: seL4/machine_queue
-          ref: refs/heads/cancel
           path: machine_queue
           token: ${{ secrets.PRIV_REPO_TOKEN }}
       - name: Get march
@@ -104,6 +115,7 @@ jobs:
         with:
           platform: ${{ matrix.platform }}
           compiler: ${{ matrix.compiler }}
+          mode: ${{ matrix.mode }}
           index: $${{ strategy.job-index }}
         env:
           HW_SSH: ${{ secrets.HW_SSH }}

--- a/.github/workflows/sel4test-hw.yml
+++ b/.github/workflows/sel4test-hw.yml
@@ -10,7 +10,7 @@ name: seL4Test
 
 on:
   push:
-    branches: [master]
+    branches: [master, hw-test]
   # needs PR target for secrets access; guard by requiring label
   pull_request_target:
     types: [opened, reopened, synchronize, labeled]

--- a/.github/workflows/sel4test-hw.yml
+++ b/.github/workflows/sel4test-hw.yml
@@ -75,7 +75,7 @@ jobs:
           - odroid_c2
           # - odroid_xu4
           - am335x_boneblack
-          - rpi3
+          # - rpi3
           # - zynqmp
         compiler: [gcc, clang]
         include:

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Community
 
 See the [contact] links on the seL4 website for the full list.
 
-[contact]: https://sel4.systems/contact.html
+[contact]: https://sel4.systems/contact
 
 Reporting security vulnerabilities
 ----------------------------------


### PR DESCRIPTION
This PR adds the trigger that replaces Bamboo hardware tests. It runs the same general sel4test setup with the UNSW machine queue, just triggered from GitHub.

The current set of available boards is fairly small, more boards will come online over time.

The test runs on push to the `master` branch or on PR when explicitly labeled with `hw-test`.

See also seL4/ci-actions#135