### PR TITLE
cmake/rockpro64: remove unnecessary configuration

### DIFF
--- a/src/plat/rockpro64/config.cmake
+++ b/src/plat/rockpro64/config.cmake
@@ -15,7 +15,6 @@ if(KernelPlatformRockpro64)
     set(KernelArchArmV8a ON)
     set(KernelArmGicV3 ON)
     config_set(KernelARMPlatform ARM_PLAT "rockpro64")
-    set(KernelArmPASizeBits40 ON)
     list(APPEND KernelDTSList "tools/dts/rockpro64.dts")
     list(APPEND KernelDTSList "src/plat/rockpro64/overlay-rockpro64.dts")
     declare_default_headers(


### PR DESCRIPTION
`KernelArmPASizeBits40` is enabled by the generic code automatically if `KernelArmCortexA53` is set.
