### PR TITLE
tools: use /usr/bin/env for bash/sh invocation

### DIFF
--- a/tools/cpp_gen.sh
+++ b/tools/cpp_gen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
 #

--- a/tools/dts/update-dts.sh
+++ b/tools/dts/update-dts.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 #
 # Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
 #

--- a/tools/kernel_pylint.sh
+++ b/tools/kernel_pylint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
 #

--- a/tools/kernel_pylint.sh
+++ b/tools/kernel_pylint.sh
@@ -6,12 +6,12 @@
 #
 
 python_sources=$(find ../tools ../manual/tools ../libsel4/tools -name '*.py')
-if [[ -z $python_sources ]]; then
+if [ -z "$python_sources" ]; then
     echo "Unable to find python source files"
     exit 1
 fi
 pylintrc=$(find . -name 'pylintrc')
-if [[ -z $pylintrc ]]; then
+if [ -z "$pylintrc" ]; then
     echo "Unable to find pylintrc"
     exit 1
 fi

--- a/tools/kernel_xmllint.sh
+++ b/tools/kernel_xmllint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
 #

--- a/tools/kernel_xmllint.sh
+++ b/tools/kernel_xmllint.sh
@@ -6,13 +6,13 @@
 #
 
 xml_sources=$(find ../libsel4/arch_include/*/interfaces ../libsel4/sel4_arch_include/*/interfaces -name 'sel4arch.xml')
-if [[ -z $xml_sources ]]; then
+if [ -z "$xml_sources" ]; then
     echo "Unable to find sel4arch.xml files"
     exit 1
 fi
 
 idl_source=$(find ../libsel4/tools -name 'sel4_idl.dtd')
-if [[ -z $idl_source ]]; then
+if [ -z "$idl_source" ]; then
     echo "Unable to find sel4_idl.dtd"
     exit 1
 fi

--- a/tools/xmllint.sh
+++ b/tools/xmllint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
 #


### PR DESCRIPTION
This implements GitHub PR #115 on the current repo state. `/usr/bin/env` is already used for other (cmake/python/etc) invocations, and this PR brings bash/sh into line with that for slightly improved portability.
