### PR TITLE
Make debug output for fault and dump a bit nicer

### DIFF
--- a/include/api/debug.h
+++ b/include/api/debug.h
@@ -4,133 +4,32 @@
  * SPDX-License-Identifier: GPL-2.0-only
  */
 
-#include <config.h>
-
-#ifdef CONFIG_DEBUG_BUILD
 #pragma once
 
-#include <benchmark/benchmark_track.h>
-#include <arch/api/syscall.h>
-#include <arch/kernel/vspace.h>
-#include <model/statedata.h>
-#include <kernel/thread.h>
+#include <config.h>
 
 #ifdef CONFIG_PRINTING
 
-static inline void debug_printKernelEntryReason(void)
-{
-    printf("\nKernel entry via ");
-    switch (ksKernelEntry.path) {
-    case Entry_Interrupt:
-        printf("Interrupt, irq %lu\n", (unsigned long) ksKernelEntry.word);
-        break;
-    case Entry_UnknownSyscall:
-        printf("Unknown syscall, word: %lu", (unsigned long) ksKernelEntry.word);
-        break;
-    case Entry_VMFault:
-        printf("VM Fault, fault type: %lu\n", (unsigned long) ksKernelEntry.word);
-        break;
-    case Entry_UserLevelFault:
-        printf("User level fault, number: %lu", (unsigned long) ksKernelEntry.word);
-        break;
-#ifdef CONFIG_HARDWARE_DEBUG_API
-    case Entry_DebugFault:
-        printf("Debug fault. Fault Vaddr: 0x%lx", (unsigned long) ksKernelEntry.word);
-        break;
-#endif
-    case Entry_Syscall:
-        printf("Syscall, number: %ld, %s\n", (long) ksKernelEntry.syscall_no, syscall_names[ksKernelEntry.syscall_no]);
-        if (ksKernelEntry.syscall_no == -SysSend ||
-            ksKernelEntry.syscall_no == -SysNBSend ||
-            ksKernelEntry.syscall_no == -SysCall) {
+#include <types.h>
 
-            printf("Cap type: %lu, Invocation tag: %lu\n", (unsigned long) ksKernelEntry.cap_type,
-                   (unsigned long) ksKernelEntry.invocation_tag);
-        }
-        break;
-#ifdef CONFIG_ARCH_ARM
-    case Entry_VCPUFault:
-        printf("VCPUFault\n");
-        break;
-#endif
-#ifdef CONFIG_ARCH_x86
-    case Entry_VMExit:
-        printf("VMExit\n");
-        break;
-#endif
-    default:
-        printf("Unknown (%u)\n", ksKernelEntry.path);
-        break;
+void debug_print_fault_handler(
+    tcb_t *tptr,
+    seL4_Fault_t fault
+#ifndef CONFIG_KERNEL_MCS
+    ,
+    exception_t status,
+    seL4_Fault_t ipcFault
+#endif /* not CONFIG_KERNEL_MCS */
+);
 
-    }
-}
+#ifdef CONFIG_DEBUG_BUILD
 
+void debug_printKernelEntryReason(void);
 /* Prints the user context and stack trace of the current thread */
-static inline void debug_printUserState(void)
-{
-    tcb_t *tptr = NODE_STATE(ksCurThread);
-    printf("Current thread: %s\n", TCB_PTR_DEBUG_PTR(tptr)->tcbName);
-    printf("Next instruction adress: %lx\n", getRestartPC(tptr));
-    printf("Stack:\n");
-    Arch_userStackTrace(tptr);
-}
+void debug_printUserState(void);
+void debug_printTCB(tcb_t *tcb);
+void debug_dumpScheduler(void);
 
