### PR TITLE
risc-v: fix signature for Arch_setTLSRegister()

### DIFF
--- a/include/arch/riscv/arch/machine.h
+++ b/include/arch/riscv/arch/machine.h
@@ -238,10 +238,11 @@ static inline void arch_pause(void)
 #endif
 
 /* Update the value of the actual register to hold the expected value */
-static inline void Arch_setTLSRegister(word_t tls_base)
+static inline exception_t Arch_setTLSRegister(word_t tls_base)
 {
     /* The register is always reloaded upon return from kernel. */
     setRegister(NODE_STATE(ksCurThread), TLS_BASE, tls_base);
+    return EXCEPTION_NONE;
 }
 
 #endif // __ASSEMBLER__


### PR DESCRIPTION
This fixed that issue that if `KernelSetTLSBaseSelf` is enabled on RISC-V, the compilation fails with 
```
...src/api/syscall.c:320:20: error: void value not ignored as it ought to be
  320 |             return Arch_setTLSRegister(tls_base);
      |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```