### PR TITLE
fastpath: placate clang-11

### DIFF
--- a/src/fastpath/fastpath.c
+++ b/src/fastpath/fastpath.c
@@ -131,7 +131,7 @@ void NORETURN fastpath_call(word_t cptr, word_t msgInfo)
 #endif
 
     /* Ensure the original caller is in the current domain and can be scheduled directly. */
-    if (unlikely(dest->tcbDomain != ksCurDomain && maxDom)) {
+    if (unlikely(dest->tcbDomain != ksCurDomain && 0 < maxDom)) {
         slowpath(SysCall);
     }
 
@@ -377,7 +377,7 @@ void NORETURN fastpath_reply_recv(word_t cptr, word_t msgInfo)
 #endif
 
     /* Ensure the original caller is in the current domain and can be scheduled directly. */
-    if (unlikely(caller->tcbDomain != ksCurDomain && maxDom)) {
+    if (unlikely(caller->tcbDomain != ksCurDomain && 0 < maxDom)) {
         slowpath(SysReplyRecv);
     }
 


### PR DESCRIPTION
clang-11 warns "converting the enum constant to a boolean". The comparison generates the same code, since the expression can be evaluated at compile time (I checked the objdump).

This is in preparation for upgrading the docker containers to clang-11 and gcc-10 (see initial discussion on seL4/seL4-CAmkES-L4v-dockerfiles#39 -- debian bullseye is released, which means our docker build no longer works).