### PR TITLE
Fix linking for armv8-a with gcc 10.1

### DIFF
--- a/src/arch/arm/64/config.cmake
+++ b/src/arch/arm/64/config.cmake
@@ -21,3 +21,7 @@ add_sources(
         kernel/vspace.c
     ASMFILES head.S traps.S
 )
+
+if(CMAKE_C_COMPILER_VERSION VERSION_GREATER 10.1)
+    add_compile_options(-mno-outline-atomics)
+endif()


### PR DESCRIPTION
Starting from gcc 10.1 -moutline-atomics is enabled by default.
This option causes gcc to generate code that will determine at
runtime whether the hardware supports the newer armv8.1-a atomic
instructions. This is useful if the same binary will be used on
multiple platforms. As this is not the case for seL4, disable this
option, it will only cause unnecessary runtime overhead.

If later it is decided to enable outline-atomics, seL4 will need
to link against libgcc.