### PR TITLE
riscv: pass hart mask by value to SBI wrappers

### DIFF
--- a/include/arch/riscv/arch/machine.h
+++ b/include/arch/riscv/arch/machine.h
@@ -82,13 +82,13 @@ static inline void ifence(void)
 {
     ifence_local();
 
-    unsigned long mask = 0;
+    word_t mask = 0;
     for (int i = 0; i < CONFIG_MAX_NUM_NODES; i++) {
         if (i != getCurrentCPUIndex()) {
             mask |= BIT(cpuIndexToID(i));
         }
     }
-    sbi_remote_fence_i(&mask);
+    sbi_remote_fence_i(mask);
 }
 
 static inline void sfence(void)
@@ -96,13 +96,13 @@ static inline void sfence(void)
     fence_w_rw();
     sfence_local();
 
-    unsigned long mask = 0;
+    word_t mask = 0;
     for (int i = 0; i < CONFIG_MAX_NUM_NODES; i++) {
         if (i != getCurrentCPUIndex()) {
             mask |= BIT(cpuIndexToID(i));
         }
     }
-    sbi_remote_sfence_vma(&mask, 0, 0);
+    sbi_remote_sfence_vma(mask, 0, 0);
 }
 
 static inline void hwASIDFlushLocal(asid_t asid)
@@ -114,13 +114,13 @@ static inline void hwASIDFlush(asid_t asid)
 {
     hwASIDFlushLocal(asid);
 
-    unsigned long mask = 0;
+    word_t mask = 0;
     for (int i = 0; i < CONFIG_MAX_NUM_NODES; i++) {
         if (i != getCurrentCPUIndex()) {
             mask |= BIT(cpuIndexToID(i));
         }
     }
-    sbi_remote_sfence_vma_asid(&mask, 0, 0, asid);
+    sbi_remote_sfence_vma_asid(mask, 0, 0, asid);
 }
 
 #else

--- a/include/arch/riscv/arch/sbi.h
+++ b/include/arch/riscv/arch/sbi.h
@@ -32,7 +32,7 @@
 
 #pragma once
 
-
+#include <config.h>
 #include <stdint.h>
 
 /* See https://github.com/riscv/riscv-sbi-doc/blob/master/riscv-sbi.adoc for
@@ -96,33 +96,62 @@ static inline void sbi_shutdown(void)
     SBI_CALL_0(SBI_SHUTDOWN);
 }
 
+#ifdef ENABLE_SMP_SUPPORT
+
 static inline void sbi_clear_ipi(void)
 {
     SBI_CALL_0(SBI_CLEAR_IPI);
 }
 
-static inline void sbi_send_ipi(const unsigned long *hart_mask)
+static inline void sbi_send_ipi(word_t hart_mask)
 {
-    SBI_CALL_1(SBI_SEND_IPI, (word_t)hart_mask);
+    /* ToDo: In the legacy SBI API the hart mask parameter is not a value, but
+     *       the virtual address of a bit vector. This was intended to allow
+     *       passing an arbitrary number of harts without being limited by the
+     *       architecture's word size. We hide this feature here because:
+     *       - All systems currently supported by the kernel have less harts
+     *           than bits in a word. Support for more harts would requires
+     *           reworking parts of the kernel.
+     *       - The legacy SBI interface is deprecated. Passing pointers with
+     *           virtual addresses has several practical drawbacks or corner
+     *           cases, these outweight the gain of being able to address all
+     *           harts in one call. The new interface uses a window concept and
+     *           passes plain values.
+     *       - Using pointers to local variables is perfectly fine in C, but
+     *           verification does not support this, because passing pointers to
+     *           stack objects is not allowed. However, verification does not
+     *           run for the RISC-V SMP configuration at the moment, thus
+     *           keeping this detail hidden here allows postponing finding a
+     *           solution and higher layers are kept agnostic of this.
+     */
+    word_t virt_addr_hart_mask = (word_t)&hart_mask;
+    SBI_CALL_1(SBI_SEND_IPI, virt_addr_hart_mask);
 }
 
-static inline void sbi_remote_fence_i(const unsigned long *hart_mask)
+static inline void sbi_remote_fence_i(word_t hart_mask)
 {
-    SBI_CALL_1(SBI_REMOTE_FENCE_I, (word_t)hart_mask);
+    /* See comment at sbi_send_ipi() about the pointer parameter. */
+    word_t virt_addr_hart_mask = (word_t)&hart_mask;
+    SBI_CALL_1(SBI_REMOTE_FENCE_I, virt_addr_hart_mask);
 }
 
-static inline void sbi_remote_sfence_vma(const unsigned long *hart_mask,
+static inline void sbi_remote_sfence_vma(word_t hart_mask,
                                          unsigned long start,
                                          unsigned long size)
 {
-    SBI_CALL_1(SBI_REMOTE_SFENCE_VMA, (word_t)hart_mask);
+    /* See comment at sbi_send_ipi() about the pointer parameter. */
+    word_t virt_addr_hart_mask = (word_t)&hart_mask;
+    SBI_CALL_1(SBI_REMOTE_SFENCE_VMA, virt_addr_hart_mask);
 }
 
-static inline void sbi_remote_sfence_vma_asid(const unsigned long *hart_mask,
+static inline void sbi_remote_sfence_vma_asid(word_t hart_mask,
                                               unsigned long start,
                                               unsigned long size,
                                               unsigned long asid)
 {
-    SBI_CALL_1(SBI_REMOTE_SFENCE_VMA_ASID, (word_t)hart_mask);
+    /* See comment at sbi_send_ipi() about the pointer parameter. */
+    word_t virt_addr_hart_mask = (word_t)&hart_mask;
+    SBI_CALL_1(SBI_REMOTE_SFENCE_VMA_ASID, virt_addr_hart_mask);
 }
 
+#endif /* ENABLE_SMP_SUPPORT */

--- a/src/arch/riscv/smp/ipi.c
+++ b/src/arch/riscv/smp/ipi.c
@@ -77,17 +77,16 @@ void ipi_clear_irq(irq_t irq)
 /* this function is called with a single hart id. */
 void ipi_send_target(irq_t irq, word_t hart_id)
 {
-    unsigned long hart_mask;
+    word_t hart_mask = BIT(hart_id);
     word_t core_id = hartIDToCoreID(hart_id);
     assert(core_id < CONFIG_MAX_NUM_NODES);
-    hart_mask = BIT(hart_id);
 
     assert((ipiIrq[core_id] == irqInvalid) || (ipiIrq[core_id] == irq_reschedule_ipi) ||
            (ipiIrq[core_id] == irq_remote_call_ipi && big_kernel_lock.node_owners[core_id].ipi == 0));
 
     ipiIrq[core_id] = irq;
     fence_rw_rw();
-    sbi_send_ipi(&hart_mask);
+    sbi_send_ipi(hart_mask);
 }
 
 #endif


### PR DESCRIPTION
Hide the actual SBI call parameter details of the legacy API and remove the pointer parameters in the higher code layers. This is a preparation step for switching to the newer SBI API.
