### PR TITLE
trivial: fix missing semicolon

### DIFF
--- a/src/plat/bcm2837/overlay-rpi3.dts
+++ b/src/plat/bcm2837/overlay-rpi3.dts
@@ -39,6 +39,6 @@
 		reserved-memory@0{
 			reg = <0x0 0x1000>;
 			no-map;
-		}
+		};
 	};
 };


### PR DESCRIPTION
This was accidentally removed in a previous commit
