### PR TITLE
use proper types for bootloader parameters

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -38,6 +38,10 @@ Upcoming release: BINARY COMPATIBLE
   constant seL4_GlobalsFrame from libsel4.
 * Implement KernelArmExportPTMRUser and KernelArmExportVTMRUser options for Arm generic timer use access on aarch32.
 * Removed obsolete define `HAVE_AUTOCONF`
+* Changed kernel boot parameters to become architecture agnostic with using word_t instead of uint32. Stop using
+  sword_t due to C rule violations, use word_t instead and explicitly allow overflows and underflows in the
+  unsigned integer calculations. These changes could break the boot process on 64-bit platforms, as the upper 32 bit
+  must be set correctly now also. The elfloader has been updated, custom bootloaders might need to be updated also.
 
 ## Upgrade Notes
 ---

--- a/include/arch/arm/arch/kernel/boot.h
+++ b/include/arch/arm/arch/kernel/boot.h
@@ -1,5 +1,6 @@
 /*
  * Copyright 2014, General Dynamics C4 Systems
+ * Copyright 2021, HENSOLDT Cyber
  *
  * SPDX-License-Identifier: GPL-2.0-only
  */
@@ -12,12 +13,15 @@ cap_t create_unmapped_it_frame_cap(pptr_t pptr, bool_t use_large);
 cap_t create_mapped_it_frame_cap(cap_t pd_cap, pptr_t pptr, vptr_t vptr, asid_t asid, bool_t use_large,
                                  bool_t executable);
 
+/* This is called from assembly code and thus there are no specific types in
+ * the signature.
+ */
 void init_kernel(
-    paddr_t ui_p_reg_start,
-    paddr_t ui_p_reg_end,
-    sword_t pv_offset,
-    vptr_t  v_entry,
-    paddr_t dtb_addr_p,
-    uint32_t dtb_size
+    word_t ui_p_reg_start,
+    word_t ui_p_reg_end,
+    word_t pv_offset,
+    word_t v_entry,
+    word_t dtb_addr_p,
+    word_t dtb_size
 );
 

--- a/include/arch/riscv/arch/kernel/boot.h
+++ b/include/arch/riscv/arch/kernel/boot.h
@@ -1,6 +1,7 @@
 /*
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  * Copyright 2015, 2016 Hesham Almatary <heshamelmatary@gmail.com>
+ * Copyright 2021, HENSOLDT Cyber
  *
  * SPDX-License-Identifier: GPL-2.0-only
  */
@@ -14,13 +15,16 @@ cap_t create_unmapped_it_frame_cap(pptr_t pptr, bool_t use_large);
 cap_t create_mapped_it_frame_cap(cap_t pd_cap, pptr_t pptr, vptr_t vptr, asid_t asid, bool_t use_large,
                                  bool_t executable);
 
