### PR TITLE
x86: Always eliminate function prologue for idle_thread()

### DIFF
--- a/src/arch/x86/idle.c
+++ b/src/arch/x86/idle.c
@@ -7,11 +7,21 @@
 #include <config.h>
 #include <api/debug.h>
 
-void idle_thread(void)
+/*
+ * The idle thread does not have a dedicated stack and runs in
+ * the context of the idle thread TCB. Make sure that the compiler
+ * always eliminates the function prologue by declaring the
+ * idle_thread with the naked attribute.
+ */
+__attribute__((naked)) void idle_thread(void)
 {
-    while (1) {
-        asm volatile("hlt");
-    }
+    /* We cannot use for-loop or while-loop here because they may
+     * involve stack manipulations (the compiler will not allow
+     * them in a naked function anyway). */
+    asm volatile(
+        "1: hlt\n"
+        "jmp 1b"
+    );
 }
 
 /** DONT_TRANSLATE */

--- a/src/arch/x86/idle.c
+++ b/src/arch/x86/idle.c
@@ -13,7 +13,7 @@
  * always eliminates the function prologue by declaring the
  * idle_thread with the naked attribute.
  */
-__attribute__((naked)) void idle_thread(void)
+__attribute__((naked)) NORETURN void idle_thread(void)
 {
     /* We cannot use for-loop or while-loop here because they may
      * involve stack manipulations (the compiler will not allow


### PR DESCRIPTION
The idle_thread() cannot perform any stack manipulations since it runs in the idle thread TCB context. Declare the function with the naked attribute, to ensure that the compiler always eliminates the function prologue. Previously we rely on the -O2 optimization flag for this, which on certain compilers may not guarantee that the function prologue gets eliminated.

This is in response to a kernel crash on ia32 when compiled with clang 12.0.1. See  https://sel4.discourse.group/t/kernel-crash-on-x86-but-not-on-x86-64/398