### PR TITLE
riscv: provide functions for CSR access

### DIFF
--- a/include/arch/riscv/arch/32/mode/machine.h
+++ b/include/arch/riscv/arch/32/mode/machine.h
@@ -18,7 +18,7 @@ static inline uint64_t riscv_read_time(void)
         "rdtime  %1\n"
         "rdtimeh %2\n"
         : "=r"(nH1), "=r"(nL), "=r"(nH2));
-    if (nH1 < nH2) {
+    if (nH1 != nH2) {
         /* Ensure that the time is correct if there is a rollover in the
          * high bits between reading the low and high bits. */
         asm volatile("rdtime  %0\n" : "=r"(nL));

--- a/include/arch/riscv/arch/32/mode/machine.h
+++ b/include/arch/riscv/arch/32/mode/machine.h
@@ -24,7 +24,7 @@ static inline uint64_t riscv_read_time(void)
         asm volatile("rdtime  %0\n" : "=r"(nL));
         nH1 = nH2;
     }
-    return ((uint64_t)((uint64_t) nH1 << 32)) | (nL);
+    return ((uint64_t)nH1 << 32) | nL;
 }
 
 
@@ -42,5 +42,5 @@ static inline uint64_t riscv_read_cycle(void)
         asm volatile("rdcycle  %0\n" : "=r"(nL));
         nH1 = nH2;
     }
-    return ((uint64_t)((uint64_t) nH1 << 32)) | (nL);
+    return ((uint64_t) nH1 << 32) | nL;
 }

--- a/include/arch/riscv/arch/32/mode/machine.h
+++ b/include/arch/riscv/arch/32/mode/machine.h
@@ -22,9 +22,8 @@ static inline uint64_t riscv_read_time(void)
         /* Ensure that the time is correct if there is a rollover in the
          * high bits between reading the low and high bits. */
         asm volatile("rdtime  %0\n" : "=r"(nL));
-        nH1 = nH2;
     }
-    return ((uint64_t)nH1 << 32) | nL;
+    return (((uint64_t)nH2) << 32) | nL;
 }
 
 
@@ -40,7 +39,6 @@ static inline uint64_t riscv_read_cycle(void)
         /* Ensure that the cycles are correct if there is a rollover in the
          * high bits between reading the low and high bits. */
         asm volatile("rdcycle  %0\n" : "=r"(nL));
-        nH1 = nH2;
     }
-    return ((uint64_t) nH1 << 32) | nL;
+    return (((uint64_t)nH2) << 32) | nL;
 }

--- a/include/arch/riscv/arch/32/mode/machine.h
+++ b/include/arch/riscv/arch/32/mode/machine.h
@@ -12,7 +12,7 @@
 
 static inline uint64_t riscv_read_time(void)
 {
-    uint32_t nH1, nL, nH2;
+    word_t nH1, nL, nH2;
     asm volatile(
         "rdtimeh %0\n"
         "rdtime  %1\n"
@@ -30,7 +30,7 @@ static inline uint64_t riscv_read_time(void)
 
 static inline uint64_t riscv_read_cycle(void)
 {
-    uint32_t nH1, nL, nH2;
+    word_t nH1, nL, nH2;
     asm volatile(
         "rdcycleh %0\n"
         "rdcycle  %1\n"

--- a/include/arch/riscv/arch/64/mode/machine.h
+++ b/include/arch/riscv/arch/64/mode/machine.h
@@ -12,14 +12,14 @@
 
 static inline uint64_t riscv_read_time(void)
 {
-    uint64_t n;
+    word_t n;
     asm volatile("rdtime %0" : "=r"(n));
     return n;
 }
 
 static inline uint64_t riscv_read_cycle(void)
 {
-    uint64_t n;
+    word_t n;
     asm volatile("rdcycle %0" : "=r"(n));
     return n;
 }


### PR DESCRIPTION
Provide generic CSR access function macros that can be extended easily for other CSRs.
Note that this PR is on top of https://github.com/seL4/seL4/pull/646