+/* This is called from assembly code and thus there are no specific types in
+ * the signature.
+ */
 void init_kernel(
-    paddr_t ui_p_reg_start,
-    paddr_t ui_p_reg_end,
-    sword_t pv_offset,
-    vptr_t  v_entry,
-    paddr_t dtb_addr_p,
-    uint32_t dtb_size
+    word_t ui_p_reg_start,
+    word_t ui_p_reg_end,
+    word_t pv_offset,
+    word_t v_entry,
+    word_t dtb_addr_p,
+    word_t dtb_size
 #ifdef ENABLE_SMP_SUPPORT
     ,
     word_t hart_id,

--- a/src/arch/arm/kernel/boot.c
+++ b/src/arch/arm/kernel/boot.c
@@ -310,7 +310,6 @@ BOOT_CODE static void release_secondary_cpus(void)
 #endif /* ENABLE_SMP_SUPPORT */
 
 /* Main kernel initialisation function. */
-
 static BOOT_CODE bool_t try_init_kernel(
     paddr_t ui_p_reg_start,
     paddr_t ui_p_reg_end,
@@ -336,7 +335,27 @@ static BOOT_CODE bool_t try_init_kernel(
     create_frames_of_region_ret_t create_frames_ret;
     create_frames_of_region_ret_t extra_bi_ret;
 
-    /* convert from physical addresses to userland vptrs */
+    /* Conversion from physical addresses to userland vptrs uses pv_offset,
+     * which is defined as:
+     *     virt_address + pv_offset = phys_address
+     * The offset is usually a positive value, because the virtual address of
+     * the user image is a low value and the actually physical address is much
+     * greater. However, there is no restrictions on the physical and virtual
+     * image location in general. Defining pv_offset as a signed value might
+     * seem the intuitive choice how to handle this, but there are two catches
+     * here that break the C rules. We can't cover the full integer range then,
+     * and overflows/underflows are well defined for unsigned values only. They
+     * are undefined for signed values, even if such operations practically work
+     * in many cases due to how compiler and machine implement negative integers
+     * using the two's-complement.
+     * Assume a 32-bit system with virt_address=0xc0000000 and phys_address=0,
+     * then pv_offset would have to be -0xc0000000. This value is not in the
+     * 32-bit signed integer range. Calculating '0 - 0xc0000000' using unsigned
+     * integers, the result is 0x40000000 after an underflow, the reverse
+     * calculation '0xc0000000 + 0x40000000' results in 0 again after overflow.
+     * If 0x40000000 is a signed integer, the result is likely the same, but the
+     * whole operation is undefined by C rules.
+     */
     v_region_t ui_v_reg = {
         .start = ui_p_reg_start - pv_offset,
         .end   = ui_p_reg_end   - pv_offset
@@ -615,13 +634,16 @@ static BOOT_CODE bool_t try_init_kernel(
     return true;
 }
 
+/* This is called from assembly code and thus there are no specific types in
+ * the signature.
+ */
 BOOT_CODE VISIBLE void init_kernel(
-    paddr_t ui_p_reg_start,
-    paddr_t ui_p_reg_end,
-    sword_t pv_offset,
-    vptr_t  v_entry,
-    paddr_t dtb_addr_p,
-    uint32_t dtb_size
+    word_t ui_p_reg_start,
+    word_t ui_p_reg_end,
+    word_t pv_offset,
+    word_t v_entry,
+    word_t dtb_addr_p,
+    word_t dtb_size
 )
 {
     bool_t result;
@@ -629,21 +651,21 @@ BOOT_CODE VISIBLE void init_kernel(
 #ifdef ENABLE_SMP_SUPPORT
     /* we assume there exists a cpu with id 0 and will use it for bootstrapping */
     if (getCurrentCPUIndex() == 0) {
-        result = try_init_kernel(ui_p_reg_start,
-                                 ui_p_reg_end,
+        result = try_init_kernel((paddr_t)ui_p_reg_start,
+                                 (paddr_t)ui_p_reg_end,
                                  pv_offset,
-                                 v_entry,
-                                 dtb_addr_p, dtb_size);
+                                 (vptr_t)v_entry,
+                                 (paddr_t)dtb_addr_p, dtb_size);
     } else {
         result = try_init_kernel_secondary_core();
     }
 
 #else
-    result = try_init_kernel(ui_p_reg_start,
-                             ui_p_reg_end,
+    result = try_init_kernel((paddr_t)ui_p_reg_start,
+                             (paddr_t)ui_p_reg_end,
                              pv_offset,
-                             v_entry,
-                             dtb_addr_p, dtb_size);
+                             (vptr_t)v_entry,
+                             (paddr_t)dtb_addr_p, dtb_size);
 
 #endif /* ENABLE_SMP_SUPPORT */
 


### PR DESCRIPTION
Use word_t and sword_t to be architecture agnostic.

Notes:
- This PR is on top of https://github.com/seL4/seL4/pull/425
- This PR needs https://github.com/seL4/seL4_tools/pull/100

(edit: removed test reference, because these two are now merged)