### PR TITLE
arm,generic_timer: Add config user access on 32bit

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -36,6 +36,7 @@ Upcoming release: BINARY COMPATIBLE
   unused. See https://sel4.atlassian.net/browse/RFC-8.
 * Remove ARMv6 specific configs: KernelGlobalsFrame and KernelDangerousCodeInjectionOnUndefInstr. This removes the
   constant seL4_GlobalsFrame from libsel4.
+* Implement KernelArmExportPTMRUser and KernelArmExportVTMRUser options for Arm generic timer use access on aarch32.
 
 ## Upgrade Notes
 ---

--- a/src/arch/arm/armv/armv7-a/user_access.c
+++ b/src/arch/arm/armv/armv7-a/user_access.c
@@ -47,9 +47,15 @@ static void check_export_arch_timer(void)
 #ifdef CONFIG_EXPORT_PCNT_USER
     v |= CNTKCTL_PL0PCTEN;
 #endif
+#ifdef CONFIG_EXPORT_PTMR_USER
+    v |= CNTKCTL_PL0PTEN;
+#endif /* CONFIG_EXPORT_PTMR_USER */
 #ifdef CONFIG_EXPORT_VCNT_USER
     v |= CNTKCTL_PL0VCTEN;
 #endif
+#ifdef CONFIG_EXPORT_VTMR_USER
+    v |= CNTKCTL_PL0VTEN;
+#endif /* CONFIG_EXPORT_VTMR_USER */
     MCR(CNTKCTL, v);
 }
 


### PR DESCRIPTION
The KernelArmExportPTMRUser and KernelArmExportVTMRUser options for
enabling user access to the generic timer were previously only supported
on aarch64 but are now supported on aarch32 also.

Signed-off-by: Kent McLeod <kent@kry10.com>