### PR TITLE
unify libsel4 type definitions

### DIFF
--- a/include/arch/arm/arch/types.h
+++ b/include/arch/arm/arch/types.h
@@ -30,16 +30,6 @@ enum hwASIDConstants {
     hwASIDBits = 8
 };
 
-/* for libsel4 headers that the kernel shares */
-typedef word_t seL4_Word;
-typedef cptr_t seL4_CPtr;
-typedef uint32_t seL4_Uint32;
-typedef uint16_t seL4_Uint16;
-typedef uint8_t seL4_Uint8;
-typedef node_id_t seL4_NodeId;
-typedef dom_t seL4_Domain;
-typedef paddr_t seL4_PAddr;
-
 typedef struct kernel_frame {
     paddr_t paddr;
     pptr_t pptr;

--- a/include/arch/riscv/arch/types.h
+++ b/include/arch/riscv/arch/types.h
@@ -26,15 +26,6 @@ typedef word_t cpu_id_t;
 typedef word_t node_id_t;
 typedef word_t dom_t;
 
-/* for libsel4 headers that the kernel shares */
-typedef word_t seL4_Word;
-typedef cptr_t seL4_CPtr;
-typedef uint32_t seL4_Uint32;
-typedef uint8_t seL4_Uint8;
-typedef node_id_t seL4_NodeId;
-typedef paddr_t seL4_PAddr;
-typedef dom_t seL4_Domain;
-
 typedef uint64_t timestamp_t;
 
 #define wordBits BIT(wordRadix)

--- a/include/arch/x86/arch/types.h
+++ b/include/arch/x86/arch/types.h
@@ -25,14 +25,4 @@ typedef uint32_t logical_id_t;
 typedef word_t node_id_t;
 typedef word_t dom_t;
 
-/* for libsel4 headers that the kernel shares */
-typedef word_t seL4_Word;
-typedef cptr_t seL4_CPtr;
-typedef uint16_t seL4_Uint16;
-typedef uint32_t seL4_Uint32;
-typedef uint8_t seL4_Uint8;
-typedef node_id_t seL4_NodeId;
-typedef paddr_t seL4_PAddr;
-typedef dom_t seL4_Domain;
-
 typedef uint64_t timestamp_t;

--- a/include/basic_types.h
+++ b/include/basic_types.h
@@ -67,3 +67,13 @@ typedef struct v_region {
 /* equivalent to a word_t except that we tell the compiler that we may alias with
  * any other type (similar to a char pointer) */
 typedef word_t __attribute__((__may_alias__)) word_t_may_alias;
+
+/* for libsel4 headers that the kernel shares */
+typedef uint8_t seL4_Uint8;
+typedef uint16_t seL4_Uint16;
+typedef uint32_t seL4_Uint32;
+typedef word_t seL4_Word;
+typedef cptr_t seL4_CPtr;
+typedef node_id_t seL4_NodeId;
+typedef paddr_t seL4_PAddr;
+typedef dom_t seL4_Domain;


### PR DESCRIPTION
Seems these definition are all based on generic types, so they could be move one level up and get unified across architectures then.