### PR TITLE
libsel4: add EPT attributes

### DIFF
--- a/libsel4/arch_include/x86/sel4/arch/types.h
+++ b/libsel4/arch_include/x86/sel4/arch/types.h
@@ -37,6 +37,17 @@ typedef enum {
     SEL4_FORCE_LONG_ENUM(seL4_X86_VMAttributes),
 } seL4_X86_VMAttributes;
 
+typedef enum {
+    seL4_X86_EPT_Uncached_VMAttributes = 6,
+    seL4_X86_EPT_Uncacheable = 0,
+    seL4_X86_EPT_WriteCombining = 1,
+    seL4_X86_EPT_WriteThrough = 4,
+    seL4_X86_EPT_WriteProtected = 5,
+    seL4_X86_EPT_WriteBack = 6,
+    seL4_X86_EPT_Default_VMAttributes = 6,
+    SEL4_FORCE_LONG_ENUM(seL4_X86_EPT_VMAttributes),
+} seL4_X86_EPT_VMAttributes;
+
 typedef struct seL4_VCPUContext_ {
     seL4_Word eax, ebx, ecx, edx, esi, edi, ebp;
 } seL4_VCPUContext;

--- a/src/arch/x86/kernel/ept.c
+++ b/src/arch/x86/kernel/ept.c
@@ -179,14 +179,12 @@ static lookupEPTPTSlot_ret_t lookupEPTPTSlot(ept_pml4e_t *pml4, vptr_t vptr)
 
 static ept_cache_options_t eptCacheFromVmAttr(vm_attributes_t vmAttr)
 {
-    /* PAT cache options are 1-1 with ept_cache_options. But need to
-       verify user has specified a sensible option */
+    /* Need to sanitise user input, vmAttr will not have been verified at this point. */
     ept_cache_options_t option = vmAttr.words[0];
     if (option != EPTUncacheable &&
         option != EPTWriteCombining &&
         option != EPTWriteThrough &&
         option != EPTWriteBack) {
-        /* No failure mode is supported here, vmAttr settings should be verified earlier */
         option = EPTWriteBack;
     }
     return option;


### PR DESCRIPTION
In x86, EPT and normal mappings have different cache attributes. This
commit adds an enum for the EPT attributes.

Signed-off-by: Chris Guikema <chris.guikema@dornerworks.com>