### PR TITLE
Remove C semantics from CMake files

### DIFF
--- a/include/arch/riscv/arch/machine/timer.h
+++ b/include/arch/riscv/arch/machine/timer.h
@@ -18,8 +18,10 @@
 
 static inline CONST time_t getKernelWcetUs(void)
 {
-    /* Copied from x86_64. Hopefully it's an overestimate here. */
-    return  10u;
+    /* The value is copied from x86_64, hopefully it's an overestimate here.
+     * Making this an explicit unsigned type simplifies verification.
+     */
+    return 10u;
 }
 
 static inline PURE ticks_t usToTicks(time_t us)

--- a/include/arch/x86/arch/machine/timer.h
+++ b/include/arch/x86/arch/machine/timer.h
@@ -16,7 +16,8 @@
 
 static inline CONST time_t getKernelWcetUs(void)
 {
-    return  10u;
+    /* Making this an explicit unsigned type simplifies verification. */
+    return 10u;
 }
 
 static inline PURE ticks_t usToTicks(time_t us)

--- a/include/util.h
+++ b/include/util.h
@@ -13,12 +13,13 @@
 #ifdef __ASSEMBLER__
 
 /* Provide a helper macro to define integer constants that are not of the
- * default type 'ìnt', but 'unsigned long'. When such constants are shared
- * between assembly and C code, some assemblers will fail because don't support
- * C-style integer suffixes like 'ul'. Using a macro works around this, as the
- * suffix is only applies when the C compiler is used and dropped when the
- * assembler runs.
+ * default type 'ìnt', but 'unsigned [long [long]]'. When such constants are
+ * shared between assembly and C code, some assemblers will fail because don't
+ * support C-style integer suffixes like 'ul'. Using a macro works around this,
+ * as the suffix is only applies when the C compiler is used and dropped when
+ * the assembler runs.
  */
+#define U_CONST(x) x
 #define UL_CONST(x) x
 #define ULL_CONST(x) x
 #define NULL 0
@@ -30,6 +31,7 @@
  * printf() format specifiers, '%lu' is the only form that is supported. Thus
  * 'ul' is the preferred suffix to avoid confusion.
  */
+#define U_CONST(x) PASTE(x, u)
 #define UL_CONST(x) PASTE(x, ul)
 #define ULL_CONST(x) PASTE(x, llu)
 #define NULL ((void *)0)

--- a/src/arch/arm/platform_gen.h.in
+++ b/src/arch/arm/platform_gen.h.in
@@ -39,6 +39,7 @@ enum IRQConstants {
 #ifdef CONFIG_KERNEL_MCS
 static inline CONST time_t getKernelWcetUs(void)
 {
-    return @CONFIGURE_KERNEL_WCET@;
+    /* Making this an explicit unsigned type simplifies verification. */
+    return U_CONST(@CONFIGURE_KERNEL_WCET@);
 }
 #endif

--- a/src/plat/am335x/config.cmake
+++ b/src/plat/am335x/config.cmake
@@ -52,7 +52,7 @@ if(KernelPlatformAM335X)
         TIMER_FREQUENCY 24000000
         CLK_MAGIC 2863311531llu
         CLK_SHIFT 36u
-        KERNEL_WCET 10u
+        KERNEL_WCET 10
     )
 endif()
 

--- a/src/plat/bcm2711/config.cmake
+++ b/src/plat/bcm2711/config.cmake
@@ -39,7 +39,7 @@ if(KernelPlatformRpi4)
         NUM_PPI 32
         TIMER drivers/timer/arm_generic.h
         INTERRUPT_CONTROLLER arch/machine/gic_v2.h
-        KERNEL_WCET 10u
+        KERNEL_WCET 10
         CLK_MAGIC 5337599559llu
         CLK_SHIFT 58u
     )

--- a/src/plat/bcm2837/config.cmake
+++ b/src/plat/bcm2837/config.cmake
@@ -29,7 +29,7 @@ if(KernelPlatformRpi3)
         NUM_PPI 32
         TIMER drivers/timer/arm_generic.h
         INTERRUPT_CONTROLLER drivers/irq/bcm2836-armctrl-ic.h
