### PR TITLE
riscv: add missing benchmark function

### DIFF
--- a/include/arch/riscv/arch/benchmark.h
+++ b/include/arch/riscv/arch/benchmark.h
@@ -16,5 +16,11 @@ static inline timestamp_t timestamp(void)
 {
     return riscv_read_cycle();
 }
+
+static inline void benchmark_arch_utilisation_reset(void)
+{
+    /* nothing here */
+}
+
 #endif /* CONFIG_ENABLE_BENCHMARK */
 


### PR DESCRIPTION
Compilation on RISC-V with `set(KernelBenchmarks "track_utilisation" CACHE STRING "" FORCE)` fails because `benchmark_arch_utilisation_reset()`is missing.