### PR TITLE
avoid invoking scheduler when setting log buffer

### DIFF
--- a/src/api/syscall.c
+++ b/src/api/syscall.c
@@ -239,10 +239,9 @@ exception_t handleUnknownSyscall(word_t w)
             setRegister(NODE_STATE(ksCurThread), capRegister, seL4_IllegalOperation);
             return EXCEPTION_SYSCALL_ERROR;
         }
-
+#endif /* CONFIG_KERNEL_LOG_BUFFER */
         setRegister(NODE_STATE(ksCurThread), capRegister, seL4_NoError);
         return EXCEPTION_NONE;
-#endif /* CONFIG_KERNEL_LOG_BUFFER */
     }
 
 #ifdef CONFIG_BENCHMARK_TRACK_UTILISATION


### PR DESCRIPTION
make `SysBenchmarkSetLogBuffer` a no-op if `CONFIG_KERNEL_LOG_BUFFER` is not set instead of invoking the scheduler. That aligns the behavior with the other benchmarking syscalls that also return in their dedicated handler.

I've found this while taking over https://github.com/seL4/seL4/pull/298 and I'm not sure if `setRegister(NODE_STATE(ksCurThread), capRegister, seL4_NoError)` is a goot idea if `CONFIG_KERNEL_LOG_BUFFER` is not set. It could set `seL4_IllegalOperation` instead to tell the user that the syscall does not work in this case. Halting the kernel with an error might also be an option, as this is likely a misconfiguration and there is no point in continuing.
On a similar case, `SysBenchmarkFinalizeLog` also leaves `capRegister` then, maybe `0` or `-1` should be set in this case to have a well-define behavior?

