### PR TITLE
Change QEMU version check to FATAL_ERROR

### DIFF
--- a/src/plat/qemu-arm-virt/config.cmake
+++ b/src/plat/qemu-arm-virt/config.cmake
@@ -50,7 +50,7 @@ if(KernelPlatformQEMUArmVirt)
             ${QEMU_VERSION_STR}
     )
     if("${QEMU_VERSION}" VERSION_LESS "${MIN_QEMU_VERSION}")
-        message(WARNING "Warning: qemu version should be at least ${MIN_QEMU_VERSION}")
+        message(FATAL_ERROR "Error: qemu version must be at least ${MIN_QEMU_VERSION}")
     endif()
 
     if("${QEMU_MEMORY}" STREQUAL "")


### PR DESCRIPTION
Low version QEMU dump dts not have intc location information
and make subsequent generate dtb failed.

Error information:
Reference to non-existent node or label "/intc@8000000"

So when the QEMU version does not meet the requirements there
should be FATAL_ERROR to notice user early and immediately exit

Signed-off-by: Qiao Yongchang <qiaoyongchang@gmail.com>