### PR TITLE
print 64-bit integers on 32-bits systems fully

### DIFF
--- a/include/stdint.h
+++ b/include/stdint.h
@@ -23,6 +23,12 @@ typedef signed long long int64_t;
 #define INT64_MAX  (0x7FFFFFFFFFFFFFFF)
 #define INT32_MAX  (0x7FFFFFFF)
 
+typedef uint64_t    uintmax_t;
+typedef int64_t     intmax_t;
+
+#define INTMAX_MAX  UINT64_MAX
+#define UINTMAX_MAX INT64_MAX
+
 #define PRId64     "lld"
 #define PRIi64     "lli"
 #define PRIu64     "llu"


### PR DESCRIPTION
`PRIu64`/`PRIx64` were only printing the lower 32 bits of the value on 32-bit systems.

Found while experimenting with the system time for https://github.com/seL4/seL4/pull/657