### PR TITLE
boot: don't round DTB area down or up

### DIFF
--- a/src/arch/arm/kernel/boot.c
+++ b/src/arch/arm/kernel/boot.c
@@ -364,7 +364,7 @@ static BOOT_CODE bool_t try_init_kernel(
     /* If a DTB was provided, pass the data on as extra bootinfo */
     p_region_t dtb_p_reg = P_REG_EMPTY;
     if (dtb_size > 0) {
-        paddr_t dtb_phys_end = ROUND_UP(dtb_phys_addr + dtb_size, PAGE_BITS);
+        paddr_t dtb_phys_end = dtb_phys_addr + dtb_size;
         if (dtb_phys_end < dtb_phys_addr) {
             /* An integer overflow happened in DTB end address calculation, the
              * location or size passed seems invalid.
@@ -385,7 +385,7 @@ static BOOT_CODE bool_t try_init_kernel(
         }
         /* DTB seems valid and accessible, pass it on in bootinfo. */
         extra_bi_size += sizeof(seL4_BootInfoHeader) + dtb_size;
-        /* Remember the page aligned memory region it uses. */
+        /* Remember the memory region it uses. */
         dtb_p_reg = (p_region_t) {
             .start = dtb_phys_addr,
             .end   = dtb_phys_end

--- a/src/arch/riscv/kernel/boot.c
+++ b/src/arch/riscv/kernel/boot.c
@@ -229,7 +229,7 @@ static BOOT_CODE bool_t try_init_kernel(
     /* If a DTB was provided, pass the data on as extra bootinfo */
     p_region_t dtb_p_reg = P_REG_EMPTY;
     if (dtb_size > 0) {
-        paddr_t dtb_phys_end = ROUND_UP(dtb_phys_addr + dtb_size, PAGE_BITS);
+        paddr_t dtb_phys_end = dtb_phys_addr + dtb_size;
         if (dtb_phys_end < dtb_phys_addr) {
             /* An integer overflow happened in DTB end address calculation, the
              * location or size passed seems invalid.
@@ -250,9 +250,9 @@ static BOOT_CODE bool_t try_init_kernel(
         }
         /* DTB seems valid and accessible, pass it on in bootinfo. */
         extra_bi_size += sizeof(seL4_BootInfoHeader) + dtb_size;
-        /* Remember the page aligned memory region it uses. */
+        /* Remember the memory region it uses. */
         dtb_p_reg = (p_region_t) {
-            .start = ROUND_DOWN(dtb_phys_addr, PAGE_BITS),
+            .start = dtb_phys_addr,
             .end   = dtb_phys_end
         };
     }


### PR DESCRIPTION
Follow-up from comment https://github.com/seL4/seL4/pull/422#discussion_r715981928

There is no reason to round the DTB area up or down to page boundaries, because the content is copied anyway and reserving memory areas works on arbitrary granularity.

This is also a step towards https://github.com/seL4/seL4/issues/660 to align the ARM/RISC-V boot code, so it can be unified eventually.