### PR TITLE
imx8mm-evk: Don't use symlink for constants.h

### DIFF
--- a/libsel4/sel4_plat_include/imx8mm-evk
+++ b/libsel4/sel4_plat_include/imx8mm-evk
@@ -1,1 +1,0 @@
-imx8mq-evk/

--- a/libsel4/sel4_plat_include/imx8mm-evk/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/imx8mm-evk/sel4/plat/api/constants.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <autoconf.h>
+
+#define seL4_NumHWBreakpoints (10)
+#define seL4_NumExclusiveBreakpoints (6)
+#define seL4_NumExclusiveWatchpoints (4)
+#ifdef CONFIG_HARDWARE_DEBUG_API
+#define seL4_FirstWatchpoint (6)
+#define seL4_NumDualFunctionMonitors (0)
+#endif
+
+#if CONFIG_WORD_SIZE == 32
+/* First address in the virtual address space that is not accessible to user level */
+#define seL4_UserTop 0xe0000000
+#else
+/* otherwise this is defined at the arch level */
+#endif


### PR DESCRIPTION
Using a symlink means that ninja install now works for this platform.

Signed-off-by: Kent McLeod <kent@kry10.com>