### PR TITLE
Fix getMaxUsToTicks function in RISC-V machine/timer.h

### DIFF
--- a/include/arch/riscv/arch/machine/timer.h
+++ b/include/arch/riscv/arch/machine/timer.h
@@ -39,12 +39,12 @@ static inline PURE ticks_t getTimerPrecision(void)
 
 static inline CONST ticks_t getMaxTicksToUs(void)
 {
-    return UINT64_MAX / TICKS_IN_US;
+    return UINT64_MAX;
 }
 
-static inline PURE time_t getMaxUsToTicks(void)
+static inline CONST time_t getMaxUsToTicks(void)
 {
-    return usToTicks(getMaxTicksToUs());
+    return UINT64_MAX / TICKS_IN_US;
 }
 
 /* Read the current time from the timer. */


### PR DESCRIPTION
The `getMaxUsToTicks` function is supposed to return maximum amount of time you can pass to `usToTicks` without overflow,but in RISC-V implementation it returns ticks instead. This patch corrects it so it's implementation is akin to those in other platforms.