### PR TITLE
boot: don't enforcing defining MODE_RESERVED

### DIFF
--- a/include/arch/arm/arch/bootinfo.h
+++ b/include/arch/arm/arch/bootinfo.h
@@ -18,11 +18,19 @@
  */
 #define MAX_NUM_FREEMEM_REG (ARRAY_SIZE(avail_p_regs) + MODE_RESERVED + 1 + 1)
 
+/* The regions reserved by the boot code are:
+ * +1 for kernel
+ * +1 for device tree binary
+ * +1 for user image.
+ * +1 for each the MODE_RESERVED region, there might be none
+ */
+#define NUM_RESERVED_REGIONS (3 + MODE_RESERVED)
+
+
 /* The maximum number of reserved regions is:
  * +1 for each free memory region (MAX_NUM_FREEMEM_REG)
  * +1 for each kernel frame (NUM_KERNEL_DEVICE_FRAMES, there might be none)
- * +1 for each mode-reserved region (MODE_RESERVED)
- * +1 for each region reserved by the boot code (3: kernel, dtb, user image)
+ * +1 for each region reserved by the boot code (NUM_RESERVED_REGIONS)
  */
 #define MAX_NUM_RESV_REG (MAX_NUM_FREEMEM_REG + NUM_KERNEL_DEVICE_FRAMES + \
-                          MODE_RESERVED + 3)
+                          NUM_RESERVED_REGIONS)

--- a/include/arch/arm/arch/bootinfo.h
+++ b/include/arch/arm/arch/bootinfo.h
@@ -6,17 +6,19 @@
 
 #pragma once
 
-/* Modifiers:
- *  + 1: allow the kernel to release its own boot data region
- *  + 1: possible gap between ELF images and rootserver objects;
- *       see arm/arch_init_freemem */
+/* The max number of free memory regions is:
+ * +1 for each available physical memory region (elements in avail_p_regs)
+ * +1 for each MODE_RESERVED region, there might be none
+ * +1 to allow the kernel to release its own boot data region
+ * +1 for a possible gap between ELF images and rootserver objects
+ */
 #define MAX_NUM_FREEMEM_REG (ARRAY_SIZE(avail_p_regs) + MODE_RESERVED + 1 + 1)
 
 /* The maximum number of reserved regions is:
- * - 1 for each physical memory region (MAX_NUM_FREEMEM_REG)
- * - 1 for each kernel frame (NUM_KERNEL_DEVICE_FRAMES, there might be none)
- * - 1 for each mode-reserved region. (MODE_RESERVED)
- * - 1 each for kernel, dtb, and user image. (3)
+ * +1 for each free memory region (MAX_NUM_FREEMEM_REG)
+ * +1 for each kernel frame (NUM_KERNEL_DEVICE_FRAMES, there might be none)
+ * +1 for each mode-reserved region (MODE_RESERVED)
+ * +1 for each region reserved by the boot code (3: kernel, dtb, user image)
  */
 #define MAX_NUM_RESV_REG (MAX_NUM_FREEMEM_REG + NUM_KERNEL_DEVICE_FRAMES + \
                           MODE_RESERVED + 3)

--- a/include/arch/arm/arch/bootinfo.h
+++ b/include/arch/arm/arch/bootinfo.h
@@ -6,6 +6,10 @@
 
 #pragma once
 
+#include <config.h>
+#include <plat/machine/devices_gen.h>
+#include <kernel/vspace.h>
+
 /* The max number of free memory regions is:
  * +1 for each available physical memory region (elements in avail_p_regs)
  * +1 for each MODE_RESERVED region, there might be none

--- a/include/arch/riscv/arch/bootinfo.h
+++ b/include/arch/riscv/arch/bootinfo.h
@@ -16,11 +16,17 @@
  */
 #define MAX_NUM_FREEMEM_REG 16
 
