### PR TITLE
Remove llvm toolchain supplied compiler options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,7 @@ macro(KernelCommonFlags)
         string(APPEND CMAKE_EXE_LINKER_FLAGS " ${common_flag} ")
     endforeach()
 endmacro(KernelCommonFlags)
-KernelCommonFlags(-nostdinc -nostdlib ${KernelOptimisation} -DHAVE_AUTOCONF)
+KernelCommonFlags(-nostdlib ${KernelOptimisation} -DHAVE_AUTOCONF)
 if(KernelFWholeProgram)
     KernelCommonFlags(-fwhole-program)
 endif()
@@ -162,6 +162,7 @@ if(KernelArchRiscV)
 endif()
 KernelCommonFlags(-fno-pic -fno-pie)
 add_compile_options(
+    -nostdinc
     -fno-stack-protector
     -fno-asynchronous-unwind-tables
     -std=c99

--- a/llvm.cmake
+++ b/llvm.cmake
@@ -19,9 +19,6 @@ set(CMAKE_ASM_COMPILER "clang")
 set(CMAKE_ASM_COMPILER_ID Clang)
 set(CMAKE_ASM_COMPILER_TARGET ${TRIPLE})
 
-string(APPEND asm_common_flags " -Wno-unused-command-line-argument")
-string(APPEND asm_common_flags " -fno-integrated-as")
-
 set(CMAKE_C_COMPILER "clang")
 set(CMAKE_C_COMPILER_ID Clang)
 set(CMAKE_C_COMPILER_TARGET ${TRIPLE})
@@ -29,16 +26,6 @@ set(CMAKE_C_COMPILER_TARGET ${TRIPLE})
 set(CMAKE_CXX_COMPILER "clang++")
 set(CMAKE_CXX_COMPILER_ID Clang)
 set(CMAKE_CXX_COMPILER_TARGET ${TRIPLE})
-
-string(APPEND c_common_flags " -Wno-sizeof-pointer-div")
-string(APPEND c_common_flags " -Qunused-arguments")
-string(APPEND c_common_flags " -Wno-constant-logical-operand")
-if(NOT ("${TRIPLE}" MATCHES "^riscv"))
-    string(APPEND c_common_flags " -fno-integrated-as")
-endif()
-# clang 11 has a regression in GlobalISel (only used at -O0) affecting the syscall
-# stubs in libsel4runtime; see https://reviews.llvm.org/D83384#2189132
-string(APPEND c_common_flags " -fno-experimental-isel")
 
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)


### PR DESCRIPTION
This will require: https://github.com/seL4/sel4runtime/pull/15 and https://github.com/seL4/musllibc/pull/14

Also will need to see if all the configurations compile and run because there tends to be a ton of edge cases when altering these flags.

- `-fno-integrated-as` prevents the llvm assembler from being.  The reason for this historically was because using llvm-as caused assembly errors.  Hopefully https://github.com/seL4/musllibc/pull/14/commits/8b644601dc98592817c5b3e09c6c0d26539ff961 is the only one left now.
- `-Wno-unused-command-line-argument` and `-Qunused-arguments` suppressed warnings about unused command line arguments. https://github.com/seL4/musllibc/pull/14/commits/88403f7404bbf79dff470cc771b6dba31d63b4b1 suppresses these warnings for muslc and https://github.com/seL4/sel4runtime/pull/15 and https://github.com/seL4/seL4/commit/f1d2e919567e7ecc155e16e44b3ee4c53bc45704 should resolve the rest.
- `-Wno-sizeof-pointer-div` and `-Wno-constant-logical-operand` should be applied more directly to the warnings that they are trying to suppress.  I haven't found any of these warnings yet.
- `-fno-experimental-isel` I haven't been able to reproduce this using clang-11. 

Test with seL4/sel4runtime#15 and seL4/musllibc#15