-        KERNEL_WCET 10u
+        KERNEL_WCET 10
         CLK_MAGIC 458129845llu
         CLK_SHIFT 43u
     )

--- a/src/plat/exynos4/config.cmake
+++ b/src/plat/exynos4/config.cmake
@@ -22,7 +22,7 @@ if(KernelPlatformExynos4)
         NUM_PPI 32
         TIMER drivers/timer/exynos4412-mct.h
         INTERRUPT_CONTROLLER arch/machine/gic_v2.h
-        KERNEL_WCET 10u
+        KERNEL_WCET 10
         CLK_MAGIC 2863311531llu
         CLK_SHIFT 36u
         TIMER_PRECISION 0u

--- a/src/plat/exynos5/config.cmake
+++ b/src/plat/exynos5/config.cmake
@@ -65,7 +65,7 @@ if(KernelPlatExynos5)
         INTERRUPT_CONTROLLER arch/machine/gic_v2.h
         CLK_MAGIC 2863311531llu
         CLK_SHIFT 36u
-        KERNEL_WCET 10u
+        KERNEL_WCET 10
     )
 endif()
 

--- a/src/plat/hikey/config.cmake
+++ b/src/plat/hikey/config.cmake
@@ -29,7 +29,7 @@ if(KernelPlatformHikey)
         INTERRUPT_CONTROLLER arch/machine/gic_v2.h
         CLK_MAGIC 458129845llu
         CLK_SHIFT 39u
-        KERNEL_WCET 10u
+        KERNEL_WCET 10
     )
 endif()
 

--- a/src/plat/imx6/config.cmake
+++ b/src/plat/imx6/config.cmake
@@ -72,7 +72,7 @@ if(KernelPlatImx6)
         TIMER ${timer_file}
         CLK_SHIFT 41llu
         CLK_MAGIC 4415709349llu
-        KERNEL_WCET 10llu
+        KERNEL_WCET 10
         TIMER_PRECISION 2u
     )
 endif()

--- a/src/plat/imx7/config.cmake
+++ b/src/plat/imx7/config.cmake
@@ -25,7 +25,7 @@ if(KernelPlatImx7)
         INTERRUPT_CONTROLLER arch/machine/gic_v2.h
         CLK_MAGIC 1llu
         CLK_SHIFT 8u
-        KERNEL_WCET 10u
+        KERNEL_WCET 10
     )
 else()
     config_set(KernelPlatImx7 PLAT_IMX7 OFF)

--- a/src/plat/imx8m-evk/config.cmake
+++ b/src/plat/imx8m-evk/config.cmake
@@ -36,7 +36,7 @@ if(KernelPlatformImx8mq-evk OR KernelPlatformImx8mm-evk)
         NUM_PPI 32
         CLK_MAGIC 1llu
         CLK_SHIFT 3u
-        KERNEL_WCET 10u
+        KERNEL_WCET 10
     )
 endif()
 

--- a/src/plat/odroidc2/config.cmake
+++ b/src/plat/odroidc2/config.cmake
@@ -24,7 +24,7 @@ if(KernelPlatformOdroidc2)
         INTERRUPT_CONTROLLER arch/machine/gic_v2.h
         CLK_MAGIC 375299969u
         CLK_SHIFT 53u
-        KERNEL_WCET 10u
+        KERNEL_WCET 10
         TIMER_PRECISION 1u
     )
 endif()

--- a/src/plat/odroidc4/config.cmake
+++ b/src/plat/odroidc4/config.cmake
@@ -23,7 +23,7 @@ if(KernelPlatformOdroidc4)
         INTERRUPT_CONTROLLER arch/machine/gic_v2.h
         CLK_MAGIC 375299969u
         CLK_SHIFT 53u
-        KERNEL_WCET 10u
+        KERNEL_WCET 10
         TIMER_PRECISION 1u
     )
 endif()

--- a/src/plat/omap3/config.cmake
+++ b/src/plat/omap3/config.cmake
@@ -24,7 +24,7 @@ if(KernelPlatformOMAP3)
         TIMER drivers/timer/omap3430.h
         CLK_MAGIC 1321528399llu
         CLK_SHIFT 34u
-        KERNEL_WCET 10u
+        KERNEL_WCET 10
     )
 endif()
 

