### PR TITLE
rework IPI handling

### DIFF
--- a/include/arch/riscv/arch/model/smp.h
+++ b/include/arch/riscv/arch/model/smp.h
@@ -26,17 +26,6 @@ static inline cpu_id_t cpuIndexToID(word_t index)
     return coreMap.map[index];
 }
 
-static inline word_t hartIDToCoreID(word_t hart_id)
-{
-    word_t i = 0;
-    for (i = 0; i < CONFIG_MAX_NUM_NODES; i++) {
-        if (coreMap.map[i] == hart_id) {
-            break;
-        }
-    }
-    return i;
-}
-
 static inline void add_hart_to_core_map(word_t hart_id, word_t core_id)
 {
     assert(core_id < CONFIG_MAX_NUM_NODES);

--- a/include/arch/riscv/arch/smp/ipi.h
+++ b/include/arch/riscv/arch/smp/ipi.h
@@ -15,7 +15,6 @@ typedef enum {
     IpiNumArchRemoteCall
 } IpiRemoteCall_t;
 
-void ipi_send_target(irq_t irq, word_t cpuTargetList);
 irq_t ipi_get_irq(void);
 void  ipi_clear_irq(irq_t irq);
 #endif

--- a/include/arch/x86/arch/kernel/apic.h
+++ b/include/arch/x86/arch/kernel/apic.h
@@ -29,6 +29,3 @@ bool_t apic_is_interrupt_pending(void);
 
 void apic_send_ipi_core(irq_t vector, cpu_id_t cpu_id);
 void apic_send_ipi_cluster(irq_t vector, word_t mda);
-
-#define ipi_send_target apic_send_ipi_core
-

--- a/include/smp/ipi.h
+++ b/include/smp/ipi.h
@@ -54,8 +54,13 @@ void generic_ipi_send_mask(irq_t ipi, word_t mask, bool_t isBlocking);
  */
 void ipi_send_mask(irq_t ipi, word_t mask, bool_t isBlocking);
 
-/* Hardware implementation for sending IPIs */
-void ipi_send_target(irq_t irq, word_t cpuTargetList);
+/* Architecture specific implementation for sending IPIs. The target list is a
+ * bitmap of logical core IDs, which is the common view of the system use in the
+ * kernel and userland. Each logical ID This is translated to the actual
+ * hardware IDs of each core, but this is well hidden inside the architecture
+ * specific code.
+ */
+void ipi_send_target(irq_t irq, word_t targetList);
 
 /* This function switches the core it is called on to the idle thread,
  * in order to avoid IPI storms. If the core is waiting on the lock, the actual

--- a/src/arch/x86/smp/ipi.c
+++ b/src/arch/x86/smp/ipi.c
@@ -127,4 +127,15 @@ void ipi_send_mask(irq_t ipi, word_t mask, bool_t isBlocking)
     generic_ipi_send_mask(interrupt_ipi, mask, isBlocking);
 #endif /* CONFIG_USE_LOGICAL_IDS */
 }
+
+void ipi_send_target(irq_t irq, word_t targetList)
+{
+    while (targetList > 0) {
+        unsigned int core_id = wordBits - 1 - clzl(targetList);
+        targetList &= ~BIT(core_id);
+        apic_send_ipi_core(irq, cpuIndexToID(core_id));
+    }
+}
+
+
 #endif /* ENABLE_SMP_SUPPORT */

--- a/src/smp/ipi.c
+++ b/src/smp/ipi.c
@@ -121,29 +121,15 @@ void doMaskReschedule(word_t mask)
 
 void generic_ipi_send_mask(irq_t ipi, word_t mask, bool_t isBlocking)
 {
-    word_t nr_target_cores = 0;
-    uint16_t target_cores[CONFIG_MAX_NUM_NODES];
-
-    while (mask) {
-        int index = wordBits - 1 - clzl(mask);
-        if (isBlocking) {
+    if (isBlocking) {
+        while (mask) {
+            unsigned int index = wordBits - 1 - clzl(mask);
+            mask &= ~BIT(index);
             big_kernel_lock.node_owners[index].ipi = 1;
-            target_cores[nr_target_cores] = index;
-            nr_target_cores++;
-        } else {
-            IPI_MEM_BARRIER;
-            ipi_send_target(ipi, cpuIndexToID(index));
         }
-        mask &= ~BIT(index);
+        IPI_MEM_BARRIER; /* ensure big_kernel_lock update is visible */
     }
-
-    if (nr_target_cores > 0) {
-        /* sending IPIs... */
-        IPI_MEM_BARRIER;
-        for (int i = 0; i < nr_target_cores; i++) {
-            ipi_send_target(ipi, cpuIndexToID(target_cores[i]));
-        }
-    }
+    ipi_send_target(ipi, mask);
 }
 
 #ifdef CONFIG_DEBUG_BUILD


### PR DESCRIPTION
Stick to the logic core view in the generic code and resolve the mask at the lowest layer instead. That avoids translating forth an back from a logical core ID to an ID that is just another artificial ID on some architectures. Using the logical core ID as much as possible seem the most simple approach. 
This also allows supporting the feature that a target mask can be used down to the lowest level. Just there is's finally decided to implement this.