### PR TITLE
qemu-arm-virt: fix in cmake for STRIP

### DIFF
--- a/src/plat/qemu-arm-virt/config.cmake
+++ b/src/plat/qemu-arm-virt/config.cmake
@@ -82,7 +82,9 @@ if(KernelPlatformQEMUArmVirt)
         ERROR_VARIABLE QEMU_OUTPUT_MESSAGE
         RESULT_VARIABLE error
     )
-    string(STRIP ${QEMU_OUTPUT_MESSAGE} QEMU_OUTPUT_MESSAGE)
+    if(${QEMU_OUTPUT_MESSAGE})
+        string(STRIP ${QEMU_OUTPUT_MESSAGE} QEMU_OUTPUT_MESSAGE)
+    endif()
     message(STATUS ${QEMU_OUTPUT_MESSAGE})
     if(error)
         message(FATAL_ERROR "Failed to dump DTB using ${QEMU_BINARY})")


### PR DESCRIPTION
Check if QEMU_OUTPUT_MESSAGE is empty before the STRIP
If no error in the previous qemu test command, the output
message is empty (QEMU_OUTPUT_MESSAGE), then the STRIP
will fail on empty input. Then, if it is empty do not
run STRIP.

Signed-off-by: Juan Pablo Ruiz <juanpablo@ssrc.tii.ae>