--- a/src/plat/qemu-arm-virt/config.cmake
+++ b/src/plat/qemu-arm-virt/config.cmake
@@ -109,7 +109,7 @@ if(KernelPlatformQEMUArmVirt)
         INTERRUPT_CONTROLLER arch/machine/gic_v2.h
         CLK_MAGIC 4611686019llu
         CLK_SHIFT 58u
-        KERNEL_WCET 10u
+        KERNEL_WCET 10
     )
 endif()
 

--- a/src/plat/rockpro64/config.cmake
+++ b/src/plat/rockpro64/config.cmake
@@ -21,7 +21,7 @@ if(KernelPlatformRockpro64)
         TIMER_FREQUENCY 24000000
         MAX_IRQ 181
         NUM_PPI 32
-        KERNEL_WCET 10u
+        KERNEL_WCET 10
         TIMER drivers/timer/arm_generic.h
         INTERRUPT_CONTROLLER arch/machine/gic_v3.h
     )

--- a/src/plat/tk1/config.cmake
+++ b/src/plat/tk1/config.cmake
@@ -31,7 +31,7 @@ if(KernelPlatformTK1)
         TIMER drivers/timer/arm_generic.h SMMU plat/machine/smmu.h
         CLK_MAGIC 2863311531llu
         CLK_SHIFT 35u
-        KERNEL_WCET 100u
+        KERNEL_WCET 100
     )
 endif()
 

--- a/src/plat/tqma8xqp1gb/config.cmake
+++ b/src/plat/tqma8xqp1gb/config.cmake
@@ -26,7 +26,7 @@ if(KernelPlatformTqma8xqp1gb)
         NUM_PPI 32
         CLK_MAGIC 1llu
         CLK_SHIFT 3u
-        KERNEL_WCET 10u
+        KERNEL_WCET 10
     )
 endif()
 

--- a/src/plat/tx1/config.cmake
+++ b/src/plat/tx1/config.cmake
@@ -24,7 +24,7 @@ if(KernelPlatformTx1)
         TIMER drivers/timer/arm_generic.h
         CLK_MAGIC 2863311531llu
         CLK_SHIFT 35u
-        KERNEL_WCET 10u
+        KERNEL_WCET 10
     )
 endif()
 

--- a/src/plat/tx2/config.cmake
+++ b/src/plat/tx2/config.cmake
@@ -28,7 +28,7 @@ if(KernelPlatformTx2)
         TIMER drivers/timer/arm_generic.h
         CLK_SHIFT 57u
         CLK_MAGIC 4611686019u
-        KERNEL_WCET 10u SMMU drivers/smmu/smmuv2.h
+        KERNEL_WCET 10 SMMU drivers/smmu/smmuv2.h
         MAX_SID 128
         MAX_CB 64
     )

--- a/src/plat/zynq7000/config.cmake
+++ b/src/plat/zynq7000/config.cmake
@@ -32,7 +32,7 @@ if(KernelPlatformZynq7000)
         TIMER ${timer_file}
         CLK_SHIFT 40llu
         CLK_MAGIC 3435973837llu
-        KERNEL_WCET 10llu
+        KERNEL_WCET 10
     )
 endif()
 

--- a/src/plat/zynqmp/config.cmake
+++ b/src/plat/zynqmp/config.cmake
@@ -65,7 +65,7 @@ if(KernelPlatformZynqmp)
         INTERRUPT_CONTROLLER arch/machine/gic_v2.h
         CLK_MAGIC 1374389535llu
         CLK_SHIFT 37u
-        KERNEL_WCET 10u
+        KERNEL_WCET 10
     )
 endif()
 


### PR DESCRIPTION
There seems no need to pull in C semantics into the CMake files. The constant `CONFIG_KERNEL_WCET` in not supposed to be used directly, but the value must be retrieved by calling `getKernelWcetUs()`, which add the proper type semantics. Within the function itself, the compiler can do the integer conversion from the plain number automatically, which still allows constant folding to happen on higher optimization levels.

This basically follows the road of 7d379904650b76f4d33d5c78b232879c5bcbccc6 that did remove the suffix for `TIMER_FREQUENCY` in the CMake files.
