### PR TITLE
Fix indexing into an empty array

### DIFF
--- a/tools/circular_includes.py
+++ b/tools/circular_includes.py
@@ -58,7 +58,7 @@ def main(parse_args):
                 file_stack.append(header)
         else:
             # popped back up to an earlier header
-            while file_stack[-1] != header:
+            while (len(file_stack) > 0) and (file_stack[-1] != header):
                 file_stack.pop()
 
     return 0


### PR DESCRIPTION
When compiling hello world tutorial the following error happens:
```
  File "/home/sel4repo/sel4-tutorials-manifest/kernel/tools/circular_includes.py", line 61, in main
    while file_stack[-1] != header:
IndexError: list index out of range
```

This PR fixes the indexed access into potentially empty array