### PR TITLE
boot: improve user image location check

### DIFF
--- a/src/arch/riscv/kernel/boot.c
+++ b/src/arch/riscv/kernel/boot.c
@@ -1,6 +1,7 @@
 /*
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  * Copyright 2015, 2016 Hesham Almatary <heshamelmatary@gmail.com>
+ * Copyright 2021, HENSOLDT Cyber
  *
  * SPDX-License-Identifier: GPL-2.0-only
  */
@@ -235,6 +236,17 @@ static BOOT_CODE bool_t try_init_kernel(
 
     /* initialize the platform */
     init_plat();
+
+    if (it_v_reg.end >= USER_TOP) {
+        /* Variable arguments for printf() require well defined integer types
+         * to work properly. Unfortunately, the definition of USER_TOP differs
+         * between platforms (int, long), so we have to cast here to play safe.
+         */
+        printf("ERROR: userland image virt [%"SEL4_PRIx_word"..%"SEL4_PRIx_word"]"
+               "exceeds USER_TOP (%"SEL4_PRIx_word")\n",
+               it_v_reg.start, it_v_reg.end, (word_t)USER_TOP);
+        return false;
+    }
 
     /* make the free memory available to alloc_region() */
     if (!arch_init_freemem(ui_reg, it_v_reg, dtb_reg, extra_bi_size_bits)) {


### PR DESCRIPTION
Addresses parts of https://github.com/seL4/seL4/issues/540

- On ARM systems, the UART must be set up first before any error messages are visible. Move the user image location check after the platform init that brings up the UART.
- Add the user image location check on RISC-V systems also.
- Make the error message more verbose to clearly show the problem.
