### PR TITLE
move type checks to mode/types.h

### DIFF
--- a/include/arch/arm/arch/32/mode/types.h
+++ b/include/arch/arm/arch/32/mode/types.h
@@ -6,6 +6,10 @@
 
 #pragma once
 
+#include <assert.h>
+
+compile_assert(long_is_32bits, sizeof(unsigned long) == 4)
+
 #define wordRadix 5
 #define wordBits (1 << wordRadix)
 

--- a/include/arch/arm/arch/64/mode/types.h
+++ b/include/arch/arm/arch/64/mode/types.h
@@ -6,6 +6,10 @@
 
 #pragma once
 
+#include <assert.h>
+
+compile_assert(long_is_64bits, sizeof(unsigned long) == 8)
+
 #define wordRadix 6
 #define wordBits (1 << wordRadix)
 

--- a/include/arch/arm/arch/types.h
+++ b/include/arch/arm/arch/types.h
@@ -7,14 +7,8 @@
 #pragma once
 
 #include <config.h>
-#include <assert.h>
+#include <mode/types.h>
 #include <stdint.h>
-
-#if defined(CONFIG_ARCH_AARCH32)
-compile_assert(long_is_32bits, sizeof(unsigned long) == 4)
-#elif defined(CONFIG_ARCH_AARCH64)
-compile_assert(long_is_64bits, sizeof(unsigned long) == 8)
-#endif
 
 typedef unsigned long word_t;
 typedef signed long sword_t;

--- a/include/arch/x86/arch/32/mode/types.h
+++ b/include/arch/x86/arch/32/mode/types.h
@@ -6,5 +6,9 @@
 
 #pragma once
 
+#include <assert.h>
+
+compile_assert(long_is_32bits, sizeof(unsigned long) == 4)
+
 #define wordRadix 5
 #define wordBits (1 << wordRadix)

--- a/include/arch/x86/arch/64/mode/types.h
+++ b/include/arch/x86/arch/64/mode/types.h
@@ -6,5 +6,9 @@
 
 #pragma once
 
+#include <assert.h>
+
+compile_assert(long_is_64bits, sizeof(unsigned long) == 8)
+
 #define wordRadix 6
 #define wordBits (1 << wordRadix)

--- a/include/arch/x86/arch/types.h
+++ b/include/arch/x86/arch/types.h
@@ -7,14 +7,8 @@
 #pragma once
 
 #include <config.h>
-#include <assert.h>
+#include <mode/types.h>
 #include <stdint.h>
-
-#if defined(CONFIG_ARCH_IA32)
-compile_assert(long_is_32bits, sizeof(unsigned long) == 4)
-#elif defined(CONFIG_ARCH_X86_64)
-compile_assert(long_is_64bits, sizeof(unsigned long) == 8)
-#endif
 
 typedef unsigned long word_t;
 typedef signed long sword_t;


### PR DESCRIPTION
Moving the type checks avoid the need for conditional compilation. This also allows simplifying some include file dependencies.