### PR TITLE
tqma8xqp1gb: Remove Linux specific memory regions

### DIFF
--- a/src/plat/tqma8xqp1gb/overlay-tqma8xqp1gb.dts
+++ b/src/plat/tqma8xqp1gb/overlay-tqma8xqp1gb.dts
@@ -26,4 +26,9 @@
         interrupts = < 0x00 0x50 0x04 >;
         status = "disabled";
     };
+    reserved-memory {
+        /* The following normal memory regions are Linux specific. */
+        /delete-node/ dsp@92400000;
+        /delete-node/ linux,cma;
+    };
 };


### PR DESCRIPTION
seL4 can use those memory regions however it likes,
it's just normal memory.

Signed-off-by: Indan Zupancic <Indan.Zupancic@mep-info.com>