### PR TITLE
Cleanup python scripts

### DIFF
--- a/tools/hardware/config.py
+++ b/tools/hardware/config.py
@@ -15,15 +15,6 @@ class Config:
         self.sel4arch = sel4arch
         self.addrspace_max = addrspace_max
 
-    def get_kernel_phys_align(self) -> int:
-        ''' Used to align the base of physical memory. Returns alignment size in bits. '''
-        return 0
-
-    def get_bootloader_reserve(self) -> int:
-        ''' Used to reserve a fixed amount of memory for the bootloader. Offsets
-            the kernel load address by the amount returned in bytes. '''
-        return 0
-
     def get_page_bits(self) -> int:
         ''' Get page size in bits for this arch '''
         return 12  # 4096-byte pages
@@ -35,13 +26,13 @@ class Config:
         ''' Get page size in bits for mapping devices for this arch '''
         return self.get_page_bits()
 
-    def align_memory(self, regions: Set[Region]) -> List[Region]:
-        ''' Given a set of regions, sort them and align the first so that the
-        ELF loader will be able to load the kernel into it. Will return the
-        aligned memory region list, a set of any regions of memory that were
-        aligned out and the physBase value that the kernel will use. memory
-        region list, a set of any regions of memory that were aligned out and
-        the physBase value that the kernel will use. '''
+    def align_memory(self, regions: Set[Region]) -> (List[Region], int):
+        '''
+        Given a set of regions, reserve memory to ensure proper alignment of the
+        first region so that the ELF loader will be able to load the kernel into
+        it. Will return a set of memory regions that are reserved (ie aligned
+        out) and the kernel_phys_base value that the kernel will use (it's
+        called 'phys_base' in the kernel headers). '''
         pass
 
 
@@ -50,23 +41,17 @@ class ARMConfig(Config):
     arch = 'arm'
     SUPERSECTION_BITS = 24  # 2^24 = 16 MiByte
 
-    def get_kernel_phys_align(self) -> int:
-        ''' on ARM the ELF loader expects to be able to map a supersection page to load the kernel. '''
-        return self.SUPERSECTION_BITS
-
-    def align_memory(self, regions: Set[Region]) -> List[Region]:
-        ''' Arm wants physBase to be the physical load address of the kernel. '''
-        ret = sorted(regions)
-        extra_reserved = set()
-
-        new = ret[0].align_base(self.get_kernel_phys_align())
-        resv = Region(ret[0].base, new.base - ret[0].base)
-        extra_reserved.add(resv)
-        ret[0] = new
-
-        physBase = ret[0].base
-
-        return ret, extra_reserved, physBase
+    def align_memory(self, regions: Set[Region]) -> (List[Region], int):
+        '''
+        On ARM the kernel is put at the start of a supersection. The memory
+        before that is marked as reserved and lost.
+        '''
+        region_list = sorted(regions, key=lambda r: r.base)
+        reg0 = region_list[0]
+        reg_aligned = reg0.align_base(self.SUPERSECTION_BITS)
+        kernel_phys_base = reg_aligned.base
+        reserved_list = {Region(reg0.base, reg_aligned.base - reg0.base)}
+        return reserved_list, kernel_phys_base
 
 
 class RISCVConfig(Config):
@@ -74,29 +59,35 @@ class RISCVConfig(Config):
     arch = 'riscv'
     MEGAPAGE_BITS_RV32 = 22  # 2^22 = 4 MiByte
     MEGAPAGE_BITS_RV64 = 21  # 2^21 = 2 MiByte
-    MEGA_PAGE_SIZE_RV64 = 2**MEGAPAGE_BITS_RV64
 
