### PR TITLE
Reset SBC on kernel fault for AOS

### DIFF
--- a/src/arch/arm/64/idle.c
+++ b/src/arch/arm/64/idle.c
@@ -15,6 +15,8 @@ void idle_thread(void)
     }
 }
 
+void wdog_reset(void);
+
 /** DONT_TRANSLATE */
 void NORETURN NO_INLINE VISIBLE halt(void)
 {
@@ -27,6 +29,7 @@ void NORETURN NO_INLINE VISIBLE halt(void)
     debug_printKernelEntryReason();
 #endif
 #endif
+    wdog_reset();
     idle_thread();
     UNREACHABLE();
 }

--- a/src/drivers/serial/meson-gx-uart.c
+++ b/src/drivers/serial/meson-gx-uart.c
@@ -45,6 +45,14 @@ void init_serial(void)
     *(UART_REG(UART_MISC)) = 1;
 }
 
+void wdog_reset(void)
+{
+    printf("\nResetting Odroid-C2\n");
+    volatile uint32_t *wdog = (volatile uint32_t *)(WDOG_PPTR);
+    *wdog = (WDOG_EN | WDOG_SYS_RESET_EN | WDOG_CLK_EN |
+             WDOG_CLK_DIV_EN | WDOG_SYS_RESET_NOW);
+}
+
 void handleUartIRQ(void)
 {
     /* while there are chars to process */
@@ -60,10 +68,7 @@ void handleUartIRQ(void)
         }
         if (index == strnlen(reset, 5)) {
             /* do the reset */
-            printf("\nResetting Odroid-C2\n");
-            volatile uint32_t *wdog = (volatile uint32_t *) (WDOG_PPTR);
-            *wdog = (WDOG_EN | WDOG_SYS_RESET_EN | WDOG_CLK_EN |
-                     WDOG_CLK_DIV_EN | WDOG_SYS_RESET_NOW);
+            wdog_reset();
         }
     }
 }


### PR DESCRIPTION
This ensures the hardware reset is triggered when the kernel faults ensuring that the hardware is rebooted rather than causing the hardware to hang requiring a full power down (which can't currently be performed remotely).

This only needs to be added to the AOS branch of the kernel.

Signed-off-by: Curtis Millar <curtis@curtism.me>