### PR TITLE
Tidy up some untyped creation edge cases in boot code.

### DIFF
--- a/src/arch/arm/kernel/boot.c
+++ b/src/arch/arm/kernel/boot.c
@@ -93,13 +93,18 @@ BOOT_CODE static bool_t arch_init_freemem(p_region_t ui_p_reg,
             reserved[index] = ui_reg;
             index++;
         }
-    } else if (MODE_RESERVED == 1) {
-        if (index >= ARRAY_SIZE(reserved)) {
-            printf("ERROR: no slot to add the mode-reserved region\n");
-            return false;
+    } else {
+        if (MODE_RESERVED == 1) {
+            if (index >= ARRAY_SIZE(reserved)) {
+                printf("ERROR: no slot to add the mode-reserved region\n");
+                return false;
+            }
+            reserved[index] = mode_reserved_region[0];
+            index++;
         }
-        reserved[index] = mode_reserved_region[0];
-        index++;
+
+        /* Reserve the ui_p_reg region still so it doesn't get turned into device UT. */
+        reserve_region(ui_p_reg);
     }
 
     /* avail_p_regs comes from the auto-generated code */

--- a/src/arch/x86/kernel/boot.c
+++ b/src/arch/x86/kernel/boot.c
@@ -72,7 +72,10 @@ BOOT_CODE static bool_t arch_init_freemem(p_region_t ui_p_reg,
                                           mem_p_regs_t *mem_p_regs,
                                           word_t extra_bi_size_bits)
 {
-    ui_p_reg.start = 0;
+    // Extend the reserved region down to include the base of the kernel image.
+    // KERNEL_ELF_PADDR_BASE is the lowest physical load address used
+    // in the x86 linker script.
+    ui_p_reg.start = KERNEL_ELF_PADDR_BASE;
     reserved[0] = paddr_to_pptr_reg(ui_p_reg);
     return init_freemem(mem_p_regs->count, mem_p_regs->list, MAX_RESERVED,
                         reserved, it_v_reg, extra_bi_size_bits);

--- a/src/arch/x86/kernel/boot_sys.c
+++ b/src/arch/x86/kernel/boot_sys.c
@@ -213,7 +213,7 @@ static BOOT_CODE bool_t add_mem_p_regs(p_region_t reg)
     printf("Adding physical memory region 0x%lx-0x%lx\n", reg.start, reg.end);
     boot_state.mem_p_regs.list[boot_state.mem_p_regs.count] = reg;
     boot_state.mem_p_regs.count++;
-    return reserve_region(reg);
+    return true;
 }
 
 /*

--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -655,13 +655,7 @@ BOOT_CODE bool_t create_untypeds(cap_t root_cnode_cap,
         region_t reg = paddr_to_pptr_reg((p_region_t) {
             start, CONFIG_PADDR_USER_DEVICE_TOP
         });
-        /*
-         * The auto-generated bitfield code will get upset if the
-         * end pptr is larger than the maximum pointer size for this architecture.
-         */
-        if (reg.end > PPTR_TOP) {
-            reg.end = PPTR_TOP;
-        }
+
         if (!create_untypeds_for_region(root_cnode_cap, true, reg, first_untyped_slot)) {
             return false;
         }

--- a/tools/hardware/config.py
+++ b/tools/hardware/config.py
@@ -27,6 +27,9 @@ class Config:
         ''' Get page size in bits for this arch '''
         return 12  # 4096-byte pages
 
+    def get_smallest_kernel_object_alignment(self) -> int:
+        return 4  # seL4_MinUntypedBits is 4 for all configurations
+
     def get_device_page_bits(self) -> int:
         ''' Get page size in bits for mapping devices for this arch '''
         return self.get_page_bits()

--- a/tools/hardware/utils/memory.py
+++ b/tools/hardware/utils/memory.py
@@ -97,7 +97,9 @@ def get_physical_memory(tree: FdtParser, config: Config) -> List[Region]:
 def get_addrspace_exclude(regions: List[Region], config: Config):
     ''' Returns a list of regions that represents the inverse of the given region list. '''
     ret = set()
-    as_max = utils.align_down(config.addrspace_max, config.get_page_bits())
+    # We can't create untypeds that exceed the addrspace_max, so we round down to the smallest
+    # untyped size alignment so that the kernel will be able to turn the entire range into untypeds.
+    as_max = utils.align_down(config.addrspace_max, config.get_smallest_kernel_object_alignment())
     ret.add(Region(0, as_max, None))
 
     for reg in regions:


### PR DESCRIPTION
- On x86 there was some device UT being created for a region that was intended to be reserved because of an incorrect extra call to `reserve_region()`
- On aarch32 if the user image was loaded into a region outside of the kernel memory window, then the kernel would create device untypeds as well as frame objects for the same memory.
- The last page of memory in the kernel window was being rounded off and not given to user level. It's possible to give smaller UT instead though. (It may even be possible to just allow the last page to be given anyway, but that could be a future change).
- A PPTR_TOP restriction in create_untypeds doesn't make sense as the bitfield code would only error if the address was non-canonical which wouldn't be a valid region and have been excluded before hand already.