### PR TITLE
Trivial: Remove now incorrect comment

### DIFF
--- a/include/object/structures.h
+++ b/include/object/structures.h
@@ -357,8 +357,7 @@ struct sched_context {
      * when the scheduling context was passed over a Call */
     reply_t *scReply;
 
-    /* notification this scheduling context is bound to
-     * (scTcb and scNotification cannot be set at the same time) */
+    /* notification this scheduling context is bound to */
     notification_t *scNotification;
 
     /* data word that is sent with timeout faults that occur on this scheduling context */


### PR DESCRIPTION
Since commit e18e32e2, "Allow Lazy SC Rebind", this is not true anymore.

Signed-off-by: Indan Zupancic <Indan.Zupancic@mep-info.com>