-    def get_bootloader_reserve(self) -> int:
-        ''' OpenSBI reserved the first 2 MiByte of physical memory on rv64,
-        which is exactly a megapage. For rv32 we use the same value for now, as
-        this seems to work nicely - even if this is just half of the 4 MiByte
-        magepages that exist there. '''
-        return self.MEGA_PAGE_SIZE_RV64
-
-    def align_memory(self, regions: Set[Region]) -> List[Region]:
-        ''' Currently the RISC-V port expects physBase to be the address that the
-        bootloader is loaded at. To be generalised in the future. '''
-        ret = sorted(regions)
-        extra_reserved = set()
-
-        physBase = ret[0].base
-
-        resv = Region(ret[0].base, self.get_bootloader_reserve())
-        extra_reserved.add(resv)
-        ret[0].base += self.get_bootloader_reserve()
-        ret[0].size -= self.get_bootloader_reserve()
-
-        return ret, extra_reserved, physBase
+    def align_memory(self, regions: Set[Region]) -> (List[Region], int):
+        '''
+        The boot process on RISC-V is still a bit of a hack and rv32 seem to
+        copy what rv64 does. The first memory region starts at a rv64 megapage
+        boundary (2 MiByte). The common boot loader is OpenSBI, which reserves
+        the fist 2 MiByte of the physical memory. It puts the ELF loader with
+        the system image after itself (ie, an offset of 2 MiByte) and starts it
+        from there. The kernel expects kernel_phys_base to be the address where
+        the bootloader is and a 4 MiByte offset is added internally in the
+        kernel headers. The ELF loader has to put the kernel as this 4 MiByte
+        offset. This leaves 2 MiByte for the ELF loader and the system image,
+        otherwise the offset must be increased. Since this boot flow is quite
+        difficult to understand and also fragile, this needs to be reworked.
+        '''
+        region_list = sorted(regions, key=lambda r: r.base)
+        reg0 = region_list[0]
+        bootloader_reserved = 2 ** self.MEGAPAGE_BITS_RV64
+        reg_aligned = reg0.align_base(self.MEGAPAGE_BITS_RV64)
+        if reg_aligned.base != reg0.base:
+            raise ValueError(
+                '{} must be 2 Mibyte aligned'.format(reg0))
+        if reg_aligned.size < bootloader_reserved:
+            raise ValueError(
+                '{} too small, need at lest {} bytes'.format(
+                    reg0, bootloader_reserved))
+        kernel_phys_base = reg_aligned.base
+        reserved_list = {Region(reg_aligned.base, bootloader_reserved)}
+        return reserved_list, kernel_phys_base
 
     def get_device_page_bits(self) -> int:
         ''' Get page size in bits for mapping devices for this arch '''

--- a/tools/hardware/outputs/compat_strings.py
+++ b/tools/hardware/outputs/compat_strings.py
@@ -6,13 +6,11 @@
 
 ''' generate a text file with matched compatible strings from the device tree '''
 import argparse
-from hardware.config import Config
 from hardware.fdt import FdtParser
 from hardware.utils.rule import HardwareYaml
 
 
-def run(tree: FdtParser, hw_yaml: HardwareYaml, config: Config,
-        args: argparse.Namespace):
+def run(tree: FdtParser, hw_yaml: HardwareYaml, args: argparse.Namespace):
     if not args.compat_strings_out:
         raise ValueError('You need to specify a compat-strings-out to use compat strings output')
     chosen = tree.get_kernel_devices()

--- a/tools/hardware/outputs/elfloader.py
+++ b/tools/hardware/outputs/elfloader.py
@@ -140,7 +140,7 @@ def get_elfloader_cpus(tree: fdt.FdtParser, devices: List[device.WrappedNode]) -
     return sorted(cpu_info, key=lambda a: a['cpuid'])
 
 
-def run(tree: fdt.FdtParser, hardware: rule.HardwareYaml, config: config.Config, args: argparse.Namespace):
+def run(tree: fdt.FdtParser, hardware: rule.HardwareYaml, args: argparse.Namespace):
     devices = tree.get_elfloader_devices()
     cpu_info = get_elfloader_cpus(tree, devices)
 

--- a/tools/hardware/outputs/yaml.py
+++ b/tools/hardware/outputs/yaml.py
@@ -10,7 +10,6 @@ import argparse
 import yaml
 from typing import List, Dict
 import hardware
-from hardware.config import Config
 from hardware.fdt import FdtParser
 from hardware.memory import Region
 from hardware.utils.rule import HardwareYaml, KernelInterrupt
@@ -41,7 +40,7 @@ def create_yaml_file(regions_dict: Dict[str, List[Region]], outputStream):
             outputStream)
 
 
-def run(tree: FdtParser, hw_yaml: HardwareYaml, config: Config, args: argparse.Namespace):
+def run(tree: FdtParser, hw_yaml: HardwareYaml, args: argparse.Namespace):
 
     if not args.yaml_out:
         raise ValueError('you need to provide a yaml-out to use the yaml output method')
