### PR TITLE
Add additional cmake checks

### DIFF
--- a/configs/seL4Config.cmake
+++ b/configs/seL4Config.cmake
@@ -166,6 +166,18 @@ foreach(file ${result})
     include("${file}")
 endforeach()
 
+# Verify that, as a minimum any variables that are used
+# to find other build files are actually defined at this
+# point. This means at least: KernelArch KernelWordSize
+
+if("${KernelArch}" STREQUAL "")
+    message(FATAL_ERROR "Variable 'KernelArch' is not set.")
+endif()
+
+if("${KernelWordSize}" STREQUAL "")
+    message(FATAL_ERROR "Variable 'KernelWordSize' is not set.")
+endif()
+
 config_choice(KernelPlatform PLAT "Select the platform" ${kernel_platforms})
 
 # Now enshrine all the common variables in the config


### PR DESCRIPTION
Verify that KernelArch and KernelWordSize have been correctly
set after including the platform cmake files.

Signed-off-by: Ben Leslie <benno@brkawy.com>