### PR TITLE
boot: remove unnecessary cast

### DIFF
--- a/src/arch/riscv/kernel/boot.c
+++ b/src/arch/riscv/kernel/boot.c
@@ -207,8 +207,8 @@ static BOOT_CODE bool_t try_init_kernel(
 
     /* convert from physical addresses to userland vptrs */
     v_region_t ui_v_reg = {
-        .start = (word_t)(ui_p_reg_start - pv_offset),
-        .end   = (word_t)(ui_p_reg_end   - pv_offset)
+        .start = ui_p_reg_start - pv_offset,
+        .end   = ui_p_reg_end   - pv_offset
     };
 
     ipcbuf_vptr = ui_v_reg.end;


### PR DESCRIPTION
The cast does not exist in the ARM version of this code either. Both `vptr_t` and `paddr_t` ars aliases for `word_t`, so this is safe at the moment. If this ever changes and `vptr_t` gets a smaller size than `paddr_t`then I'd expect the compiler to issue a warning here without the cast, so we will catch this. With the cast in the code we silence such a compiler warning, which seems undesired.