### PR TITLE
github: run actions with secrets only in seL4 org

### DIFF
--- a/.github/workflows/preprocess-deploy.yml
+++ b/.github/workflows/preprocess-deploy.yml
@@ -40,6 +40,7 @@ jobs:
   deploy:
     name: Deploy manifest
     needs: [code, preprocess]
+    if: ${{ github.repository_owner == 'seL4' }}
     runs-on: ubuntu-latest
     steps:
     - uses: seL4/ci-actions/l4v-deploy@master

--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -14,9 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     # run on any normal trigger when the label exists, and run when the label is added
     # don't run again when other labels are added
-    if: ${{ github.event.action != 'labeled' &&
-              contains(github.event.pull_request.labels.*.name, 'proof-test') ||
-            github.event.action == 'labeled' && github.event.label.name == 'proof-test' }}
+    if: ${{ github.repository_owner == 'seL4' &&
+            (github.event.action != 'labeled' &&
+               contains(github.event.pull_request.labels.*.name, 'proof-test') ||
+             github.event.action == 'labeled' && github.event.label.name == 'proof-test') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/sel4test-deploy.yml
+++ b/.github/workflows/sel4test-deploy.yml
@@ -78,6 +78,7 @@ jobs:
 
   hw-run:
     name: HW Run
+    if: ${{ github.repository_owner == 'seL4' }}
     runs-on: ubuntu-latest
     needs: [sim, hw-build]
     strategy:
@@ -140,6 +141,7 @@ jobs:
 
   deploy:
     name: Deploy manifest
+    if: ${{ github.repository_owner == 'seL4' }}
     runs-on: ubuntu-latest
     needs: [code, hw-run]
     steps:

--- a/.github/workflows/sel4test-hw.yml
+++ b/.github/workflows/sel4test-hw.yml
@@ -55,13 +55,14 @@ jobs:
     name: HW Run
     runs-on: ubuntu-latest
     needs: hw-build
-    if: ${{ github.event_name == 'push' ||
-            github.event_name == 'pull_request_target' &&
-              github.event.action != 'labeled' &&
-              contains(github.event.pull_request.labels.*.name, 'hw-test') ||
-            github.event_name == 'pull_request_target' &&
-              github.event.action == 'labeled' &&
-              github.event.label.name == 'hw-test' }}
+    if: ${{ github.repository_owner == 'seL4' &&
+            (github.event_name == 'push' ||
+             github.event_name == 'pull_request_target' &&
+               github.event.action != 'labeled' &&
+               contains(github.event.pull_request.labels.*.name, 'hw-test') ||
+             github.event_name == 'pull_request_target' &&
+               github.event.action == 'labeled' &&
+               github.event.label.name == 'hw-test') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/trigger.yml
+++ b/.github/workflows/trigger.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   trigger:
     name: Repository Dispatch
+    if: ${{ github.repository_owner == 'seL4' }}
     runs-on: ubuntu-latest
     steps:
     - uses: seL4/ci-actions/trigger@master


### PR DESCRIPTION
Some of the Github actions in this repository require secrets for
access to hardware test or other compute infrastructure, or for
deployment. When these are run in a fork on GitHub they are safe,
but generate annoying error messages.

This commit adds tests in the relevant actions whether they are run
from the seL4 org or not, and skips the action when they are run
outside. This should make the remaining actions more useful on forks.
