### PR TITLE
boot: created untypeds up to PADDR_TOP only

### DIFF
--- a/src/arch/arm/kernel/boot.c
+++ b/src/arch/arm/kernel/boot.c
@@ -102,9 +102,6 @@ BOOT_CODE static bool_t arch_init_freemem(p_region_t ui_p_reg,
             reserved[index] = mode_reserved_region[0];
             index++;
         }
-
-        /* Reserve the ui_p_reg region still so it doesn't get turned into device UT. */
-        reserve_region(ui_p_reg);
     }
 
     /* avail_p_regs comes from the auto-generated code */

--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -654,9 +654,17 @@ BOOT_CODE bool_t create_untypeds(cap_t root_cnode_cap,
         start = ndks_boot.reserved[i].end;
     }
 
-    if (start < CONFIG_PADDR_USER_DEVICE_TOP) {
+    if (start < PADDR_TOP) {
+        /* Provide untyped device capabilities for the remaining physical
+         * address space that can be accessed via the kernel window. This could
+         * be less than the physical address space implemented by the platform
+         * or defined by the architecture (CONFIG_PADDR_USER_DEVICE_TOP). Due to
+         * the kernel design, only the part of the physical address space is
+         * accessible that fits into the kernel window.
+         */
         region_t reg = paddr_to_pptr_reg((p_region_t) {
-            start, CONFIG_PADDR_USER_DEVICE_TOP
+            .start = start,
+            .end   = PADDR_TOP
         });
 
         if (!create_untypeds_for_region(root_cnode_cap, true, reg, first_untyped_slot)) {


### PR DESCRIPTION
Provide untyped device capabilities for the remaining physical address space that can be accessed via the kernel window. This could be less than the physical address space implemented by the platform or defined by the architecture (`CONFIG_PADDR_USER_DEVICE_TOP`). Due to the kernel design, only the part of the physical address space is accessible that fits into the kernel window.

This limit used to exists in the past, but the commit [fc1674](https://github.com/seL4/seL4/commit/fc167441f02ac35e0654047a323936e563bcff79) removed this, because the comment there was invalid thus not justification.