+/* The regions reserved by the boot code are:
+ * +1 for kernel
+ * +1 for device tree binary
+ * +1 for user image.
+ */
+#define NUM_RESERVED_REGIONS (3 + MODE_RESERVED)
+
 /* The maximum number of reserved regions is:
  * +1 for each free memory region (MAX_NUM_FREEMEM_REG)
  * +1 for each kernel frame (NUM_KERNEL_DEVICE_FRAMES, there might be none)
- * +1 for each mode-reserved region (MODE_RESERVED)
- * +1 for each region reserved by the boot code (3: kernel, dtb, user image)
+ * +1 for each region reserved by the boot code (NUM_RESERVED_REGIONS)
  */
 #define MAX_NUM_RESV_REG (MAX_NUM_FREEMEM_REG + NUM_KERNEL_DEVICE_FRAMES + \
-                          MODE_RESERVED + 3)
+                          NUM_RESERVED_REGIONS)

--- a/include/arch/riscv/arch/bootinfo.h
+++ b/include/arch/riscv/arch/bootinfo.h
@@ -8,7 +8,6 @@
 
 #include <config.h>
 #include <plat/machine/devices_gen.h>
-#include <arch/machine/hardware.h>
 
 /* The value for the max number of free memory region is basically an arbitrary
  * choice. We could calculate the exact number, but just picking 16 will also
@@ -21,7 +20,7 @@
  * +1 for device tree binary
  * +1 for user image.
  */
-#define NUM_RESERVED_REGIONS (3 + MODE_RESERVED)
+#define NUM_RESERVED_REGIONS 3
 
 /* The maximum number of reserved regions is:
  * +1 for each free memory region (MAX_NUM_FREEMEM_REG)

--- a/include/arch/riscv/arch/bootinfo.h
+++ b/include/arch/riscv/arch/bootinfo.h
@@ -6,6 +6,10 @@
 
 #pragma once
 
+#include <config.h>
+#include <plat/machine/devices_gen.h>
+#include <arch/machine/hardware.h>
+
 /* The value for the max number of free memory region is basically an arbitrary
  * choice. We could calculate the exact number, but just picking 16 will also
  * do for now. Increase this value if the boot fails.

--- a/include/arch/riscv/arch/bootinfo.h
+++ b/include/arch/riscv/arch/bootinfo.h
@@ -6,13 +6,17 @@
 
 #pragma once
 
+/* The value for the max number of free memory region is basically an arbitrary
+ * choice. We could calculate the exact number, but just picking 16 will also
+ * do for now. Increase this value if the boot fails.
+ */
 #define MAX_NUM_FREEMEM_REG 16
 
 /* The maximum number of reserved regions is:
- * - 1 for each physical memory region (MAX_NUM_FREEMEM_REG)
- * - 1 for each kernel region (NUM_KERNEL_DEVICE_FRAMES, there might be none)
- * - 1 for each mode-reserved region. (MODE_RESERVED)
- * - 1 each for kernel, dtb, and user image. (3)
+ * +1 for each free memory region (MAX_NUM_FREEMEM_REG)
+ * +1 for each kernel frame (NUM_KERNEL_DEVICE_FRAMES, there might be none)
+ * +1 for each mode-reserved region (MODE_RESERVED)
+ * +1 for each region reserved by the boot code (3: kernel, dtb, user image)
  */
 #define MAX_NUM_RESV_REG (MAX_NUM_FREEMEM_REG + NUM_KERNEL_DEVICE_FRAMES + \
                           MODE_RESERVED + 3)

--- a/include/arch/riscv/arch/machine/hardware.h
+++ b/include/arch/riscv/arch/machine/hardware.h
@@ -39,8 +39,6 @@
 
 #define PAGE_BITS seL4_PageBits
 
-#define MODE_RESERVED 0
-
 /* MMU RISC-V related definitions. See RISC-V manual priv-1.10 */
 
 /* Extract the n-level PT index from a virtual address. This works for any

--- a/src/arch/arm/kernel/boot.c
+++ b/src/arch/arm/kernel/boot.c
@@ -43,22 +43,27 @@ BOOT_CODE static bool_t arch_init_freemem(p_region_t ui_p_reg,
                                           v_region_t it_v_reg,
                                           word_t extra_bi_size_bits)
 {
+    /* reserve the kernel image region */
     reserved[0].start = KERNEL_ELF_BASE;
     reserved[0].end = (pptr_t)ki_end;
 
     int index = 1;
