### PR TITLE
cleanup code using BI_PTR(), use BI_FRAME_SIZE_BITS instead of seL4_PageBits

### DIFF
--- a/include/bootinfo.h
+++ b/include/bootinfo.h
@@ -10,8 +10,10 @@
 #include <types.h>
 #include <sel4/bootinfo_types.h>
 
+/* declare object-specific macros to hide the casting */
 #define BI_PTR(r) ((seL4_BootInfo*)(r))
 #define BI_REF(p) ((word_t)(p))
+
 #define S_REG_EMPTY (seL4_SlotRegion){ .start = 0, .end = 0 }
 
 /* The boot info frame takes at least one page, it must be big enough to hold

--- a/include/bootinfo.h
+++ b/include/bootinfo.h
@@ -12,8 +12,12 @@
 
 #define BI_PTR(r) ((seL4_BootInfo*)(r))
 #define BI_REF(p) ((word_t)(p))
-#define BI_FRAME_SIZE_BITS PAGE_BITS
 #define S_REG_EMPTY (seL4_SlotRegion){ .start = 0, .end = 0 }
 
-/* adjust constants in config.h if this assert fails */
+/* The boot info frame takes at least one page, it must be big enough to hold
+ * the seL4_BootInfo data structure. Due to internal restrictions, the boot info
+ * frame size must be of the form 2^n. Furthermore, there might still be code
+ * that makes the hard-coded assumption the boot info frame is always one page.
+ */
+#define BI_FRAME_SIZE_BITS PAGE_BITS
 compile_assert(bi_size, sizeof(seL4_BootInfo) <= BIT(BI_FRAME_SIZE_BITS))

--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -324,15 +324,17 @@ BOOT_CODE void populate_bi_frame(node_id_t node_id, word_t num_nodes,
     }
 
     /* initialise bootinfo-related global state */
-    ndks_boot.bi_frame = BI_PTR(rootserver.boot_info);
+    seL4_BootInfo *bi = BI_PTR(rootserver.boot_info);
+    bi->nodeID = node_id;
+    bi->numNodes = num_nodes;
+    bi->numIOPTLevels = 0;
+    bi->ipcBuffer = (seL4_IPCBuffer *)ipcbuf_vptr;
+    bi->initThreadCNodeSizeBits = CONFIG_ROOT_CNODE_SIZE_BITS;
+    bi->initThreadDomain = ksDomSchedule[ksDomScheduleIdx].domain;
+    bi->extraLen = extra_bi_size;
+
+    ndks_boot.bi_frame = bi;
     ndks_boot.slot_pos_cur = seL4_NumInitialCaps;
-    BI_PTR(rootserver.boot_info)->nodeID = node_id;
-    BI_PTR(rootserver.boot_info)->numNodes = num_nodes;
-    BI_PTR(rootserver.boot_info)->numIOPTLevels = 0;
-    BI_PTR(rootserver.boot_info)->ipcBuffer = (seL4_IPCBuffer *) ipcbuf_vptr;
-    BI_PTR(rootserver.boot_info)->initThreadCNodeSizeBits = CONFIG_ROOT_CNODE_SIZE_BITS;
-    BI_PTR(rootserver.boot_info)->initThreadDomain = ksDomSchedule[ksDomScheduleIdx].domain;
-    BI_PTR(rootserver.boot_info)->extraLen = extra_bi_size;
 }
 
 BOOT_CODE bool_t provide_cap(cap_t root_cnode_cap, cap_t cap)

--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -313,12 +313,14 @@ BOOT_CODE word_t calculate_extra_bi_size_bits(word_t extra_size)
     return msb;
 }
 
-BOOT_CODE void populate_bi_frame(node_id_t node_id, word_t num_nodes, vptr_t ipcbuf_vptr,
-                                 word_t extra_bi_size)
+BOOT_CODE void populate_bi_frame(node_id_t node_id, word_t num_nodes,
+                                 vptr_t ipcbuf_vptr, word_t extra_bi_size)
 {
-    clearMemory((void *) rootserver.boot_info, BI_FRAME_SIZE_BITS);
+    /* clear boot info memory */
+    clearMemory((void *)rootserver.boot_info, BI_FRAME_SIZE_BITS);
     if (extra_bi_size) {
-        clearMemory((void *) rootserver.extra_bi, calculate_extra_bi_size_bits(extra_bi_size));
+        clearMemory((void *)rootserver.extra_bi,
+                    calculate_extra_bi_size_bits(extra_bi_size));
     }
 
     /* initialise bootinfo-related global state */

--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -151,7 +151,8 @@ BOOT_CODE static word_t calculate_rootserver_size(v_region_t it_v_reg, word_t ex
     /* work out how much memory we need for root server objects */
     word_t size = BIT(CONFIG_ROOT_CNODE_SIZE_BITS + seL4_SlotBits);
     size += BIT(seL4_TCBBits); // root thread tcb
-    size += 2 * BIT(seL4_PageBits); // boot info + ipc buf
+    size += BIT(seL4_PageBits); // ipc buf
+    size += BIT(BI_FRAME_SIZE_BITS); // boot info
     size += BIT(seL4_ASIDPoolBits);
     size += extra_bi_size_bits > 0 ? BIT(extra_bi_size_bits) : 0;
     size += BIT(seL4_VSpaceBits); // root vspace
@@ -201,7 +202,7 @@ BOOT_CODE static void create_rootserver_objects(pptr_t start, v_region_t it_v_re
     maybe_alloc_extra_bi(seL4_PageBits, extra_bi_size_bits);
     rootserver.asid_pool = alloc_rootserver_obj(seL4_ASIDPoolBits, 1);
     rootserver.ipc_buf = alloc_rootserver_obj(seL4_PageBits, 1);
-    rootserver.boot_info = alloc_rootserver_obj(seL4_PageBits, 1);
+    rootserver.boot_info = alloc_rootserver_obj(BI_FRAME_SIZE_BITS, 1);
 
     /* TCBs on aarch32 can be larger than page tables in certain configs */
 #if seL4_TCBBits >= seL4_PageTableBits


### PR DESCRIPTION
- simplify the boot code by removing the trivial macros BI_PTR() and BI_REF().
- clarify assumptions that boot info is one page