### PR TITLE
trivial: use #ifdef instead of #if

### DIFF
--- a/libsel4/sel4_plat_include/tqma8xqp1gb/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/tqma8xqp1gb/sel4/plat/api/constants.h
@@ -17,7 +17,7 @@
 #define seL4_NumDualFunctionMonitors (0)
 #endif
 
-#if CONFIG_ARCH_AARCH32
+#ifdef CONFIG_ARCH_AARCH32
 /* Platform support for tqma8xqp1gb is provided for AARCH64 only, even if the
  * Cortex-A35 supports AARCH32 also. Keep this as a build blocker as long as
  * AARCH32 remains untested.


### PR DESCRIPTION
`#if` fails if the symbol is not defined, at least for the older tool chain currently in docker.