### PR TITLE
x86 ioapic: make sure array is non-empty

### DIFF
--- a/src/plat/pc99/machine/ioapic.c
+++ b/src/plat/pc99/machine/ioapic.c
@@ -34,7 +34,7 @@
 
 /* Cache what we believe is in the low word of the IOREDTBL. This
  * has all the state of trigger modes etc etc */
-static uint32_t ioredtbl_state[IOAPIC_IRQ_LINES * CONFIG_MAX_NUM_IOAPIC];
+static uint32_t ioredtbl_state[IOAPIC_IRQ_LINES * MAX(1, CONFIG_MAX_NUM_IOAPIC)];
 
 /* Number of IOAPICs in the system */
 static uint32_t num_ioapics = 0;


### PR DESCRIPTION
CONFIG_MAX_NUM_IOAPIC can end up being 0 when the kernel is configured as PIC-only. This code is then unreachable, but gcc-10 can't figure that out and fails on array-out-of-bounds access (which would be correct if the code were reachable).
