### PR TITLE
mcs: Remove domain time check from preemptionPoint

### DIFF
--- a/include/api/syscall.h
+++ b/include/api/syscall.h
@@ -19,6 +19,7 @@
 #ifdef CONFIG_KERNEL_MCS
 #define MCS_DO_IF_BUDGET(_block) \
     updateTimestamp(); \
+    checkDomainTime(); \
     if (likely(checkBudgetRestart())) { \
         _block \
     }

--- a/include/kernel/thread.h
+++ b/include/kernel/thread.h
@@ -229,18 +229,23 @@ static inline void updateTimestamp(void)
     time_t consumed = (NODE_STATE(ksCurTime) - prev);
     NODE_STATE(ksConsumed) += consumed;
     if (CONFIG_NUM_DOMAINS > 1) {
-
         if ((consumed + MIN_BUDGET) >= ksDomainTime) {
             ksDomainTime = 0;
         } else {
             ksDomainTime -= consumed;
         }
-        if (unlikely(isCurDomainExpired())) {
-            NODE_STATE(ksReprogram) = true;
-            rescheduleRequired();
-        }
     }
+}
 
+/*
+ * Check if domain time has expired
+ */
+static inline void checkDomainTime(void)
+{
+    if (unlikely(CONFIG_NUM_DOMAINS > 1 && isCurDomainExpired())) {
+        NODE_STATE(ksReprogram) = true;
+        rescheduleRequired();
+    }
 }
 
 /* Check if the current thread/domain budget has expired.

--- a/src/api/syscall.c
+++ b/src/api/syscall.c
@@ -40,6 +40,7 @@ exception_t handleInterruptEntry(void)
 #ifdef CONFIG_KERNEL_MCS
     if (SMP_TERNARY(clh_is_self_in_queue(), 1)) {
         updateTimestamp();
+        checkDomainTime();
         checkBudget();
     }
 #endif
@@ -624,6 +625,7 @@ exception_t handleSyscall(syscall_t syscall)
         case SysSend:
             ret = handleInvocation(false, true, false, false, getRegister(NODE_STATE(ksCurThread), capRegister));
             if (unlikely(ret != EXCEPTION_NONE)) {
+                checkDomainTime();
                 irq = getActiveIRQ();
                 mcsPreemptionPoint(irq);
                 if (IRQT_TO_IRQ(irq) != IRQT_TO_IRQ(irqInvalid)) {
@@ -637,6 +639,7 @@ exception_t handleSyscall(syscall_t syscall)
         case SysNBSend:
             ret = handleInvocation(false, false, false, false, getRegister(NODE_STATE(ksCurThread), capRegister));
             if (unlikely(ret != EXCEPTION_NONE)) {
+                checkDomainTime();
                 irq = getActiveIRQ();
                 mcsPreemptionPoint(irq);
                 if (IRQT_TO_IRQ(irq) != IRQT_TO_IRQ(irqInvalid)) {
@@ -649,6 +652,7 @@ exception_t handleSyscall(syscall_t syscall)
         case SysCall:
             ret = handleInvocation(true, true, true, false, getRegister(NODE_STATE(ksCurThread), capRegister));
             if (unlikely(ret != EXCEPTION_NONE)) {
+                checkDomainTime();
                 irq = getActiveIRQ();
                 mcsPreemptionPoint(irq);
                 if (IRQT_TO_IRQ(irq) != IRQT_TO_IRQ(irqInvalid)) {
@@ -692,6 +696,7 @@ exception_t handleSyscall(syscall_t syscall)
             cptr_t dest = getNBSendRecvDest();
             ret = handleInvocation(false, false, true, true, dest);
             if (unlikely(ret != EXCEPTION_NONE)) {
+                checkDomainTime();
                 irq = getActiveIRQ();
                 mcsPreemptionPoint(irq);
                 if (IRQT_TO_IRQ(irq) != IRQT_TO_IRQ(irqInvalid)) {
@@ -707,6 +712,7 @@ exception_t handleSyscall(syscall_t syscall)
         case SysNBSendWait:
             ret = handleInvocation(false, false, true, true, getRegister(NODE_STATE(ksCurThread), replyRegister));
             if (unlikely(ret != EXCEPTION_NONE)) {
+                checkDomainTime();
                 irq = getActiveIRQ();
                 mcsPreemptionPoint(irq);
                 if (IRQT_TO_IRQ(irq) != IRQT_TO_IRQ(irqInvalid)) {


### PR DESCRIPTION
This removes the operations that trigger a reschedule or reprogram the timer from `preemptionPoint` to ensure they relevant state updates in the proof occur where it they are easier to verify.