### PR TITLE
Remove unused PYTHON tool definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,6 @@ endif()
 include(tools/internal.cmake)
 
 # Define tools used by the kernel
-set(PYTHON "python2" CACHE INTERNAL "")
 set(PYTHON3 "python3" CACHE INTERNAL "")
 RequireTool(CPP_GEN_PATH cpp_gen.sh)
 RequireTool(CIRCULAR_INCLUDES circular_includes.py)


### PR DESCRIPTION
python2 is not used in the kernel build anymore so the tool
definition is unnecessary.

python2 is also end-of-line so there is no reason to think
we would ever depend on it again.

Signed-off-by: Ben Leslie <benno@brkawy.com>