### PR TITLE
docs: add link explaining license implications

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -15,13 +15,17 @@ directory `LICENSES` contains the text for all licenses that are
 mentioned by files in this repository.
 
 
-### GPL syscall note
+## GPL syscall note
+
 Note that, as in the [Linux syscall note for the GPL][2], the seL4
 kernel GPL license does *not* cover user-level code that uses kernel
 services by normal system calls - this is merely considered normal use
 of the kernel, and does *not* fall under the heading of "derived work".
 Syscall headers are provided under BSD.
 
+For a longer explanation of how the seL4 license does or does not affect
+your own code see also [this blog post][3].
 
 [1]: https://spdx.org
 [2]: https://spdx.org/licenses/Linux-syscall-note.html
+[3]: https://microkerneldude.wordpress.com/2019/12/09/what-does-sel4s-license-imply/

--- a/README.md
+++ b/README.md
@@ -108,3 +108,8 @@ A list of releases and current project status can be found under [seL4 releases]
 - [Userland Components and
       Drivers](https://docs.sel4.systems/projects/available-user-components.html): available device
       drivers and userland components
+
+License
+-------
+
+See the file [LICENSE.md](./LICENSE.md).


### PR DESCRIPTION
Adding a link to Gernot's blog post that explains what GPL on seL4
means for other code. This is mainly intended for people who aren't
that familiar with what all of these licenses mean.

Closes #524
