### PR TITLE
boot: reduce amount of helper functions

### DIFF
--- a/include/arch/arm/arch/machine.h
+++ b/include/arch/arm/arch/machine.h
@@ -15,8 +15,6 @@
 
 int get_num_avail_p_regs(void);
 const p_region_t *get_avail_p_regs(void);
-int get_num_dev_p_regs(void);
-p_region_t get_dev_p_reg(word_t i);
 void map_kernel_devices(void);
 
 void initL2Cache(void);

--- a/include/arch/arm/arch/machine.h
+++ b/include/arch/arm/arch/machine.h
@@ -13,8 +13,6 @@
 
 #ifndef __ASSEMBLER__
 
-int get_num_avail_p_regs(void);
-const p_region_t *get_avail_p_regs(void);
 void map_kernel_devices(void);
 
 void initL2Cache(void);

--- a/include/arch/riscv/arch/machine.h
+++ b/include/arch/riscv/arch/machine.h
@@ -215,8 +215,6 @@ static inline void Arch_finaliseInterrupt(void)
 {
 }
 
-int get_num_avail_p_regs(void);
-p_region_t *get_avail_p_regs(void);
 void map_kernel_devices(void);
 
 /** MODIFIES: [*] */

--- a/include/arch/riscv/arch/machine.h
+++ b/include/arch/riscv/arch/machine.h
@@ -217,8 +217,6 @@ static inline void Arch_finaliseInterrupt(void)
 
 int get_num_avail_p_regs(void);
 p_region_t *get_avail_p_regs(void);
-int get_num_dev_p_regs(void);
-p_region_t get_dev_p_reg(word_t i);
 void map_kernel_devices(void);
 
 /** MODIFIES: [*] */

--- a/src/arch/arm/kernel/boot.c
+++ b/src/arch/arm/kernel/boot.c
@@ -83,8 +83,10 @@ BOOT_CODE static bool_t arch_init_freemem(p_region_t ui_p_reg,
         index++;
     }
 
-    return init_freemem(get_num_avail_p_regs(), get_avail_p_regs(), index,
-                        reserved, it_v_reg, extra_bi_size_bits);
+    /* avail_p_regs comes from the auto-generated code */
+    return init_freemem(ARRAY_SIZE(avail_p_regs), avail_p_regs,
+                        index, reserved,
+                        it_v_reg, extra_bi_size_bits);
 }
 
 

--- a/src/arch/arm/machine/hardware.c
+++ b/src/arch/arm/machine/hardware.c
@@ -19,16 +19,6 @@ void setNextPC(tcb_t *thread, word_t v)
     setRegister(thread, NEXT_PC_REG, v);
 }
 
-BOOT_CODE int get_num_avail_p_regs(void)
-{
-    return sizeof(avail_p_regs) / sizeof(p_region_t);
-}
-
-BOOT_CODE const p_region_t *get_avail_p_regs(void)
-{
-    return (const p_region_t *) avail_p_regs;
-}
-
 BOOT_CODE void map_kernel_devices(void)
 {
     for (int i = 0; i < ARRAY_SIZE(kernel_devices); i++) {

--- a/src/arch/riscv/kernel/boot.c
+++ b/src/arch/riscv/kernel/boot.c
@@ -72,8 +72,10 @@ BOOT_CODE static bool_t arch_init_freemem(region_t ui_reg, v_region_t it_v_reg,
     res_reg[index].end = ui_reg.end;
     index += 1;
 
-    return init_freemem(get_num_avail_p_regs(), get_avail_p_regs(), index,
-                        res_reg, it_v_reg, extra_bi_size_bits);
+    /* avail_p_regs comes from the auto-generated code */
+    return init_freemem(ARRAY_SIZE(avail_p_regs), avail_p_regs,
+                        index, res_reg,
+                        it_v_reg, extra_bi_size_bits);
 }
 
 BOOT_CODE static void init_irqs(cap_t root_cnode_cap)

--- a/src/arch/riscv/machine/hardware.c
+++ b/src/arch/riscv/machine/hardware.c
@@ -38,16 +38,6 @@ void setNextPC(tcb_t *thread, word_t v)
     setRegister(thread, NextIP, v);
 }
 
-BOOT_CODE int get_num_avail_p_regs(void)
-{
-    return sizeof(avail_p_regs) / sizeof(p_region_t);
-}
-
-BOOT_CODE p_region_t *get_avail_p_regs(void)
-{
-    return (p_region_t *) avail_p_regs;
-}
-
 BOOT_CODE void map_kernel_devices(void)
 {
     if (kernel_devices == NULL) {


### PR DESCRIPTION
* The python code generator ensures avail_p_regs always exists, so it can be used directly.
* `dev_p_regs` does not exist anymore, so there is no need for the helper functions.