### PR TITLE
python: use KernelSel4Arch instead of KernelArch

### DIFF
--- a/config.cmake
+++ b/config.cmake
@@ -184,8 +184,8 @@ if(DEFINED KernelDTSList AND (NOT "${KernelDTSList}" STREQUAL ""))
                 ${PYTHON3} "${HARDWARE_GEN_PATH}" --dtb "${KernelDTBPath}" --compat-strings
                 --compat-strings-out "${compatibility_outfile}" --c-header --header-out
                 "${device_dest}" --hardware-config "${config_file}" --hardware-schema
-                "${config_schema}" --yaml --yaml-out "${platform_yaml}" --arch "${KernelArch}"
-                --addrspace-max "${KernelPaddrUserTop}"
+                "${config_schema}" --yaml --yaml-out "${platform_yaml}" --sel4arch
+                "${KernelSel4Arch}" --addrspace-max "${KernelPaddrUserTop}"
             RESULT_VARIABLE error
         )
         if(error)

--- a/tools/hardware/outputs/c_header.py
+++ b/tools/hardware/outputs/c_header.py
@@ -78,7 +78,7 @@ static const kernel_frame_t BOOT_RODATA kernel_device_frames[] = {
         /* contains {{ ', '.join(group.labels.keys()) }} */
         .pptr = KDEV_BASE + {{ "0x{:x}".format(map_addr) }},
         {% endif %}
-        {% if args.arch == 'arm' %}
+        {% if config.arch == 'arm' %}
         .armExecuteNever = true,
         {% endif %}
         .userAvailable = {{ str(group.user_ok).lower() }}
@@ -176,7 +176,7 @@ def get_interrupts(tree: FdtParser, hw_yaml: HardwareYaml) -> List:
     return ret
 
 
-def create_c_header_file(args, kernel_irqs: List, kernel_macros: Dict,
+def create_c_header_file(config, kernel_irqs: List, kernel_macros: Dict,
                          kernel_regions: List, physBase: int, physical_memory,
                          outputStream):
 
@@ -187,7 +187,7 @@ def create_c_header_file(args, kernel_irqs: List, kernel_macros: Dict,
     template_args = dict(
         builtins.__dict__,
         **{
-            'args': args,
+            'config': config,
             'kernel_irqs': kernel_irqs,
             'kernel_macros': kernel_macros,
             'kernel_regions': kernel_regions,
@@ -207,7 +207,7 @@ def run(tree: FdtParser, hw_yaml: HardwareYaml, config: Config, args: argparse.N
     kernel_regions, kernel_macros = get_kernel_devices(tree, hw_yaml)
 
     create_c_header_file(
-        args,
+        config,
         get_interrupts(tree, hw_yaml),
         kernel_macros,
         kernel_regions,

--- a/tools/hardware_gen.py
+++ b/tools/hardware_gen.py
@@ -49,7 +49,7 @@ def add_task_args(outputs: dict, parser: argparse.ArgumentParser):
 def main(args: argparse.Namespace):
     ''' Parse the DT and hardware config YAML and run each
     selected output method. '''
-    cfg = hardware.config.get_arch_config(args.arch, args.addrspace_max)
+    cfg = hardware.config.get_arch_config(args.sel4arch, args.addrspace_max)
     parsed_dt = FdtParser(args.dtb)
     rules = yaml.load(args.hardware_config, Loader=yaml.FullLoader)
     schema = yaml.load(args.hardware_schema, Loader=yaml.FullLoader)
@@ -73,7 +73,8 @@ if __name__ == '__main__':
                         required=True, type=argparse.FileType('r'))
     parser.add_argument('--hardware-schema', help='YAML file containing schema for hardware config',
                         required=True, type=argparse.FileType('r'))
-    parser.add_argument('--arch', help='architecture to generate for', default='arm')
+    parser.add_argument('--sel4arch', help='seL4 architecture to generate for',
+                        required=True)
     parser.add_argument('--addrspace-max',
                         help='maximum address that is available as device untyped', type=int, default=32)
 


### PR DESCRIPTION
Also make 'arch' a required parameter to avoid implicit assumptions.

This PR make a change in the ELF-Loader script necessary, too. See https://github.com/seL4/seL4_tools/pull/130

Test with seL4/seL4_tools#130