-static inline void debug_printTCB(tcb_t *tcb)
-{
-    printf("%40s\t", TCB_PTR_DEBUG_PTR(tcb)->tcbName);
-    char *state;
-    switch (thread_state_get_tsType(tcb->tcbState)) {
-    case ThreadState_Inactive:
-        state = "inactive";
-        break;
-    case ThreadState_Running:
-        state = "running";
-        break;
-    case ThreadState_Restart:
-        state = "restart";
-        break;
-    case ThreadState_BlockedOnReceive:
-        state = "blocked on recv";
-        break;
-    case ThreadState_BlockedOnSend:
-        state = "blocked on send";
-        break;
-    case ThreadState_BlockedOnReply:
-        state = "blocked on reply";
-        break;
-    case ThreadState_BlockedOnNotification:
-        state = "blocked on ntfn";
-        break;
-#ifdef CONFIG_VTX
-    case ThreadState_RunningVM:
-        state = "running VM";
-        break;
-#endif
-    case ThreadState_IdleThreadState:
-        state = "idle";
-        break;
-    default:
-        fail("Unknown thread state");
-    }
-
-    word_t core = SMP_TERNARY(tcb->tcbAffinity, 0);
-    printf("%15s\t%p\t%20lu\t%lu", state, (void *) getRestartPC(tcb), tcb->tcbPriority, core);
-#ifdef CONFIG_KERNEL_MCS
-    printf("\t%lu", (word_t) thread_state_get_tcbInReleaseQueue(tcb->tcbState));
-#endif
-    printf("\n");
-}
-
-static inline void debug_dumpScheduler(void)
-{
-    printf("Dumping all tcbs!\n");
-    printf("Name                                    \tState          \tIP                  \t Prio \t Core%s\n",
-           config_set(CONFIG_KERNEL_MCS) ?  "\t InReleaseQueue" : "");
-    printf("--------------------------------------------------------------------------------------\n");
-    for (tcb_t *curr = NODE_STATE(ksDebugTCBs); curr != NULL; curr = TCB_PTR_DEBUG_PTR(curr)->tcbDebugNext) {
-        debug_printTCB(curr);
-    }
-}
-#endif /* CONFIG_PRINTING */
 #endif /* CONFIG_DEBUG_BUILD */
 
+#endif /* CONFIG_PRINTING */

