### PR TITLE
Remove userError from seL4_ReplyRecv path

### DIFF
--- a/libsel4/include/sel4/syscalls_master.h
+++ b/libsel4/include/sel4/syscalls_master.h
@@ -72,7 +72,9 @@ seL4_Call(seL4_CPtr dest, seL4_MessageInfo_t msgInfo);
 /**
  * @xmlonly <manual name="Reply" label="sel4_reply"/> @endxmlonly
  * @brief Perform a send to a one-off reply capability stored when
- *        the thread was last called
+ *        the thread was last called. Does nothing if there is no
+ *        reply capability which can happen if the blocked thread
+ *        was unblocked via an operation such as destroying it.
  *
  * @xmlonly
  * <docref>See <autoref label="sec:sys_reply"/></docref>

--- a/src/api/syscall.c
+++ b/src/api/syscall.c
@@ -490,7 +490,7 @@ static void handleReply(void)
     }
 
     case cap_null_cap:
-        userError("Attempted reply operation when no reply cap present.");
+        /* Do nothing when no caller is pending */
         return;
 
     default:


### PR DESCRIPTION
Remove a userError that is present on mainline kernel but not on MCS.

seL4_ReplyRecv is often used in a loop to create an event handler. When
first entering this loop, or when handling signals from notifications,
there won't already be a pending caller blocked on the reply object. In
this case the kernel doesn't perform a reply transfer and continues with
the receive operation. This is a common operation and shouldn't result
in a userError being printed by the kernel each time the reply phase
ends up as a no-op.

Signed-off-by: Kent McLeod <kent@kry10.com>