### PR TITLE
resolve include dependency issues

### DIFF
--- a/src/arch/arm/platform_gen.h.in
+++ b/src/arch/arm/platform_gen.h.in
@@ -20,7 +20,6 @@ enum IRQConstants {
 #define IRQ_CNODE_SLOT_BITS (@CONFIGURE_IRQ_SLOT_BITS@)
 
 #include <@CONFIGURE_INTERRUPT_CONTROLLER@>
-#include <@CONFIGURE_TIMER@>
 
 #cmakedefine CONFIGURE_SMMU <@CONFIGURE_SMMU@>
 #if (defined(CONFIGURE_SMMU) && defined(CONFIG_TK1_SMMU))
@@ -37,8 +36,11 @@ enum IRQConstants {
 #endif
 
 #ifdef CONFIG_KERNEL_MCS
+#include <types.h>
 static inline CONST time_t getKernelWcetUs(void)
 {
     return @CONFIGURE_KERNEL_WCET@;
 }
-#endif
+#endif /* CONFIG_KERNEL_MCS */
+
+#include <@CONFIGURE_TIMER@>


### PR DESCRIPTION
Include the timer header after `getKernelWcetUs()` is defined.

The include quirk this resolves is that If `CONFIGURE_TIMER` is `drivers/timer/arm_global.h`, this includes `machine/timer. h` which implements the function `getKernelWcetTicks()` that calls `getKernelWcetUs()` which `src/arch/arm/platform_gen.h.in` defines. So it is better if we move the include after `getKernelWcetUs()`.