--- a/include/arch/arm/arch/kernel/vspace.h
+++ b/include/arch/arm/arch/kernel/vspace.h
@@ -41,8 +41,3 @@ vm_rights_t CONST maskVMRights(vm_rights_t vm_rights,
 
 exception_t decodeARMMMUInvocation(word_t invLabel, word_t length, cptr_t cptr,
                                    cte_t *cte, cap_t cap, word_t *buffer);
-
-#ifdef CONFIG_PRINTING
-void Arch_userStackTrace(tcb_t *tptr);
-#endif
-

--- a/include/arch/riscv/arch/kernel/vspace.h
+++ b/include/arch/riscv/arch/kernel/vspace.h
@@ -58,8 +58,3 @@ exception_t performPageInvocationMapPTE(cap_t cap, cte_t *ctSlot,
                                         pte_t pte, pte_t *base);
 exception_t performPageInvocationUnmap(cap_t cap, cte_t *ctSlot);
 void setVMRoot(tcb_t *tcb);
-
-#ifdef CONFIG_PRINTING
-void Arch_userStackTrace(tcb_t *tptr);
-#endif
-

--- a/include/arch/x86/arch/kernel/vspace.h
+++ b/include/arch/x86/arch/kernel/vspace.h
@@ -124,12 +124,7 @@ pde_t CONST makeUserPDEPageTable(paddr_t paddr, vm_attributes_t vm_attr);
 pde_t CONST makeUserPDEInvalid(void);
 
 
-#ifdef CONFIG_PRINTING
-void Arch_userStackTrace(tcb_t *tptr);
-#endif
-
 static inline bool_t checkVPAlignment(vm_page_size_t sz, word_t w)
 {
     return IS_ALIGNED(w, pageBitsForSize(sz));
 }
-

--- a/include/kernel/vspace.h
+++ b/include/kernel/vspace.h
@@ -12,3 +12,6 @@
 exception_t benchmark_arch_map_logBuffer(word_t frame_cptr);
 #endif /* CONFIG_KERNEL_LOG_BUFFER */
 
+#ifdef CONFIG_PRINTING
+void Arch_userStackTrace(tcb_t *tptr);
+#endif /* CONFIG_PRINTING */

--- a/src/config.cmake
+++ b/src/config.cmake
@@ -20,6 +20,7 @@ add_sources(
         src/kernel/thread.c
         src/kernel/boot.c
         src/kernel/stack.c
+        src/kernel/debug.c
         src/object/notification.c
         src/object/cnode.c
         src/object/endpoint.c

--- a/src/kernel/debug.c
+++ b/src/kernel/debug.c
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2014, General Dynamics C4 Systems
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#include <config.h>
+
+#ifdef CONFIG_PRINTING
+
+#include <types.h>
+#include <api/debug.h>
+#include <machine/io.h>
+#include <kernel/thread.h>
+
+static void print_fault(seL4_Fault_t f)
+{
+    seL4_Word fault_type = seL4_Fault_get_seL4_FaultType(f);
+    switch (fault_type) {
+    case seL4_Fault_NullFault:
+        printf("null fault");
+        break;
+    case seL4_Fault_CapFault:
+        printf("cap fault in %s phase at address %p",
+               seL4_Fault_CapFault_get_inReceivePhase(f) ? "receive" : "send",
+               (void *)seL4_Fault_CapFault_get_address(f));
+        break;
+    case seL4_Fault_VMFault:
+        printf("vm fault on %s at address %p with status %p",
+               seL4_Fault_VMFault_get_instructionFault(f) ? "code" : "data",
+               (void *)seL4_Fault_VMFault_get_address(f),
+               (void *)seL4_Fault_VMFault_get_FSR(f));
+        break;
+    case seL4_Fault_UnknownSyscall:
+        printf("unknown syscall %p",
+               (void *)seL4_Fault_UnknownSyscall_get_syscallNumber(f));
+        break;
+    case seL4_Fault_UserException:
+        printf("user exception %p code %p",
+               (void *)seL4_Fault_UserException_get_number(f),
+               (void *)seL4_Fault_UserException_get_code(f));
+        break;
+#ifdef CONFIG_KERNEL_MCS
+    case seL4_Fault_Timeout:
+        printf("Timeout fault for badge %p",
+               (void *)seL4_Fault_Timeout_get_badge(f));
+        break;
+#endif
+    default:
+        printf("unknown fault type %"SEL4_PRIu_word, fault_type);
+        break;
+    }
+}
+
+void debug_print_fault_handler(
+    tcb_t *tptr,
+    seL4_Fault_t fault
+#ifndef CONFIG_KERNEL_MCS
+    ,
+    exception_t status,
+    seL4_Fault_t ipcFault
+#endif /* not CONFIG_KERNEL_MCS */
+)
+{
+
+#ifdef CONFIG_KERNEL_MCS
+    printf("Found thread has no fault handler while trying to handle:\n");
+#else /* not CONFIG_KERNEL_MCS */
+    printf("Caught ");
+    print_fault(ipcFault);
+    printf("with IPC send status 0x%"SEL4_PRIx_word"\n"
+           "while trying to handle:\n",
+           status);
+#endif /* [not] CONFIG_KERNEL_MCS */
+    print_fault(fault);
+
+    const char *name = config_ternary(CONFIG_DEBUG_BUILD,
+                                      TCB_PTR_DEBUG_PTR(tptr)->tcbName,
+                                      null);
+
+    printf("\n"
+           "in thread %p%s%s%s at address %"SEL4_PRIx_word"\n"
+           "With stack:\n",
+           tptr,
+           name ? " (" : "",
+           name,
+           name ? ")" : "",
+           getRestartPC(tptr));
+
+    Arch_userStackTrace(tptr);
+}
+
+#ifdef CONFIG_DEBUG_BUILD
+
+void debug_printKernelEntryReason(void)
+{
+    printf("\nKernel entry via ");
+    switch (ksKernelEntry.path) {
+    case Entry_Interrupt:
+        printf("Interrupt, irq %lu\n", (unsigned long) ksKernelEntry.word);
+        break;
+    case Entry_UnknownSyscall:
+        printf("Unknown syscall, word: %lu", (unsigned long) ksKernelEntry.word);
+        break;
+    case Entry_VMFault:
+        printf("VM Fault, fault type: %lu\n", (unsigned long) ksKernelEntry.word);
+        break;
+    case Entry_UserLevelFault:
+        printf("User level fault, number: %lu", (unsigned long) ksKernelEntry.word);
+        break;
+#ifdef CONFIG_HARDWARE_DEBUG_API
+    case Entry_DebugFault:
+        printf("Debug fault. Fault Vaddr: 0x%lx", (unsigned long) ksKernelEntry.word);
+        break;
+#endif
+    case Entry_Syscall:
+        printf("Syscall, number: %ld, %s\n", (long) ksKernelEntry.syscall_no, syscall_names[ksKernelEntry.syscall_no]);
+        if (ksKernelEntry.syscall_no == -SysSend ||
+            ksKernelEntry.syscall_no == -SysNBSend ||
+            ksKernelEntry.syscall_no == -SysCall) {
+
+            printf("Cap type: %lu, Invocation tag: %lu\n", (unsigned long) ksKernelEntry.cap_type,
+                   (unsigned long) ksKernelEntry.invocation_tag);
+        }
+        break;
+#ifdef CONFIG_ARCH_ARM
+    case Entry_VCPUFault:
+        printf("VCPUFault\n");
+        break;
+#endif
+#ifdef CONFIG_ARCH_x86
+    case Entry_VMExit:
+        printf("VMExit\n");
+        break;
+#endif
+    default:
+        printf("Unknown (%u)\n", ksKernelEntry.path);
+        break;
+
+    }
+}
+
+void debug_printUserState(void)
+{
+    tcb_t *tptr = NODE_STATE(ksCurThread);
+    printf("Current thread: %s\n", TCB_PTR_DEBUG_PTR(tptr)->tcbName);
+    printf("Next instruction adress: %lx\n", getRestartPC(tptr));
+    printf("Stack:\n");
+    Arch_userStackTrace(tptr);
+}
+
+void debug_printTCB(tcb_t *tcb)
+{
+    printf("%40s\t", TCB_PTR_DEBUG_PTR(tcb)->tcbName);
+    char *state;
+    switch (thread_state_get_tsType(tcb->tcbState)) {
+    case ThreadState_Inactive:
+        state = "inactive";
+        break;
+    case ThreadState_Running:
+        state = "running";
+        break;
+    case ThreadState_Restart:
+        state = "restart";
+        break;
+    case ThreadState_BlockedOnReceive:
+        state = "blocked on recv";
+        break;
+    case ThreadState_BlockedOnSend:
+        state = "blocked on send";
+        break;
+    case ThreadState_BlockedOnReply:
+        state = "blocked on reply";
+        break;
+    case ThreadState_BlockedOnNotification:
+        state = "blocked on ntfn";
+        break;
+#ifdef CONFIG_VTX
+    case ThreadState_RunningVM:
+        state = "running VM";
+        break;
+#endif
+    case ThreadState_IdleThreadState:
+        state = "idle";
+        break;
+    default:
+        fail("Unknown thread state");
+    }
+
+    word_t core = SMP_TERNARY(tcb->tcbAffinity, 0);
+    printf("%15s\t%p\t%20lu\t%lu", state, (void *) getRestartPC(tcb), tcb->tcbPriority, core);
+#ifdef CONFIG_KERNEL_MCS
+    printf("\t%lu", (word_t) thread_state_get_tcbInReleaseQueue(tcb->tcbState));
+#endif
+    printf("\n");
+}
+
+void debug_dumpScheduler(void)
+{
+    printf("Dumping all tcbs!\n");
+    printf("Name                                    \tState          \tIP                  \t Prio \t Core%s\n",
+           config_set(CONFIG_KERNEL_MCS) ?  "\t InReleaseQueue" : "");
+    printf("--------------------------------------------------------------------------------------\n");
+    for (tcb_t *curr = NODE_STATE(ksDebugTCBs); curr != NULL; curr = TCB_PTR_DEBUG_PTR(curr)->tcbDebugNext) {
+        debug_printTCB(curr);
+    }
+}
+
+#endif /* CONFIG_DEBUG_BUILD */
+#endif /* CONFIG_PRINTING */


### PR DESCRIPTION
Improve the messages a bit to no talk about a "cap fault" just because there is no fault handler. Print a register snapshot besides the stack dump if  `CONFIG_DEBUG_BUILD` is enabled.

Fault printout for a null pointer dereferecne on RISC-V
```
## ==============================================================
## FAULT at PC=0x0 in thread 0xffffffc17fec7200 (rootserver)
## Cause: access fault on code at address 0x0, status 0x1
## Thread suspended, no userland fault handler (code 0, cap type 0)
## State snapshot:
##     x1/ra: 0x00000000'000150c6     x2/sp: 0x00000000'00143ea0
##     x3/gp: 0x00000000'00024800     x4/tp: 0x00000000'00144000
##     x5/t0: 0x00000000'00000000     x6/t1: 0x00000000'0001f5d8
##     x7/t2: 0x00000000'00000000     x8/s0: 0x00000000'00143ec0
##     x9/s1: 0x00000000'00000000    x10/a0: 0x00000000'00000000
##    x11/a1: 0x00000000'00000000    x12/a2: 0x00000000'00000000
##    x13/a3: 0x00000000'00000000    x14/a4: 0x00000000'00000000
##    x15/a5: 0x00000000'00000000    x16/a6: 0x00000000'00000000
##    x17/a7: 0xffffffff'fffffff7    x18/s2: 0x00000000'00000000
##    x19/s3: 0x00000000'00000000    x20/s4: 0x00000000'00000000
##    x21/s5: 0x00000000'00000000    x22/s6: 0x00000000'00000000
##    x23/s7: 0x00000000'00000000    x24/s8: 0x00000000'00000000
##    x25/s9: 0x00000000'00000000   x26/s10: 0x00000000'00000000
##   x27/s11: 0x00000000'00000000    x28/t3: 0x00000000'00000012
##    x29/t4: 0x00000000'20000000    x30/t5: 0x00000000'00000000
##    x31/t6: 0x00000000'00000000    scause: 0x00000000'0000000c
##   sstatus: 0x00000000'00000020   FaultIP: 0x00000000'00000000
##    NextIP: 0x00000000'00000000
##

Stack trace:
0x143ea0: 0x143ec0
0x143ea8: 0x101ea
0x143eb0: 0x143f00
0x143eb8: 0x14bcc
0x143ec0: 0x0
0x143ec8: 0x143f30
0x143ed0: 0x143f20
0x143ed8: 0x143f10
0x143ee0: 0x1
0x143ee8: 0x101d6
0x143ef0: 0x144000
0x143ef8: 0x14cf8
0x143f00: 0x0
0x143f08: 0x14a000
0x143f10: 0x20280
```

Scheduler dump ("RelQ" is only visible with MCS, "Core" only with SMP)
```
Dump of all TCBs (4):
  TCB              | State         | PC               | Prio | Core | RelQ | Name
  -----------------+---------------+------------------+------+------+------+----------------
  ffffffc100137600 | blocked/recv  | 1053a            |  255 |    0 |   no | main:fault_handler
  ffffffc100137200 | running       | 101f0            |  254 |    0 |   no | main:control
  ffffffff84028000 | idle          | 0                |    0 |    0 |   no | idle_thread
  ffffffc27ff0a200 | inactive      | 105dc            |  255 |    0 |   no | rootserver
```
