### PR TITLE
Move debug implementation out of syscall.c

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -6,12 +6,28 @@
 
 #pragma once
 
+#include <config.h>
 #include <arch/benchmark.h>
 #include <machine/io.h>
 #include <sel4/arch/constants.h>
 #include <arch/machine/hardware.h>
 #include <sel4/benchmark_tracepoints_types.h>
 #include <mode/hardware.h>
+
+#ifdef CONFIG_ENABLE_BENCHMARKS
+exception_t handle_SysBenchmarkFlushCaches(void);
+exception_t handle_SysBenchmarkResetLog(void);
+exception_t handle_SysBenchmarkFinalizeLog(void);
+exception_t handle_SysBenchmarkSetLogBuffer(void);
+#ifdef CONFIG_BENCHMARK_TRACK_UTILISATION
+exception_t handle_SysBenchmarkGetThreadUtilisation(void);
+exception_t handle_SysBenchmarkResetThreadUtilisation(void);
+#ifdef CONFIG_DEBUG_BUILD
+exception_t handle_SysBenchmarkDumpAllThreadsUtilisation(void);
+exception_t handle_SysBenchmarkResetAllThreadsUtilisation(void);
+#endif /* CONFIG_DEBUG_BUILD */
+#endif /* CONFIG_BENCHMARK_TRACK_UTILISATION */
+#endif /* CONFIG_ENABLE_BENCHMARKS */
 
 #if CONFIG_MAX_NUM_TRACE_POINTS > 0
 #define TRACE_POINT_START(x) trace_point_start(x)

