### PR TITLE
github: drop python2 tests

### DIFF
--- a/.github/workflows/compilation-checks.yml
+++ b/.github/workflows/compilation-checks.yml
@@ -21,7 +21,6 @@ jobs:
       matrix:
         arch: [ARM, ARM_HYP, RISCV64, X64]
         compiler: [gcc, llvm]
-        python: [py2, py3]
         exclude:
           # llvm RISCV64 compilation is not currently supported
           - arch: RISCV64
@@ -32,4 +31,3 @@ jobs:
       with:
         ARCH: ${{ matrix.arch }}
         COMPILER: ${{ matrix.compiler }}
-        PYTHON: ${{ matrix.python }}


### PR DESCRIPTION
Since the build system defaults to python3 now, these have not worked as advertised in a while now (they have test py3 twice).

Needs to be merged after seL4/ci-actions#153
