### PR TITLE
align include guards for seL4_DebugSendIPI()

### DIFF
--- a/libsel4/arch_include/arm/sel4/arch/syscalls.h
+++ b/libsel4/arch_include/arm/sel4/arch/syscalls.h
@@ -644,12 +644,12 @@ LIBSEL4_INLINE_FUNC void seL4_DebugNameThread(seL4_CPtr tcb, const char *name)
     arm_sys_send_recv(seL4_SysDebugNameThread, tcb, &unused0, 0, &unused1, &unused2, &unused3, &unused4, &unused5, 0);
 }
 
-#if CONFIG_MAX_NUM_NODES > 1
+#if CONFIG_ENABLE_SMP_SUPPORT
 LIBSEL4_INLINE_FUNC void seL4_DebugSendIPI(seL4_Uint8 target, unsigned irq)
 {
     arm_sys_send(seL4_SysDebugSendIPI, target, irq, 0, 0, 0, 0);
 }
-#endif
+#endif /* CONFIG_ENABLE_SMP_SUPPORT */
 #endif
 
 #ifdef CONFIG_DANGEROUS_CODE_INJECTION

--- a/libsel4/include/api/syscall.xml
+++ b/libsel4/include/api/syscall.xml
@@ -47,7 +47,7 @@
             <syscall name="DebugSnapshot" />
             <syscall name="DebugNameThread"/>
         </config>
-        <config condition="defined CONFIG_DEBUG_BUILD &amp;&amp; CONFIG_MAX_NUM_NODES > 1">
+        <config condition="defined CONFIG_DEBUG_BUILD &amp;&amp; defined CONFIG_ENABLE_SMP_SUPPORT">
             <syscall name="DebugSendIPI"/>
         </config>
         <config condition="defined CONFIG_DANGEROUS_CODE_INJECTION">


### PR DESCRIPTION
Align the API wrapper guards with the kernel syscall implementation, the function is available if `CONFIG_ENABLE_SMP_SUPPORT` is set instead of depending on `CONFIG_MAX_NUM_NODES`.
