### PR TITLE
vtx: fix EPT cache attribute setting

### DIFF
--- a/src/arch/x86/kernel/ept.c
+++ b/src/arch/x86/kernel/ept.c
@@ -182,9 +182,9 @@ static ept_cache_options_t eptCacheFromVmAttr(vm_attributes_t vmAttr)
     /* PAT cache options are 1-1 with ept_cache_options. But need to
        verify user has specified a sensible option */
     ept_cache_options_t option = vmAttr.words[0];
-    if (option != EPTUncacheable ||
-        option != EPTWriteCombining ||
-        option != EPTWriteThrough ||
+    if (option != EPTUncacheable &&
+        option != EPTWriteCombining &&
+        option != EPTWriteThrough &&
         option != EPTWriteBack) {
         /* No failure mode is supported here, vmAttr settings should be verified earlier */
         option = EPTWriteBack;


### PR DESCRIPTION
Credits for this one should go to clang-11, which correctly flags that the big `||` always yielded true and was not doing what was intended.

This means, previously the only possible cache attribute for EPT was `EPTWriteBack`.