--- a/include/smp/ipi.h
+++ b/include/smp/ipi.h
@@ -155,5 +155,10 @@ static void inline doRemoteOp3Arg(IpiRemoteCall_t func, word_t data1, word_t dat
  */
 void doMaskReschedule(word_t mask);
 
+
+#ifdef CONFIG_DEBUG_BUILD
+exception_t handle_SysDebugSendIPI(void);
+#endif
+
 #endif /* ENABLE_SMP_SUPPORT */
 

--- a/src/api/syscall.c
+++ b/src/api/syscall.c
@@ -185,124 +185,32 @@ exception_t handleUnknownSyscall(word_t w)
 #endif
 
 #ifdef CONFIG_ENABLE_BENCHMARKS
-    if (w == SysBenchmarkFlushCaches) {
-#ifdef CONFIG_ARCH_ARM
-        tcb_t *thread = NODE_STATE(ksCurThread);
-        if (getRegister(thread, capRegister)) {
-            arch_clean_invalidate_L1_caches(getRegister(thread, msgInfoRegister));
-        } else {
-            arch_clean_invalidate_caches();
-        }
-#else
-        arch_clean_invalidate_caches();
-#endif
-        return EXCEPTION_NONE;
-    } else if (w == SysBenchmarkResetLog) {
-#ifdef CONFIG_KERNEL_LOG_BUFFER
-        if (ksUserLogBuffer == 0) {
-            userError("A user-level buffer has to be set before resetting benchmark.\
-                    Use seL4_BenchmarkSetLogBuffer\n");
-            setRegister(NODE_STATE(ksCurThread), capRegister, seL4_IllegalOperation);
-            return EXCEPTION_SYSCALL_ERROR;
-        }
-
-        ksLogIndex = 0;
-#endif /* CONFIG_KERNEL_LOG_BUFFER */
+    switch (w) {
+    case SysBenchmarkFlushCaches:
+        return handle_SysBenchmarkFlushCaches();
+    case SysBenchmarkResetLog:
+        return handle_SysBenchmarkResetLog();
+    case SysBenchmarkFinalizeLog:
+        return handle_SysBenchmarkFinalizeLog();
+    case SysBenchmarkSetLogBuffer:
+        return handle_SysBenchmarkSetLogBuffer();
 #ifdef CONFIG_BENCHMARK_TRACK_UTILISATION
-        NODE_STATE(benchmark_log_utilisation_enabled) = true;
-        benchmark_track_reset_utilisation(NODE_STATE(ksIdleThread));
-        NODE_STATE(ksCurThread)->benchmark.schedule_start_time = ksEnter;
-        NODE_STATE(ksCurThread)->benchmark.number_schedules++;
-
-        NODE_STATE(benchmark_start_time) = ksEnter;
-        NODE_STATE(benchmark_kernel_time) = 0;
-        NODE_STATE(benchmark_kernel_number_entries) = 0;
-        NODE_STATE(benchmark_kernel_number_schedules) = 1;
-        benchmark_arch_utilisation_reset();
-#endif /* CONFIG_BENCHMARK_TRACK_UTILISATION */
-        setRegister(NODE_STATE(ksCurThread), capRegister, seL4_NoError);
-        return EXCEPTION_NONE;
-    } else if (w == SysBenchmarkFinalizeLog) {
-#ifdef CONFIG_KERNEL_LOG_BUFFER
-        ksLogIndexFinalized = ksLogIndex;
-        setRegister(NODE_STATE(ksCurThread), capRegister, ksLogIndexFinalized);
-#endif /* CONFIG_KERNEL_LOG_BUFFER */
-#ifdef CONFIG_BENCHMARK_TRACK_UTILISATION
-        benchmark_utilisation_finalise();
-#endif /* CONFIG_BENCHMARK_TRACK_UTILISATION */
-        return EXCEPTION_NONE;
-    } else if (w == SysBenchmarkSetLogBuffer) {
-#ifdef CONFIG_KERNEL_LOG_BUFFER
-        word_t cptr_userFrame = getRegister(NODE_STATE(ksCurThread), capRegister);
-
-        if (benchmark_arch_map_logBuffer(cptr_userFrame) != EXCEPTION_NONE) {
-            setRegister(NODE_STATE(ksCurThread), capRegister, seL4_IllegalOperation);
-            return EXCEPTION_SYSCALL_ERROR;
-        }
-#endif /* CONFIG_KERNEL_LOG_BUFFER */
-        setRegister(NODE_STATE(ksCurThread), capRegister, seL4_NoError);
-        return EXCEPTION_NONE;
-    }
-
-#ifdef CONFIG_BENCHMARK_TRACK_UTILISATION
-    else if (w == SysBenchmarkGetThreadUtilisation) {
-        benchmark_track_utilisation_dump();
-        return EXCEPTION_NONE;
-    } else if (w == SysBenchmarkResetThreadUtilisation) {
-        word_t tcb_cptr = getRegister(NODE_STATE(ksCurThread), capRegister);
-        lookupCap_ret_t lu_ret;
-        word_t cap_type;
-
-        lu_ret = lookupCap(NODE_STATE(ksCurThread), tcb_cptr);
-        /* ensure we got a TCB cap */
-        cap_type = cap_get_capType(lu_ret.cap);
-        if (cap_type != cap_thread_cap) {
-            userError("SysBenchmarkResetThreadUtilisation: cap is not a TCB, halting");
-            return EXCEPTION_NONE;
-        }
-
-        tcb_t *tcb = TCB_PTR(cap_thread_cap_get_capTCBPtr(lu_ret.cap));
-
-        benchmark_track_reset_utilisation(tcb);
-        return EXCEPTION_NONE;
-    }
+    case SysBenchmarkGetThreadUtilisation:
+        return handle_SysBenchmarkGetThreadUtilisation();
+    case SysBenchmarkResetThreadUtilisation:
+        return handle_SysBenchmarkResetThreadUtilisation();
 #ifdef CONFIG_DEBUG_BUILD
-    else if (w == SysBenchmarkDumpAllThreadsUtilisation) {
-        printf("{\n");
-        printf("  \"BENCHMARK_TOTAL_UTILISATION\":%lu,\n",
-               (word_t)(NODE_STATE(benchmark_end_time) - NODE_STATE(benchmark_start_time)));
-        printf("  \"BENCHMARK_TOTAL_KERNEL_UTILISATION\":%lu,\n", (word_t) NODE_STATE(benchmark_kernel_time));
-        printf("  \"BENCHMARK_TOTAL_NUMBER_KERNEL_ENTRIES\":%lu,\n", (word_t) NODE_STATE(benchmark_kernel_number_entries));
-        printf("  \"BENCHMARK_TOTAL_NUMBER_SCHEDULES\":%lu,\n", (word_t) NODE_STATE(benchmark_kernel_number_schedules));
-        printf("  \"BENCHMARK_TCB_\": [\n");
-        for (tcb_t *curr = NODE_STATE(ksDebugTCBs); curr != NULL; curr = TCB_PTR_DEBUG_PTR(curr)->tcbDebugNext) {
-            printf("    {\n");
-            printf("      \"NAME\":\"%s\",\n", TCB_PTR_DEBUG_PTR(curr)->tcbName);
-            printf("      \"UTILISATION\":%lu,\n", (word_t) curr->benchmark.utilisation);
-            printf("      \"NUMBER_SCHEDULES\":%lu,\n", (word_t) curr->benchmark.number_schedules);
-            printf("      \"KERNEL_UTILISATION\":%lu,\n", (word_t) curr->benchmark.kernel_utilisation);
-            printf("      \"NUMBER_KERNEL_ENTRIES\":%lu\n", (word_t) curr->benchmark.number_kernel_entries);
-            printf("    }");
-            if (TCB_PTR_DEBUG_PTR(curr)->tcbDebugNext != NULL) {
-                printf(",\n");
-            } else {
-                printf("\n");
-            }
-        }
-        printf("  ]\n}\n");
-        return EXCEPTION_NONE;
-    } else if (w == SysBenchmarkResetAllThreadsUtilisation) {
-        for (tcb_t *curr = NODE_STATE(ksDebugTCBs); curr != NULL; curr = TCB_PTR_DEBUG_PTR(curr)->tcbDebugNext) {
-            benchmark_track_reset_utilisation(curr);
-        }
-        return EXCEPTION_NONE;
-    }
+    case SysBenchmarkDumpAllThreadsUtilisation:
+        return handle_SysBenchmarkDumpAllThreadsUtilisation();
+    case SysBenchmarkResetAllThreadsUtilisation:
+        return handle_SysBenchmarkResetAllThreadsUtilisation();
 #endif /* CONFIG_DEBUG_BUILD */
 #endif /* CONFIG_BENCHMARK_TRACK_UTILISATION */
-
-    else if (w == SysBenchmarkNullSyscall) {
+    case SysBenchmarkNullSyscall:
         return EXCEPTION_NONE;
-    }
+    default:
+        break; /* syscall is not for benchmarking */
+    } /* end switch(w) */
 #endif /* CONFIG_ENABLE_BENCHMARKS */
 
     MCS_DO_IF_BUDGET({

--- a/src/benchmark/benchmark.c
+++ b/src/benchmark/benchmark.c
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2016, General Dynamics C4 Systems
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#include <config.h>
+
+#ifdef CONFIG_ENABLE_BENCHMARKS
+
+#include <types.h>
+#include <mode/machine.h>
+#include <benchmark/benchmark.h>
+#include <benchmark/benchmark_utilisation.h>
+
+
+exception_t handle_SysBenchmarkFlushCaches(void)
+{
+#ifdef CONFIG_ARCH_ARM
+    tcb_t *thread = NODE_STATE(ksCurThread);
+    if (getRegister(thread, capRegister)) {
+        arch_clean_invalidate_L1_caches(getRegister(thread, msgInfoRegister));
+    } else {
+        arch_clean_invalidate_caches();
+    }
+#else
+    arch_clean_invalidate_caches();
+#endif
+    return EXCEPTION_NONE;
+}
+
+exception_t handle_SysBenchmarkResetLog(void)
+{
+#ifdef CONFIG_ENABLE_KERNEL_LOG_BUFFER
+    if (ksUserLogBuffer == 0) {
+        userError("A user-level buffer has to be set before resetting benchmark.\
+                Use seL4_BenchmarkSetLogBuffer\n");
+        setRegister(NODE_STATE(ksCurThread), capRegister, seL4_IllegalOperation);
+        return EXCEPTION_SYSCALL_ERROR;
+    }
+
+    ksLogIndex = 0;
+#endif /* CONFIG_ENABLE_KERNEL_LOG_BUFFER */
+
+#ifdef CONFIG_BENCHMARK_TRACK_UTILISATION
+    NODE_STATE(benchmark_log_utilisation_enabled) = true;
+    benchmark_track_reset_utilisation(NODE_STATE(ksIdleThread));
+    NODE_STATE(ksCurThread)->benchmark.schedule_start_time = ksEnter;
+    NODE_STATE(ksCurThread)->benchmark.number_schedules++;
+    NODE_STATE(benchmark_start_time) = ksEnter;
+    NODE_STATE(benchmark_kernel_time) = 0;
+    NODE_STATE(benchmark_kernel_number_entries) = 0;
+    NODE_STATE(benchmark_kernel_number_schedules) = 1;
+    benchmark_arch_utilisation_reset();
+#endif /* CONFIG_BENCHMARK_TRACK_UTILISATION */
+
+    setRegister(NODE_STATE(ksCurThread), capRegister, seL4_NoError);
+    return EXCEPTION_NONE;
+}
+
+exception_t handle_SysBenchmarkFinalizeLog(void)
+{
+#ifdef CONFIG_ENABLE_KERNEL_LOG_BUFFER
+    ksLogIndexFinalized = ksLogIndex;
+    setRegister(NODE_STATE(ksCurThread), capRegister, ksLogIndexFinalized);
+#endif /* CONFIG_ENABLE_KERNEL_LOG_BUFFER */
+
+#ifdef CONFIG_BENCHMARK_TRACK_UTILISATION
+    benchmark_utilisation_finalise();
+#endif /* CONFIG_BENCHMARK_TRACK_UTILISATION */
+
+    return EXCEPTION_NONE;
+}
+
+exception_t handle_SysBenchmarkSetLogBuffer(void)
+{
+#ifdef CONFIG_ENABLE_KERNEL_LOG_BUFFER
+    word_t cptr_userFrame = getRegister(NODE_STATE(ksCurThread), capRegister);
+    if (benchmark_arch_map_logBuffer(cptr_userFrame) != EXCEPTION_NONE) {
+        setRegister(NODE_STATE(ksCurThread), capRegister, seL4_IllegalOperation);
+        return EXCEPTION_SYSCALL_ERROR;
+    }
+#endif /* CONFIG_ENABLE_KERNEL_LOG_BUFFER */
+
+    /* ToDo: If CONFIG_ENABLE_KERNEL_LOG_BUFFER is not set it might be better to
+     *       fail the syscall or even call halt(), because the system setup or
+     *       the configuration seems broken. Silently ignoring this pretending
+     *       the log buffer got set up might be confusing.
+     */
+    setRegister(NODE_STATE(ksCurThread), capRegister, seL4_NoError);
+    return EXCEPTION_NONE;
+}
+
+#ifdef CONFIG_BENCHMARK_TRACK_UTILISATION
+
+exception_t handle_SysBenchmarkGetThreadUtilisation(void)
+{
+    benchmark_track_utilisation_dump();
+    return EXCEPTION_NONE;
+}
+
+exception_t handle_SysBenchmarkResetThreadUtilisation(void)
+{
+    word_t tcb_cptr = getRegister(NODE_STATE(ksCurThread), capRegister);
+    lookupCap_ret_t lu_ret;
+    word_t cap_type;
+
+    lu_ret = lookupCap(NODE_STATE(ksCurThread), tcb_cptr);
+    /* ensure we got a TCB cap */
+    cap_type = cap_get_capType(lu_ret.cap);
+    if (cap_type != cap_thread_cap) {
+        userError("SysBenchmarkResetThreadUtilisation: cap is not a TCB, halting");
+        return EXCEPTION_NONE;
+    }
+
+    tcb_t *tcb = TCB_PTR(cap_thread_cap_get_capTCBPtr(lu_ret.cap));
+
+    benchmark_track_reset_utilisation(tcb);
+    return EXCEPTION_NONE;
+}
+
+#ifdef CONFIG_DEBUG_BUILD
+
+exception_t handle_SysBenchmarkDumpAllThreadsUtilisation(void)
+{
+    printf("{\n");
+    printf("  \"BENCHMARK_TOTAL_UTILISATION\":%lu,\n",
+           (word_t)(NODE_STATE(benchmark_end_time) - NODE_STATE(benchmark_start_time)));
+    printf("  \"BENCHMARK_TOTAL_KERNEL_UTILISATION\":%lu,\n", (word_t) NODE_STATE(benchmark_kernel_time));
+    printf("  \"BENCHMARK_TOTAL_NUMBER_KERNEL_ENTRIES\":%lu,\n", (word_t) NODE_STATE(benchmark_kernel_number_entries));
+    printf("  \"BENCHMARK_TOTAL_NUMBER_SCHEDULES\":%lu,\n", (word_t) NODE_STATE(benchmark_kernel_number_schedules));
+    printf("  \"BENCHMARK_TCB_\": [\n");
+    for (tcb_t *curr = NODE_STATE(ksDebugTCBs); curr != NULL; curr = TCB_PTR_DEBUG_PTR(curr)->tcbDebugNext) {
+        printf("    {\n");
+        printf("      \"NAME\":\"%s\",\n", TCB_PTR_DEBUG_PTR(curr)->tcbName);
+        printf("      \"UTILISATION\":%lu,\n", (word_t) curr->benchmark.utilisation);
+        printf("      \"NUMBER_SCHEDULES\":%lu,\n", (word_t) curr->benchmark.number_schedules);
+        printf("      \"KERNEL_UTILISATION\":%lu,\n", (word_t) curr->benchmark.kernel_utilisation);
+        printf("      \"NUMBER_KERNEL_ENTRIES\":%lu\n", (word_t) curr->benchmark.number_kernel_entries);
+        printf("    }");
+        if (TCB_PTR_DEBUG_PTR(curr)->tcbDebugNext != NULL) {
+            printf(",\n");
+        } else {
+            printf("\n");
+        }
+    }
+    printf("  ]\n}\n");
+    return EXCEPTION_NONE;
+}
+
+exception_t handle_SysBenchmarkResetAllThreadsUtilisation(void)
+{
+    for (tcb_t *curr = NODE_STATE(ksDebugTCBs); curr != NULL; curr = TCB_PTR_DEBUG_PTR(curr)->tcbDebugNext) {
+        benchmark_track_reset_utilisation(curr);
+    }
+    return EXCEPTION_NONE;
+}
+
+#endif /* CONFIG_DEBUG_BUILD */
+#endif /* CONFIG_BENCHMARK_TRACK_UTILISATION */
+#endif /* CONFIG_ENABLE_BENCHMARKS */

--- a/src/config.cmake
+++ b/src/config.cmake
@@ -34,6 +34,7 @@ add_sources(
         src/machine/capdl.c
         src/machine/registerset.c
         src/machine/fpu.c
+        src/benchmark/benchmark.c
         src/benchmark/benchmark_track.c
         src/benchmark/benchmark_utilisation.c
         src/smp/lock.c

--- a/src/smp/ipi.c
+++ b/src/smp/ipi.c
@@ -5,11 +5,13 @@
  */
 
 #include <config.h>
+
+#ifdef ENABLE_SMP_SUPPORT
+
 #include <mode/smp/ipi.h>
 #include <smp/ipi.h>
 #include <smp/lock.h>
 
-#ifdef ENABLE_SMP_SUPPORT
 /* This function switches the core it is called on to the idle thread,
  * in order to avoid IPI storms. If the core is waiting on the lock, the actual
  * switch will not occur until the core attempts to obtain the lock, at which
@@ -142,4 +144,28 @@ void generic_ipi_send_mask(irq_t ipi, word_t mask, bool_t isBlocking)
         }
     }
 }
+
+#ifdef CONFIG_DEBUG_BUILD
+exception_t handle_SysDebugSendIPI(void)
+{
+#ifdef CONFIG_ARCH_ARM
+    word_t target = getRegister(NODE_STATE(ksCurThread), capRegister);
+    word_t irq = getRegister(NODE_STATE(ksCurThread), msgInfoRegister);
+    if (target > CONFIG_MAX_NUM_NODES) {
+        userError("SysDebugSendIPI: Invalid target, halting");
+        halt();
+    }
+    if (irq > 15) {
+        userError("SysDebugSendIPI: Invalid IRQ, not a SGI, halting");
+        halt();
+    }
+    ipi_send_target(CORE_IRQ_TO_IRQT(0, irq), BIT(target));
+    return EXCEPTION_NONE;
+#else /* not CONFIG_ARCH_ARM */
+    userError("SysDebugSendIPI: not supported on this architecture");
+    halt();
+#endif  /* [not] CONFIG_ARCH_ARM */
+}
+#endif /* CONFIG_DEBUG_BUILD */
+
 #endif /* ENABLE_SMP_SUPPORT */


### PR DESCRIPTION
Make `syscall.c` call syscall handler function for debug syscalls, so the implementation is no longer visible there. That makes the dispatcher code easier to read and maintain. Also changes in the debug syscalls no longer cause cause preprocess failures, this is all hidden from verification anyway. Furthermore the this enforces a cleaner implementation of the debug syscalls, then need to fully handle the syscall.
The PR is on top of https://github.com/seL4/seL4/pull/673 and a preparation for reworking https://github.com/seL4/seL4/pull/298 eventually.