### PR TITLE
github: add TX2 to hardware test

### DIFF
--- a/.github/workflows/sel4test-hw.yml
+++ b/.github/workflows/sel4test-hw.yml
@@ -75,6 +75,7 @@ jobs:
           - odroid_c2
           # - odroid_xu4
           - am335x_boneblack
+          - tx2
           # - rpi3
           # - zynqmp
         compiler: [gcc, clang]


### PR DESCRIPTION
The board `tx2b` seems reasonably stable now.