### PR TITLE
Use asid_map bitfield object on all architectures for ASID table entry

### DIFF
--- a/include/arch/arm/arch/32/mode/fastpath/fastpath.h
+++ b/include/arch/arm/arch/32/mode/fastpath/fastpath.h
@@ -45,12 +45,9 @@ clearExMonitor_fp(void)
     );
 }
 
-static inline void FORCE_INLINE switchToThread_fp(tcb_t *thread, pde_t *cap_pd, pde_t stored_hw_asid)
+static inline void FORCE_INLINE switchToThread_fp(tcb_t *thread, pde_t *cap_pd, asid_t asid)
 {
-    hw_asid_t hw_asid;
-
-    hw_asid = pde_pde_invalid_get_stored_hw_asid(stored_hw_asid);
-    armv_contextSwitch_HWASID(cap_pd, hw_asid);
+    armv_contextSwitch(cap_pd, asid);
     if (config_set(CONFIG_ARM_HYPERVISOR_SUPPORT)) {
         vcpu_switch(thread->tcbArch.tcbVCPU);
     }

--- a/include/arch/arm/arch/32/mode/kernel/vspace.h
+++ b/include/arch/arm/arch/32/mode/kernel/vspace.h
@@ -46,6 +46,7 @@ struct lookupPTSlot_ret {
 };
 typedef struct lookupPTSlot_ret lookupPTSlot_ret_t;
 
+
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
 hw_asid_t getHWASID(asid_t asid);
 #endif
@@ -63,6 +64,7 @@ void flushPage(vm_page_size_t page_size, pde_t *pd, asid_t asid, word_t vptr);
 void flushTable(pde_t *pd, asid_t asid, word_t vptr, pte_t *pt);
 void flushSpace(asid_t asid);
 void invalidateTLBByASID(asid_t asid);
+asid_map_t findMapForASID(asid_t asid);
 
 bool_t CONST isIOSpaceFrameCap(cap_t cap);
 

--- a/include/arch/arm/arch/32/mode/object/structures.bf
+++ b/include/arch/arm/arch/32/mode/object/structures.bf
@@ -21,17 +21,28 @@ base 32
 
 -- 4k frame (these have a separate cap type as there is no room to
 -- store their size)
-block small_frame_cap {
-    field capFMappedASIDLow  10
+block small_frame_cap (
+    capFMappedASIDLow,
+    capFVMRights,
+    capFMappedAddress,
+    capFIsDevice,
+#ifdef CONFIG_ARM_SMMU
+    capFIsIOSpace,
+#endif
+    capFMappedASIDHigh,
+    capFBasePtr,
+    capType
+) {
+    field capFMappedASIDLow  9
     field capFVMRights       2
+    field capFIsDevice       1
     field_high capFMappedAddress 20
 
-    field capFIsDevice       1
 #ifdef CONFIG_ARM_SMMU
     field capFIsIOSpace      1
-    field capFMappedASIDHigh 6
-#else
     field capFMappedASIDHigh 7
+#else
+    field capFMappedASIDHigh 8
 #endif
     field_high capFBasePtr  20
     field capType            4
@@ -40,13 +51,14 @@ block small_frame_cap {
 -- 64k, 1M, 16M frames
 block frame_cap {
     field capFSize           2
-    field capFMappedASIDLow  10
+    field capFMappedASIDLow  9
     field capFVMRights       2
+    padding                  1
     field_high capFMappedAddress 18
 
-    padding                  2
+    padding                  1
     field capFIsDevice       1
-    field capFMappedASIDHigh 7
+    field capFMappedASIDHigh 8
     field_high capFBasePtr  18
     field capType            4
 }
@@ -583,5 +595,24 @@ block dbg_wcr {
     field enabled 1
 }
 #endif /* CONFIG_HARDWARE_DEBUG_API */
+
+block asid_map_none {
+    padding                         32
+
+    padding                         30
+    field type                      2
+}
+
+block asid_map_vspace {
+    field_high vspace_root          32
+
+    padding                         30
+    field type                      2
+}
+
+tagged_union asid_map type {
+    tag asid_map_none 0
+    tag asid_map_vspace 1
+}
 
 #include <sel4/arch/shared_types.bf>

--- a/include/arch/arm/arch/32/mode/object/structures.bf
+++ b/include/arch/arm/arch/32/mode/object/structures.bf
@@ -243,9 +243,7 @@ block stored_hw_asid {
 
 -- Page directory entries
 block pde_invalid {
-    field stored_hw_asid 8
-    field stored_asid_valid 1
-    padding 21
+    padding 30
     field pdeType 2
 }
 
@@ -341,9 +339,7 @@ tagged_union pte pteSize {
 
 block pdeS2_invalid {
     padding 32
-    field stored_hw_asid 8
-    field stored_asid_valid 1
-    padding 21
+    padding 30
     field pdeS2Type 2
 }
 
@@ -606,7 +602,9 @@ block asid_map_none {
 block asid_map_vspace {
     field_high vspace_root          32
 
-    padding                         30
+    padding                         21
+    field hw_asid                   8
+    field hw_asid_valid             1
     field type                      2
 }
 

--- a/include/arch/arm/arch/32/mode/object/structures.h
+++ b/include/arch/arm/arch/32/mode/object/structures.h
@@ -90,7 +90,7 @@ typedef word_t pde_type_t;
 #define LPAE_PT_REF(p) ((unsigned int)p)
 
 struct asid_pool {
-    pde_t *array[BIT(asidLowBits)];
+    asid_map_t array[BIT(asidLowBits)];
 };
 
 typedef struct asid_pool asid_pool_t;

--- a/include/arch/arm/arch/64/mode/fastpath/fastpath.h
+++ b/include/arch/arm/arch/64/mode/fastpath/fastpath.h
@@ -35,10 +35,8 @@ compile_assert(SysReplyRecv_Minus2, SysReplyRecv == -2)
 #define cap_vtable_cap_get_vspace_root_fp(vtable_cap) cap_vtable_root_get_basePtr(vtable_cap)
 
 static inline void FORCE_INLINE
-switchToThread_fp(tcb_t *thread, vspace_root_t *vroot, pde_t stored_hw_asid)
+switchToThread_fp(tcb_t *thread, vspace_root_t *vroot, asid_t asid)
 {
-    asid_t asid = (asid_t)(stored_hw_asid.words[0] & 0xffff);
-
     armv_contextSwitch(vroot, asid);
     if (config_set(CONFIG_ARM_HYPERVISOR_SUPPORT)) {
         vcpu_switch(thread->tcbArch.tcbVCPU);

--- a/include/arch/arm/arch/64/mode/kernel/vspace.h
+++ b/include/arch/arm/arch/64/mode/kernel/vspace.h
@@ -64,7 +64,7 @@ static inline exception_t performASIDPoolInvocation(asid_t asid, asid_pool_t *po
     asid_map_t asid_map;
     cap_page_upper_directory_cap_ptr_set_capPUDMappedASID(&cte->cap, asid);
     cap_page_upper_directory_cap_ptr_set_capPUDIsMapped(&cte->cap, 1);
-    asid_map = asid_map_asid_map_vspace_new(cap_page_upper_directory_cap_get_capPUDBasePtr(cte->cap));
+    asid_map = asid_map_asid_map_vspace_new(cap_page_upper_directory_cap_get_capPUDBasePtr(cte->cap), 0, false);
     poolPtr->array[asid & MASK(asidLowBits)] = asid_map;
 
     return EXCEPTION_NONE;
@@ -90,7 +90,7 @@ static inline exception_t performASIDPoolInvocation(asid_t asid, asid_pool_t *po
     asid_map_t asid_map;
     cap_page_global_directory_cap_ptr_set_capPGDMappedASID(&cte->cap, asid);
     cap_page_global_directory_cap_ptr_set_capPGDIsMapped(&cte->cap, 1);
-    asid_map = asid_map_asid_map_vspace_new(cap_page_global_directory_cap_get_capPGDBasePtr(cte->cap));
+    asid_map = asid_map_asid_map_vspace_new(cap_page_global_directory_cap_get_capPGDBasePtr(cte->cap), 0, false);
     poolPtr->array[asid & MASK(asidLowBits)] = asid_map;
 
     return EXCEPTION_NONE;

--- a/include/arch/arm/arch/64/mode/kernel/vspace.h
+++ b/include/arch/arm/arch/64/mode/kernel/vspace.h
@@ -40,6 +40,8 @@ void deleteASID(asid_t asid, vspace_root_t *vspace);
 hw_asid_t getHWASID(asid_t asid);
 #endif
 
+asid_map_t findMapForASID(asid_t asid);
+
 static const region_t BOOT_RODATA *mode_reserved_region = NULL;
 
 #ifdef AARCH64_VSPACE_S2_START_L1
@@ -59,10 +61,11 @@ static const region_t BOOT_RODATA *mode_reserved_region = NULL;
 
 static inline exception_t performASIDPoolInvocation(asid_t asid, asid_pool_t *poolPtr, cte_t *cte)
 {
+    asid_map_t asid_map;
     cap_page_upper_directory_cap_ptr_set_capPUDMappedASID(&cte->cap, asid);
     cap_page_upper_directory_cap_ptr_set_capPUDIsMapped(&cte->cap, 1);
-    poolPtr->array[asid & MASK(asidLowBits)] =
-        PUDE_PTR(cap_page_upper_directory_cap_get_capPUDBasePtr(cte->cap));
+    asid_map = asid_map_asid_map_vspace_new(cap_page_upper_directory_cap_get_capPUDBasePtr(cte->cap));
+    poolPtr->array[asid & MASK(asidLowBits)] = asid_map;
 
     return EXCEPTION_NONE;
 }
@@ -84,10 +87,11 @@ static inline exception_t performASIDPoolInvocation(asid_t asid, asid_pool_t *po
 
 static inline exception_t performASIDPoolInvocation(asid_t asid, asid_pool_t *poolPtr, cte_t *cte)
 {
+    asid_map_t asid_map;
     cap_page_global_directory_cap_ptr_set_capPGDMappedASID(&cte->cap, asid);
     cap_page_global_directory_cap_ptr_set_capPGDIsMapped(&cte->cap, 1);
-    poolPtr->array[asid & MASK(asidLowBits)] =
-        PGDE_PTR(cap_page_global_directory_cap_get_capPGDBasePtr(cte->cap));
+    asid_map = asid_map_asid_map_vspace_new(cap_page_global_directory_cap_get_capPGDBasePtr(cte->cap));
+    poolPtr->array[asid & MASK(asidLowBits)] = asid_map;
 
     return EXCEPTION_NONE;
 }

--- a/include/arch/arm/arch/64/mode/object/structures.bf
+++ b/include/arch/arm/arch/64/mode/object/structures.bf
@@ -190,7 +190,9 @@ block asid_map_none {
 
 block asid_map_vspace {
     field_high vspace_root          48
-    padding                         14
+    padding                         5
+    field hw_asid                   8
+    field hw_asid_valid             1
     field type                      2
 }
 
@@ -202,11 +204,8 @@ tagged_union asid_map type {
 -- PGDE, PUDE, PDEs and PTEs, assuming 48-bit physical address
 base 64(48,0)
 
--- hw_asids are required in hyp mode
 block pgde_invalid {
-    field stored_hw_asid            8
-    field stored_asid_valid         1
-    padding                         53
+    padding                         62
     field pgde_type                 2
 }
 
@@ -223,9 +222,7 @@ tagged_union pgde pgde_type {
 }
 
 block pude_invalid {
-    field stored_hw_asid            8
-    field stored_asid_valid         1
-    padding                         53
+    padding                         62
     field pude_type                 2
 }
 

--- a/include/arch/arm/arch/64/mode/object/structures.bf
+++ b/include/arch/arm/arch/64/mode/object/structures.bf
@@ -183,6 +183,22 @@ block vm_attributes {
 
 ---- ARM-specific object types
 
+block asid_map_none {
+    padding                         62
+    field type                      2
+}
+
+block asid_map_vspace {
+    field_high vspace_root          48
+    padding                         14
+    field type                      2
+}
+
+tagged_union asid_map type {
+    tag asid_map_none 0
+    tag asid_map_vspace 1
+}
+
 -- PGDE, PUDE, PDEs and PTEs, assuming 48-bit physical address
 base 64(48,0)
 

--- a/include/arch/arm/arch/64/mode/object/structures.h
+++ b/include/arch/arm/arch/64/mode/object/structures.h
@@ -110,7 +110,7 @@ typedef pgde_t vspace_root_t;
 #define VCPU_REF(p)       ((word_t)(p))
 
 struct asid_pool {
-    vspace_root_t *array[BIT(asidLowBits)];
+    asid_map_t array[BIT(asidLowBits)];
 };
 typedef struct asid_pool asid_pool_t;
 

--- a/include/arch/riscv/arch/32/mode/object/structures.bf
+++ b/include/arch/riscv/arch/32/mode/object/structures.bf
@@ -140,4 +140,24 @@ block satp {
     field asid          9
     field ppn           22
 }
+
+block asid_map_none {
+    padding                         32
+
+    padding                         30
+    field type                      2
+}
+
+block asid_map_vspace {
+    field_high vspace_root          32
+
+    padding                         30
+    field type                      2
+}
+
+tagged_union asid_map type {
+    tag asid_map_none 0
+    tag asid_map_vspace 1
+}
+
 #include <sel4/arch/shared_types.bf>

--- a/include/arch/riscv/arch/32/mode/object/structures.bf
+++ b/include/arch/riscv/arch/32/mode/object/structures.bf
@@ -26,9 +26,8 @@ base 32
 
 -- frames
 block frame_cap {
-    field       capFMappedASID      9
+    field       capFMappedASID      12
     field_high  capFBasePtr         20
-    padding                         3
 
     padding                         2
     field       capFSize            2
@@ -40,9 +39,8 @@ block frame_cap {
 
 -- N-level page table
 block page_table_cap {
-    field       capPTMappedASID     9
+    field       capPTMappedASID     12
     field_high  capPTBasePtr        20
-    padding                         3
 
     padding                         7
     field       capPTIsMapped       1

--- a/include/arch/riscv/arch/64/mode/object/structures.bf
+++ b/include/arch/riscv/arch/64/mode/object/structures.bf
@@ -155,4 +155,20 @@ block satp {
     field ppn           44
 }
 
+block asid_map_none {
+    padding                         62
+    field type                      2
+}
+
+block asid_map_vspace {
+    field_high vspace_root          39
+    padding                         23
+    field type                      2
+}
+
+tagged_union asid_map type {
+    tag asid_map_none 0
+    tag asid_map_vspace 1
+}
+
 #include <sel4/arch/shared_types.bf>

--- a/include/arch/riscv/arch/fastpath/fastpath.h
+++ b/include/arch/riscv/arch/fastpath/fastpath.h
@@ -45,10 +45,8 @@ NORETURN;
 #define endpoint_ptr_get_epQueue_tail_fp(ep_ptr) TCB_PTR(endpoint_ptr_get_epQueue_tail(ep_ptr))
 #define cap_vtable_cap_get_vspace_root_fp(vtable_cap) PTE_PTR(cap_page_table_cap_get_capPTBasePtr(vtable_cap))
 
-static inline void FORCE_INLINE switchToThread_fp(tcb_t *thread, pte_t *vroot, pte_t stored_hw_asid)
+static inline void FORCE_INLINE switchToThread_fp(tcb_t *thread, pte_t *vroot, asid_t asid)
 {
-    asid_t asid = (asid_t)(stored_hw_asid.words[0]);
-
     setVSpaceRoot(addrFromPPtr(vroot), asid);
 
     NODE_STATE(ksCurThread) = thread;

--- a/include/arch/riscv/arch/kernel/vspace.h
+++ b/include/arch/riscv/arch/kernel/vspace.h
@@ -51,6 +51,8 @@ struct findVSpaceForASID_ret {
 };
 typedef struct findVSpaceForASID_ret findVSpaceForASID_ret_t;
 
+asid_map_t findMapForASID(asid_t asid);
+
 void copyGlobalMappings(pte_t *newlvl1pt);
 word_t *PURE lookupIPCBuffer(bool_t isReceiver, tcb_t *thread);
 lookupPTSlot_ret_t lookupPTSlot(pte_t *lvl1pt, vptr_t vptr);

--- a/include/arch/riscv/arch/object/structures.h
+++ b/include/arch/riscv/arch/object/structures.h
@@ -33,7 +33,7 @@
 #define tcbArchCNodeEntries tcbCNodeEntries
 
 struct asid_pool {
-    pte_t *array[BIT(asidLowBits)];
+    asid_map_t array[BIT(asidLowBits)];
 };
 
 typedef struct asid_pool asid_pool_t;

--- a/include/arch/x86/arch/32/mode/fastpath/fastpath.h
+++ b/include/arch/x86/arch/32/mode/fastpath/fastpath.h
@@ -30,7 +30,7 @@ static inline vspace_root_t *cap_vtable_cap_get_vspace_root_fp(cap_t vtable_cap)
     return PDE_PTR(cap_page_directory_cap_get_capPDBasePtr(vtable_cap));
 }
 
-static inline void FORCE_INLINE switchToThread_fp(tcb_t *thread, vspace_root_t *pd, pde_t stored_hw_asid)
+static inline void FORCE_INLINE switchToThread_fp(tcb_t *thread, vspace_root_t *pd, asid_t asid)
 {
     uint32_t new_pd = pptr_to_paddr(pd);
 

--- a/include/arch/x86/arch/32/mode/object/structures.bf
+++ b/include/arch/x86/arch/32/mode/object/structures.bf
@@ -21,15 +21,14 @@ base 32
 ---- IA32-specific cap types
 
 block frame_cap {
-    padding                         1
+    padding                         2
     field       capFSize            1
-    field       capFMappedASIDLow   10
+    field       capFMappedASIDLow   9
     field_high  capFMappedAddress   20
 
-    padding                         1
     field       capFMapType         2
     field       capFIsDevice        1
-    field       capFMappedASIDHigh  2
+    field       capFMappedASIDHigh  3
     field       capFVMRights        2
     field_high  capFBasePtr         20
     field       capType             4
@@ -540,20 +539,24 @@ block vmx_eptp {
 #endif
 
 block asid_map_none {
+    padding                         32
+
     padding                         30
     field type                      2
 }
 
 block asid_map_vspace {
-    field_high vspace_root          20
-    padding                         10
+    field_high vspace_root          32
+
+    padding                         30
     field type                      2
 }
 
 #ifdef CONFIG_VTX
 block asid_map_ept {
-    field_high ept_root             20
-    padding                         10
+    field_high ept_root             32
+
+    padding                         30
     field type                      2
 }
 #endif

--- a/include/arch/x86/arch/64/mode/fastpath/fastpath.h
+++ b/include/arch/x86/arch/64/mode/fastpath/fastpath.h
@@ -41,11 +41,9 @@ static inline word_t cap_pml4_cap_get_capPML4MappedASID_fp(cap_t vtable_cap)
     return (uint32_t)vtable_cap.words[0];
 }
 
-static inline void FORCE_INLINE switchToThread_fp(tcb_t *thread, vspace_root_t *vroot, pde_t stored_hw_asid)
+static inline void FORCE_INLINE switchToThread_fp(tcb_t *thread, vspace_root_t *vroot, asid_t asid)
 {
     word_t new_vroot = pptr_to_paddr(vroot);
-    /* the asid is the 12-bit PCID */
-    asid_t asid = (asid_t)(stored_hw_asid.words[0] & 0xfff);
     cr3_t next_cr3 = makeCR3(new_vroot, asid);
     if (likely(getCurrentUserCR3().words[0] != next_cr3.words[0])) {
         SMP_COND_STATEMENT(tlb_bitmap_set(vroot, getCurrentCPUIndex());)

--- a/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/constants.h
@@ -216,14 +216,15 @@ enum {
 #define seL4_VSpaceBits seL4_PageDirBits
 
 #ifdef CONFIG_ARM_SMMU
-#define seL4_NumASIDPoolsBits 6
-#else
 #define seL4_NumASIDPoolsBits 7
+#else
+#define seL4_NumASIDPoolsBits 8
 #endif
 #define seL4_ASIDPoolBits 12
-#define seL4_ASIDPoolIndexBits 10
+#define seL4_ASIDPoolIndexBits 9
 #define seL4_ARM_VCPUBits       12
 #define seL4_IOPageTableBits    12
+#define seL4_ASIDMapSizeBits 3
 
 /* bits in a word */
 #define seL4_WordBits (sizeof(seL4_Word) * 8)
@@ -233,7 +234,7 @@ enum {
 #ifndef __ASSEMBLER__
 SEL4_SIZE_SANITY(seL4_PageTableEntryBits, seL4_PageTableIndexBits, seL4_PageTableBits);
 SEL4_SIZE_SANITY(seL4_PageDirEntryBits,   seL4_PageDirIndexBits,   seL4_PageDirBits);
-SEL4_SIZE_SANITY(seL4_WordSizeBits, seL4_ASIDPoolIndexBits, seL4_ASIDPoolBits);
+SEL4_SIZE_SANITY(seL4_ASIDMapSizeBits, seL4_ASIDPoolIndexBits, seL4_ASIDPoolBits);
 #ifdef seL4_PGDBits
 SEL4_SIZE_SANITY(seL4_PGDEntryBits, seL4_PGDIndexBits, seL4_PGDBits);
 #endif

--- a/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/constants.h
@@ -47,9 +47,10 @@
 #define seL4_VSpaceBits seL4_PageDirBits
 
 #define seL4_IOPageTableBits 12
-#define seL4_NumASIDPoolsBits 2
+#define seL4_NumASIDPoolsBits 3
 #define seL4_ASIDPoolBits    12
-#define seL4_ASIDPoolIndexBits 10
+#define seL4_ASIDPoolEntryBits 3
+#define seL4_ASIDPoolIndexBits 9
 #define seL4_WordSizeBits 2
 
 #define seL4_HugePageBits    30 /* 1GB */
@@ -59,7 +60,7 @@
 #ifndef __ASSEMBLER__
 SEL4_SIZE_SANITY(seL4_PageTableEntryBits, seL4_PageTableIndexBits, seL4_PageTableBits);
 SEL4_SIZE_SANITY(seL4_PageDirEntryBits, seL4_PageDirIndexBits, seL4_PageDirBits);
-SEL4_SIZE_SANITY(seL4_WordSizeBits, seL4_ASIDPoolIndexBits, seL4_ASIDPoolBits);
+SEL4_SIZE_SANITY(seL4_ASIDPoolEntryBits, seL4_ASIDPoolIndexBits, seL4_ASIDPoolBits);
 #endif
 
 /* Previously large frames were explicitly assumed to be 4M. If not using

--- a/libsel4/sel4_arch_include/riscv32/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/riscv32/sel4/sel4_arch/constants.h
@@ -52,8 +52,8 @@
 #define seL4_PageTableBits      12
 #define seL4_VSpaceBits         seL4_PageTableBits
 
-#define seL4_NumASIDPoolsBits    5
-#define seL4_ASIDPoolIndexBits  4
+#define seL4_NumASIDPoolsBits    3
+#define seL4_ASIDPoolIndexBits   9
 #define seL4_ASIDPoolBits       12
 #ifndef __ASSEMBLER__
 

--- a/src/arch/arm/64/kernel/vspace.c
+++ b/src/arch/arm/64/kernel/vspace.c
@@ -558,20 +558,32 @@ BOOT_CODE void activate_kernel_vspace(void)
 BOOT_CODE void write_it_asid_pool(cap_t it_ap_cap, cap_t it_vspace_cap)
 {
     asid_pool_t *ap = ASID_POOL_PTR(pptr_of_cap(it_ap_cap));
-    ap->array[IT_ASID] = (void *)(pptr_of_cap(it_vspace_cap));
+    asid_map_t asid_map = asid_map_asid_map_vspace_new(pptr_of_cap(it_vspace_cap));
+    ap->array[IT_ASID] = asid_map;
     armKSASIDTable[IT_ASID >> asidLowBits] = ap;
 }
 
 /* ==================== BOOT CODE FINISHES HERE ==================== */
 
-static findVSpaceForASID_ret_t findVSpaceForASID(asid_t asid)
+asid_map_t findMapForASID(asid_t asid)
 {
-    findVSpaceForASID_ret_t ret;
-    asid_pool_t *poolPtr;
-    vspace_root_t *vspace_root;
+    asid_pool_t        *poolPtr;
 
     poolPtr = armKSASIDTable[asid >> asidLowBits];
     if (!poolPtr) {
+        return asid_map_asid_map_none_new();
+    }
+
+    return poolPtr->array[asid & MASK(asidLowBits)];
+}
+
+static findVSpaceForASID_ret_t findVSpaceForASID(asid_t asid)
+{
+    findVSpaceForASID_ret_t ret;
+    asid_map_t asid_map;
+
+    asid_map = findMapForASID(asid);
+    if (asid_map_get_type(asid_map) != asid_map_asid_map_vspace) {
         current_lookup_fault = lookup_fault_invalid_root_new();
 
         ret.vspace_root = NULL;
@@ -579,16 +591,7 @@ static findVSpaceForASID_ret_t findVSpaceForASID(asid_t asid)
         return ret;
     }
 
-    vspace_root = poolPtr->array[asid & MASK(asidLowBits)];
-    if (!vspace_root) {
-        current_lookup_fault = lookup_fault_invalid_root_new();
-
-        ret.vspace_root = NULL;
-        ret.status = EXCEPTION_LOOKUP_FAULT;
-        return ret;
-    }
-
-    ret.vspace_root = vspace_root;
+    ret.vspace_root = (vspace_root_t *)asid_map_asid_map_vspace_get_vspace_root(asid_map);
     ret.status = EXCEPTION_NONE;
     return ret;
 }
@@ -1084,8 +1087,10 @@ static void invalidateASID(asid_t asid)
     asidPool = armKSASIDTable[asid >> asidLowBits];
     assert(asidPool);
 
-    vspace_root_t *vtable = asidPool->array[asid & MASK(asidLowBits)];
-    assert(vtable);
+    asid_map_t asid_map = asidPool->array[asid & MASK(asidLowBits)];
+    assert(asid_map_get_type(asid_map) == asid_map_asid_map_vspace);
+
+    vspace_root_t *vtable = (vspace_root_t *)asid_map_asid_map_vspace_get_vspace_root(asid_map);
 
     vtable[VTABLE_VMID_SLOT] = vtable_invalid_new(0, false);
 }
@@ -1097,8 +1102,10 @@ static vspace_root_t PURE loadHWASID(asid_t asid)
     asidPool = armKSASIDTable[asid >> asidLowBits];
     assert(asidPool);
 
-    vspace_root_t *vtable = asidPool->array[asid & MASK(asidLowBits)];
-    assert(vtable);
+    asid_map_t asid_map = asidPool->array[asid & MASK(asidLowBits)];
+    assert(asid_map_get_type(asid_map) == asid_map_asid_map_vspace);
+
+    vspace_root_t *vtable = (vspace_root_t *)asid_map_asid_map_vspace_get_vspace_root(asid_map);
 
     return vtable[VTABLE_VMID_SLOT];
 }
@@ -1110,8 +1117,10 @@ static void storeHWASID(asid_t asid, hw_asid_t hw_asid)
     asidPool = armKSASIDTable[asid >> asidLowBits];
     assert(asidPool);
 
-    vspace_root_t *vtable = asidPool->array[asid & MASK(asidLowBits)];
-    assert(vtable);
+    asid_map_t asid_map = asidPool->array[asid & MASK(asidLowBits)];
+    assert(asid_map_get_type(asid_map) == asid_map_asid_map_vspace);
+
+    vspace_root_t *vtable = (vspace_root_t *)asid_map_asid_map_vspace_get_vspace_root(asid_map);
 
     /* Store HW VMID in the last entry
        Masquerade as an invalid PDGE */
@@ -1350,13 +1359,17 @@ void deleteASID(asid_t asid, vspace_root_t *vspace)
 
     poolPtr = armKSASIDTable[asid >> asidLowBits];
 
-    if (poolPtr != NULL && poolPtr->array[asid & MASK(asidLowBits)] == vspace) {
-        invalidateTLBByASID(asid);
+    if (poolPtr != NULL) {
+        asid_map_t asid_map = poolPtr->array[asid & MASK(asidLowBits)];
+        if (asid_map_get_type(asid_map) == asid_map_asid_map_vspace &&
+            (vspace_root_t *)asid_map_asid_map_vspace_get_vspace_root(asid_map) == vspace) {
+            invalidateTLBByASID(asid);
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
-        invalidateASIDEntry(asid);
+            invalidateASIDEntry(asid);
 #endif
-        poolPtr->array[asid & MASK(asidLowBits)] = NULL;
-        setVMRoot(NODE_STATE(ksCurThread));
+            poolPtr->array[asid & MASK(asidLowBits)] = asid_map_asid_map_none_new();
+            setVMRoot(NODE_STATE(ksCurThread));
+        }
     }
 }
 
@@ -1368,7 +1381,8 @@ void deleteASIDPool(asid_t asid_base, asid_pool_t *pool)
 
     if (armKSASIDTable[asid_base >> asidLowBits] == pool) {
         for (offset = 0; offset < BIT(asidLowBits); offset++) {
-            if (pool->array[offset]) {
+            asid_map_t asid_map = pool->array[offset];
+            if (asid_map_get_type(asid_map) == asid_map_asid_map_vspace) {
                 invalidateTLBByASID(asid_base + offset);
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
                 invalidateASIDEntry(asid_base + offset);
@@ -2351,7 +2365,8 @@ exception_t decodeARMMMUInvocation(word_t invLabel, word_t length, cptr_t cptr,
 
         /* Find first free ASID */
         asid = cap_asid_pool_cap_get_capASIDBase(cap);
-        for (i = 0; i < (1 << asidLowBits) && (asid + i == 0 || pool->array[i]); i++);
+        for (i = 0; i < (1 << asidLowBits) && (asid + i == 0
+                                               || (asid_map_get_type(pool->array[i]) != asid_map_asid_map_none)); i++);
 
         if (unlikely(i == 1 << asidLowBits)) {
             current_syscall_error.type = seL4_DeleteFirst;

--- a/src/fastpath/fastpath.c
+++ b/src/fastpath/fastpath.c
@@ -120,7 +120,8 @@ fastpath_call(word_t cptr, word_t msgInfo)
     }
 
 #ifdef CONFIG_ARCH_AARCH32
-    if (unlikely(!pde_pde_invalid_get_stored_asid_valid(cap_pd[PD_ASID_SLOT]))) {
+    asid_map_t asid_map = findMapForASID(asid);
+    if (unlikely(!asid_map_asid_map_vspace_get_hw_asid_valid(asid_map))) {
         slowpath(SysCall);
     }
 #endif
@@ -354,7 +355,8 @@ void fastpath_reply_recv(word_t cptr, word_t msgInfo)
 
 #ifdef CONFIG_ARCH_AARCH32
     /* Ensure the HWASID is valid. */
-    if (unlikely(!pde_pde_invalid_get_stored_asid_valid(cap_pd[PD_ASID_SLOT]))) {
+    asid_map_t asid_map = findMapForASID(asid);
+    if (unlikely(!asid_map_asid_map_vspace_get_hw_asid_valid(asid_map))) {
         slowpath(SysReplyRecv);
     }
 #endif


### PR DESCRIPTION
When the ASID table entry only contains a reference to the vspace root object, it's not possible to add any attributes to the relationship.  Some of these attributes, such as a hardware_asid, end up getting stored in slots in the vspace root object itself which can have flow on limitations.  In the future, it is anticipated that more attributes will be needed to implement KernelImage mechanisms, and this is also in preparation for that.

EDIT: This PR is currently in a draft status because verification and performance impacts still need to be assessed.