### PR TITLE
boot: remove ndks_boot.slot_pos_max

### DIFF
--- a/include/kernel/boot.h
+++ b/include/kernel/boot.h
@@ -25,7 +25,6 @@ typedef struct ndks_boot {
     region_t   freemem[MAX_NUM_FREEMEM_REG];
     seL4_BootInfo      *bi_frame;
     seL4_SlotPos slot_pos_cur;
-    seL4_SlotPos slot_pos_max;
 } ndks_boot_t;
 
 extern ndks_boot_t ndks_boot;


### PR DESCRIPTION
- The field `slot_pos_max` from `ndks_boot` is not needed, the value stored there is the constant `BIT(CONFIG_ROOT_CNODE_SIZE_BITS)`.
- Improve the error message if the limit has been reached