+
+    /* add the dtb region, if it is not empty */
     if (dtb_p_reg.start) {
-        /* the dtb region could be empty */
         reserved[index].start = (pptr_t) paddr_to_pptr(dtb_p_reg.start);
         reserved[index].end = (pptr_t) paddr_to_pptr(dtb_p_reg.end);
         index++;
     }
 
+    /* Reserve the user image region and the mode-reserved regions. For now,
+     * only one mode-reserved region is supported, because this is all that is
+     * needed.
+     */
     if (MODE_RESERVED > 1) {
         printf("ERROR: MODE_RESERVED > 1 unsupported!\n");
         return false;
     }
-
     if (ui_p_reg.start < PADDR_TOP) {
         region_t ui_reg = paddr_to_pptr_reg(ui_p_reg);
         if (MODE_RESERVED == 1) {

--- a/src/arch/riscv/kernel/boot.c
+++ b/src/arch/riscv/kernel/boot.c
@@ -23,9 +23,7 @@
 BOOT_BSS static volatile word_t node_boot_lock;
 #endif
 
-/* kernel image + [extra bootinfo] + user image */
-#define MAX_RESERVED 3
-BOOT_BSS static region_t res_reg[MAX_RESERVED];
+BOOT_BSS static region_t res_reg[NUM_RESERVED_REGIONS];
 
 BOOT_CODE cap_t create_mapped_it_frame_cap(cap_t pd_cap, pptr_t pptr, vptr_t vptr, asid_t asid, bool_t
                                            use_large, bool_t executable)
@@ -67,12 +65,20 @@ BOOT_CODE static bool_t arch_init_freemem(region_t ui_reg, v_region_t it_v_reg,
 
     /* add the dtb region, if it is not empty */
     if (dtb_reg.start) {
+        if (index >= ARRAY_SIZE(res_reg)) {
+            printf("ERROR: no slot to add DTB to reserved regions\n");
+            return false;
+        }
         res_reg[index].start = dtb_reg.start;
         res_reg[index].end = dtb_reg.end;
         index += 1;
     }
 
     /* reserve the user image region */
+    if (index >= ARRAY_SIZE(res_reg)) {
+        printf("ERROR: no slot to add user image to reserved regions\n");
+        return false;
+    }
     res_reg[index].start = ui_reg.start;
     res_reg[index].end = ui_reg.end;
     index += 1;

--- a/src/arch/riscv/kernel/boot.c
+++ b/src/arch/riscv/kernel/boot.c
@@ -56,19 +56,23 @@ BOOT_CODE static bool_t arch_init_freemem(region_t ui_reg, v_region_t it_v_reg,
                                           region_t dtb_reg,
                                           word_t extra_bi_size_bits)
 {
-    // This looks a bit awkward as our symbols are a reference in the kernel image window, but
-    // we want to do all allocations in terms of the main kernel window, so we do some translation
+    /* Reserve the kernel image region. This may look a bit awkward, as the
+     * symbols are a reference in the kernel image window, but all allocations
+     * are done in terms of the main kernel window, so we do some translation.
+     */
     res_reg[0].start = (pptr_t)paddr_to_pptr(kpptr_to_paddr((void *)KERNEL_ELF_BASE));
     res_reg[0].end = (pptr_t)paddr_to_pptr(kpptr_to_paddr((void *)ki_end));
 
     int index = 1;
+
+    /* add the dtb region, if it is not empty */
     if (dtb_reg.start) {
-        /* optionally reserve the dtb region, as it could be empty */
         res_reg[index].start = dtb_reg.start;
         res_reg[index].end = dtb_reg.end;
         index += 1;
     }
 
+    /* reserve the user image region */
     res_reg[index].start = ui_reg.start;
     res_reg[index].end = ui_reg.end;
     index += 1;


### PR DESCRIPTION
On AARCH32 there is a special need for an ASID region. Since no other architecture needs this mechanism, handle this within the AARCH32 specific code and keep the generic code clean.