### PR TITLE
Ensure execute_process is error checked

### DIFF
--- a/config.cmake
+++ b/config.cmake
@@ -135,14 +135,22 @@ if(DEFINED KernelDTSList AND (NOT "${KernelDTSList}" STREQUAL ""))
         execute_process(
             COMMAND
                 ${DTC_TOOL} -q -I dts -O dtb -o ${KernelDTBPath} ${KernelDTSIntermediate}
+            RESULT_VARIABLE error
         )
+        if(error)
+            message(FATAL_ERROR "Failed to compile DTS to DTB: ${KernelDTBPath}")
+        endif()
         # Track the size of the DTB for downstream tools
         execute_process(
             COMMAND
                 ${STAT_TOOL} -c '%s' ${KernelDTBPath}
             OUTPUT_VARIABLE KernelDTBSize
             OUTPUT_STRIP_TRAILING_WHITESPACE
+            RESULT_VARIABLE error
         )
+        if(error)
+            message(FATAL_ERROR "Failed to determine KernelDTBSize: ${KernelDTBPath}")
+        endif()
         string(
             REPLACE
                 "\'"


### PR DESCRIPTION
Check the return value from execute_process calls and fail
with an appropriate message.

This makes debugging of cmake failures much easier.

Signed-off-by: Ben Leslie <benno@brkawy.com>