### PR TITLE
enable more test platforms

### DIFF
--- a/.github/workflows/sel4test-deploy.yml
+++ b/.github/workflows/sel4test-deploy.yml
@@ -92,7 +92,8 @@ jobs:
           # - odroid_xu4
           - am335x_boneblack
           - tx2
-          # - rpi3
+          - rpi3
+          - rpi4
           - zynqmp
         compiler: [gcc, clang]
         include:
@@ -108,9 +109,8 @@ jobs:
            - platform: pc99
              compiler: clang
              mode: 64
-        # include:
-        #    - platform: hifive
-        #      compiler: gcc
+           - platform: hifive
+             compiler: gcc
     # do not run concurrently with other workflows, but do run concurrently in the build matrix
     concurrency: hw-run-${{ strategy.job-index }}
     steps:

--- a/.github/workflows/sel4test-hw.yml
+++ b/.github/workflows/sel4test-hw.yml
@@ -9,6 +9,9 @@
 name: seL4Test HW
 
 on:
+  push:
+    branches:
+      - rpi4
   # needs PR target for secrets access; guard by requiring label
   pull_request_target:
     types: [opened, reopened, synchronize, labeled]

--- a/.github/workflows/sel4test-hw.yml
+++ b/.github/workflows/sel4test-hw.yml
@@ -75,7 +75,8 @@ jobs:
           # - odroid_xu4
           - am335x_boneblack
           - tx2
-          # - rpi3
+          - rpi3
+          - rpi4
           - zynqmp
         compiler: [gcc, clang]
         include:
@@ -91,9 +92,8 @@ jobs:
            - platform: pc99
              compiler: clang
              mode: 64
-        # include:
-        #    - platform: hifive
-        #      compiler: gcc
+           - platform: hifive
+             compiler: gcc
     steps:
       - name: Get machine queue
         uses: actions/checkout@v2


### PR DESCRIPTION
Tests should now re-run automatically on boot failure, so we can hopefully add some of the more skittish boards.