### PR TITLE
Change freemem array as physical regions

### DIFF
--- a/include/kernel/boot.h
+++ b/include/kernel/boot.h
@@ -22,7 +22,7 @@ typedef cte_t *slot_ptr_t;
 typedef struct ndks_boot {
     p_region_t reserved[MAX_NUM_RESV_REG];
     word_t resv_count;
-    region_t   freemem[MAX_NUM_FREEMEM_REG];
+    p_region_t   freemem[MAX_NUM_FREEMEM_REG];
     seL4_BootInfo      *bi_frame;
     seL4_SlotPos slot_pos_cur;
 } ndks_boot_t;
@@ -31,7 +31,7 @@ extern ndks_boot_t ndks_boot;
 
 /* function prototypes */
 
-static inline bool_t is_reg_empty(region_t reg)
+static inline bool_t is_p_reg_empty(p_region_t reg)
 {
     return reg.start == reg.end;
 }
@@ -46,7 +46,7 @@ bool_t provide_cap(cap_t root_cnode_cap, cap_t cap);
 cap_t create_it_asid_pool(cap_t root_cnode_cap);
 void write_it_pd_pts(cap_t root_cnode_cap, cap_t it_pd_cap);
 bool_t create_idle_thread(void);
-bool_t create_untypeds(cap_t root_cnode_cap, region_t boot_mem_reuse_reg);
+bool_t create_untypeds(cap_t root_cnode_cap, p_region_t boot_mem_reuse_reg);
 void bi_finalise(void);
 void create_domain_cap(cap_t root_cnode_cap);
 

--- a/src/arch/arm/kernel/boot.c
+++ b/src/arch/arm/kernel/boot.c
@@ -524,8 +524,8 @@ static BOOT_CODE bool_t try_init_kernel(
     /* create all of the untypeds. Both devices and kernel window memory */
     if (!create_untypeds(
             root_cnode_cap,
-    (region_t) {
-    KERNEL_ELF_BASE, (pptr_t)ki_boot_end
+    (p_region_t) {
+    pptr_to_paddr((void *)KERNEL_ELF_BASE), pptr_to_paddr((void *)ki_boot_end)
     } /* reusable boot code/data */
         )) {
         printf("ERROR: could not create untypteds for kernel image boot memory\n");

--- a/src/arch/riscv/kernel/boot.c
+++ b/src/arch/riscv/kernel/boot.c
@@ -183,7 +183,6 @@ static BOOT_CODE bool_t try_init_kernel(
     p_region_t boot_mem_reuse_p_reg = ((p_region_t) {
         kpptr_to_paddr((void *)KERNEL_ELF_BASE), kpptr_to_paddr(ki_boot_end)
     });
-    region_t boot_mem_reuse_reg = paddr_to_pptr_reg(boot_mem_reuse_p_reg);
     region_t ui_reg = paddr_to_pptr_reg((p_region_t) {
         ui_p_reg_start, ui_p_reg_end
     });
@@ -377,7 +376,7 @@ static BOOT_CODE bool_t try_init_kernel(
     /* convert the remaining free memory into UT objects and provide the caps */
     if (!create_untypeds(
             root_cnode_cap,
-            boot_mem_reuse_reg)) {
+            boot_mem_reuse_p_reg)) {
         printf("ERROR: could not create untypteds for kernel image boot memory\n");
         return false;
     }

--- a/src/arch/x86/kernel/boot.c
+++ b/src/arch/x86/kernel/boot.c
@@ -110,7 +110,6 @@ BOOT_CODE bool_t init_sys_state(
 
     /* convert from physical addresses to kernel pptrs */
     region_t ui_reg             = paddr_to_pptr_reg(ui_info.p_reg);
-    region_t boot_mem_reuse_reg = paddr_to_pptr_reg(boot_mem_reuse_p_reg);
 
     /* convert from physical addresses to userland vptrs */
     v_region_t ui_v_reg;
@@ -328,7 +327,7 @@ BOOT_CODE bool_t init_sys_state(
 #endif
 
     /* create all of the untypeds. Both devices and kernel window memory */
-    if (!create_untypeds(root_cnode_cap, boot_mem_reuse_reg)) {
+    if (!create_untypeds(root_cnode_cap, boot_mem_reuse_p_reg)) {
         return false;
     }
 


### PR DESCRIPTION
During boot most architectures reference memory as physical
memory (not kernel virtual pointers). However, in the current
code freemem (and related helper functions) all expect
region_t, which is a kernel virtual memory region.

This patch changes this so that things stay as p_region_t as
much as possible. Overall this leads to much fewer conversions
between region_t/p_region_t and void */paddr.

With the change the only time the generic boot code requires
a kernel virtual address (and not a paddr) is right at the point
of creating the untyped cap.

The only region that starts as virtual that needs converting
to physical is the kernel reusable region of boot memory.
(And even then, that only appears to be the case on ARM. RISC-V
and X64 start with the kernel reusable region as a p_region_t).

Signed-off-by: Ben Leslie <benno@brkawy.com>