### PR TITLE
mcs: Remove domain time check from preemptionPoint (v2)

### DIFF
--- a/include/kernel/thread.h
+++ b/include/kernel/thread.h
@@ -229,18 +229,24 @@ static inline void updateTimestamp(void)
     time_t consumed = (NODE_STATE(ksCurTime) - prev);
     NODE_STATE(ksConsumed) += consumed;
     if (CONFIG_NUM_DOMAINS > 1) {
-
         if ((consumed + MIN_BUDGET) >= ksDomainTime) {
             ksDomainTime = 0;
         } else {
             ksDomainTime -= consumed;
         }
-        if (unlikely(isCurDomainExpired())) {
-            NODE_STATE(ksReprogram) = true;
-            rescheduleRequired();
-        }
     }
 
+}
+
+/*
+ * Check if domain time has expired
+ */
+static inline void checkDomainTime(void)
+{
+    if (unlikely(isCurDomainExpired())) {
+        NODE_STATE(ksReprogram) = true;
+        rescheduleRequired();
+    }
 }
 
 /* Check if the current thread/domain budget has expired.

--- a/src/kernel/thread.c
+++ b/src/kernel/thread.c
@@ -352,6 +352,7 @@ void schedule(void)
 {
 #ifdef CONFIG_KERNEL_MCS
     awaken();
+    checkDomainTime();
 #endif
 
     if (NODE_STATE(ksSchedulerAction) != SchedulerAction_ResumeCurrentThread) {


### PR DESCRIPTION
As Curtis said: this removes the operations that trigger a reschedule or reprogram the timer from `preemptionPoint` to ensure the relevant state updates in the proof occur where they are easier to verify.

This simplifies and supersedes #480. The idea is that it is simpler and easier in both proof and code to do the check once after the main kernel event is finished, and on the path that has to deal with checking time and scheduling anyway.

The preemption point and all other places that call `updateTimestamp` now just flag that the domain will have to be changed (`ksDomainTime = 0`) and don't change the scheduler action/timer directly, so the proofs that depend on the scheduler action only have to deal with that state update once, but still before anything that depends on it.