### PR TITLE
mcs: sc_active not always true in sc_sporadic

### DIFF
--- a/include/kernel/sporadic.h
+++ b/include/kernel/sporadic.h
@@ -159,9 +159,6 @@ static inline bool_t sc_released(sched_context_t *sc)
  */
 static inline bool_t sc_sporadic(sched_context_t *sc)
 {
-    /* We do expect sc_active to be always true if sc is not NULL when
-       sc_sporadic is called, but we have not proved it yet. */
-    assert(sc == NULL || sc_active(sc));
     return sc != NULL && sc_active(sc) && sc->scSporadic;
 }
 


### PR DESCRIPTION
Turns out the invariant 17109eb8c986cd0ac refers to (discussed in #476) is hard to prove because it is not true, and the runtime check is necessary. This assertion fails in sel4test SCHED_CONTEXT_0003 (Basic api_sc_bind/UnbindObject testing).
