### PR TITLE
allwinnerA20: add option to use the ARM generic timer

### DIFF
--- a/src/plat/allwinnerA20/config.cmake
+++ b/src/plat/allwinnerA20/config.cmake
@@ -8,6 +8,13 @@ cmake_minimum_required(VERSION 3.7.2)
 
 declare_platform(allwinnerA20 KernelPlatformAllwinnerA20 PLAT_ALLWINNERA20 KernelSel4ArchAarch32)
 
+config_option(
+    KernelPlatformAllwinnerA20ArchTimer ARM_ALLWINNER_A20_ARCH_TIMER
+    "Use the ARM generic timer for kernel"
+    DEFAULT OFF
+    DEPENDS "KernelPlatformAllwinnerA20"
+)
+
 if(KernelPlatformAllwinnerA20)
     declare_seL4_arch(aarch32)
     set(KernelArmCortexA7 ON)
@@ -19,15 +26,27 @@ if(KernelPlatformAllwinnerA20)
     set(KernelPlatformSupportsMCS OFF)
 
     list(APPEND KernelDTSList "tools/dts/allwinnerA20.dts")
-    list(APPEND KernelDTSList "src/plat/allwinnerA20/overlay-allwinnerA20.dts")
+    if(KernelPlatformAllwinnerA20ArchTimer)
+        list(APPEND KernelDTSList "src/plat/allwinnerA20/overlay-allwinnerA20-generic-timer.dts")
 
-    declare_default_headers(
-        TIMER_FREQUENCY 24000000
-        MAX_IRQ 122
-        NUM_PPI 32
-        TIMER drivers/timer/allwinner.h
-        INTERRUPT_CONTROLLER arch/machine/gic_v2.h
-    )
+        declare_default_headers(
+            TIMER_FREQUENCY 24000000
+            MAX_IRQ 122
+            NUM_PPI 32
+            TIMER drivers/timer/arm_generic.h
+            INTERRUPT_CONTROLLER arch/machine/gic_v2.h
+        )
+    else()
+        list(APPEND KernelDTSList "src/plat/allwinnerA20/overlay-allwinnerA20.dts")
+
+        declare_default_headers(
+            TIMER_FREQUENCY 24000000
+            MAX_IRQ 122
+            NUM_PPI 32
+            TIMER drivers/timer/allwinner.h
+            INTERRUPT_CONTROLLER arch/machine/gic_v2.h
+        )
+    endif()
 endif()
 
 add_sources(

--- a/src/plat/allwinnerA20/overlay-allwinnerA20-generic-timer.dts
+++ b/src/plat/allwinnerA20/overlay-allwinnerA20-generic-timer.dts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+/ {
+	chosen {
+		seL4,elfloader-devices =
+		    "serial0";
+
+		seL4,kernel-devices =
+		    "serial0",
+		    &{/soc@1c00000/interrupt-controller@1c81000},
+		    &{/timer};
+	};
+};


### PR DESCRIPTION
The memory mapping for timer only uses 1K on AllwinnerA20, but the minimum device mapping is 4K in seL4. Other devices within this 4K page (CCU and PIO) cannot be accessed in userland. This option allows kernel to use the arm generic timer, and then we will have the access rights for those devices in userland.