@@ -49,7 +48,6 @@ def run(tree: FdtParser, hw_yaml: HardwareYaml, config: Config, args: argparse.N
     # Get the physical memory and device regions, we don't care about the kernel
     # phy_base address here.
     phys_mem, dev_mem, _ = hardware.utils.memory.get_phys_mem_regions(tree,
-                                                                      config,
                                                                       hw_yaml)
 
     create_yaml_file(

--- a/tools/hardware/outputs/yaml.py
+++ b/tools/hardware/outputs/yaml.py
@@ -13,7 +13,7 @@ import hardware
 from hardware.config import Config
 from hardware.fdt import FdtParser
 from hardware.memory import Region
-from hardware.utils.rule import HardwareYaml
+from hardware.utils.rule import HardwareYaml, KernelInterrupt
 
 
 def make_yaml_list_of_regions(regions: List[Region]) -> List:
@@ -41,26 +41,16 @@ def create_yaml_file(regions_dict: Dict[str, List[Region]], outputStream):
             outputStream)
 
 
-def get_kernel_devices(tree: FdtParser, hw_yaml: HardwareYaml):
-    kernel_devices = tree.get_kernel_devices()
+def run(tree: FdtParser, hw_yaml: HardwareYaml, config: Config, args: argparse.Namespace):
 
-    groups = []
-    for dev in kernel_devices:
-        rule = hw_yaml.get_rule(dev)
-        groups += rule.get_regions(dev)
-
-    return groups
-
-
-def run(tree: FdtParser, hw_yaml: HardwareYaml, config: Config,
-        args: argparse.Namespace):
     if not args.yaml_out:
         raise ValueError('you need to provide a yaml-out to use the yaml output method')
 
-    phys_mem, reserved, _ = hardware.utils.memory.get_physical_memory(tree, config)
-    kernel_devs = get_kernel_devices(tree, hw_yaml)
-    dev_mem = hardware.utils.memory.get_addrspace_exclude(
-        list(reserved) + phys_mem + kernel_devs, config)
+    # Get the physical memory and device regions, we don't care about the kernel
+    # phy_base address here.
+    phys_mem, dev_mem, _ = hardware.utils.memory.get_phys_mem_regions(tree,
+                                                                      config,
+                                                                      hw_yaml)
 
     create_yaml_file(
         {

--- a/tools/hardware/utils/memory.py
+++ b/tools/hardware/utils/memory.py
@@ -7,7 +7,6 @@
 from typing import List, Set
 
 import hardware
-from hardware.config import Config
 from hardware.device import WrappedNode
 from hardware.fdt import FdtParser
 from hardware.memory import Region
@@ -58,7 +57,7 @@ def carve_out_region(regions: List[Region], reserved_reg: Region) -> Set[Region]
     return ret_regions
 
 
-def get_phys_mem_regions(tree: FdtParser, config: Config, hw_yaml: HardwareYaml) \
+def get_phys_mem_regions(tree: FdtParser, hw_yaml: HardwareYaml) \
         -> (List[Region], List[Region], int):
     '''
     Returns a list of regions representing physical memory as used by the kernel
@@ -93,7 +92,7 @@ def get_phys_mem_regions(tree: FdtParser, config: Config, hw_yaml: HardwareYaml)
     # after we have removed the reserved region from the device tree, because we
     # also get 'kernel_phys_base' here. And once we have that, the memory
     # regions can't the modified any longer.
-    cfg_reserved_regs, kernel_phys_base = config.align_memory(mem_regions)
+    cfg_reserved_regs, kernel_phys_base = hw_yaml.config.align_memory(mem_regions)
     for r in cfg_reserved_regs:
         mem_regions = carve_out_region(mem_regions, r)
     reserved_regions.update(cfg_reserved_regs)
@@ -113,8 +112,8 @@ def get_phys_mem_regions(tree: FdtParser, config: Config, hw_yaml: HardwareYaml)
         Region(
             0,
             hardware.utils.align_down(
-                config.addrspace_max,
-                config.get_smallest_kernel_object_alignment()))
+                hw_yaml.config.addrspace_max,
+                hw_yaml.config.get_smallest_kernel_object_alignment()))
     }
 
     for reg in mem_region_list + reserved_region_list:

--- a/tools/hardware/utils/rule.py
+++ b/tools/hardware/utils/rule.py
@@ -213,10 +213,11 @@ class DeviceRule:
 
 
 class HardwareYaml:
-    ''' Represents the hardware configuration file '''
+    ''' Represents the hardware configuration '''
 
     def __init__(self, yaml: dict, config: Config):
         self.rules = {}
+        self.config = config
         for dev in yaml['devices']:
             rule = DeviceRule(dev, config)
             for compat in dev['compatible']:

--- a/tools/hardware_gen.py
+++ b/tools/hardware_gen.py
@@ -59,7 +59,7 @@ def main(args: argparse.Namespace):
     arg_dict = vars(args)
     for t in sorted(OUTPUTS.keys()):
         if arg_dict[t]:
-            OUTPUTS[t].run(parsed_dt, hw_yaml, cfg, args)
+            OUTPUTS[t].run(parsed_dt, hw_yaml, args)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Changes factored out from 
* https://github.com/seL4/seL4/pull/556
* https://github.com/seL4/seL4/pull/365

Change are code cleanups and comment improvements. Using the type hints for class member function in the class definition requires Python 3.7 at least with the "import form future", it has been added officially in 3.10 then. Can we assume Python 3.7 here?