### PR TITLE
aarch64: fix storing of thread context

### DIFF
--- a/src/arch/arm/64/traps.S
+++ b/src/arch/arm/64/traps.S
@@ -91,8 +91,11 @@ END_FUNC(arm_vector_table)
     mrs     x21, sp_el0
     mrs     x22, ELR
     mrs     x23, SPSR
+    mrs     x24, TPIDR_EL0
+    mrs     x25, TPIDRRO_EL0
     stp     x30, x21, [sp, #PT_LR]
     stp     x22, x23, [sp, #PT_ELR_EL1]
+    stp     x24, x25, [sp, #PT_TPIDR_EL0]
 .endm
 
 BEGIN_FUNC(invalid_vector_entry)


### PR DESCRIPTION
TPIDR_EL0 and TPIDRRO_EL0 had been omitted from the storing of thread context upon kernel entry. This commit corrects that omission.