### PR TITLE
github: trigger main test on push to master

### DIFF
--- a/.github/workflows/trigger.yml
+++ b/.github/workflows/trigger.yml
@@ -1,0 +1,19 @@
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Trigger repository dispatch on main test repos
+name: Trigger
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  trigger:
+    name: Repository Dispatch
+    runs-on: ubuntu-latest
+    steps:
+    - uses: seL4/ci-actions/trigger@master
+      with:
+        token: ${{ secrets.PRIV_REPO_TOKEN }}


### PR DESCRIPTION
The trigger action sends repository_dispatch events to all main test repositories of the manifests this repo is part of.
