### PR TITLE
Merge ARM and RISC-V kernel init boot code 

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -40,6 +40,7 @@ Upcoming release: BINARY COMPATIBLE
 * Removed obsolete define `HAVE_AUTOCONF`
 * Removed user address space reserved slots restriction on 40bit PA platforms when KernelArmHypervisorSupport is set.
   This change is reflected in the definition of the seL4_UserTop constant that holds the largest user virtual address.
+* Merge ARM and RISC-V generic kernel initialization code
 
 ## Upgrade Notes
 ---

--- a/include/kernel/boot.h
+++ b/include/kernel/boot.h
@@ -135,3 +135,31 @@ static inline BOOT_CODE pptr_t it_alloc_paging(void)
 
 /* return the amount of paging structures required to cover v_reg */
 word_t arch_get_n_paging(v_region_t it_veg);
+
+#if defined(CONFIG_ARCH_ARM) || defined(CONFIG_ARCH_RISCV)
+
+bool_t arch_init_freemem(
+    p_region_t ui_p_reg,
+    p_region_t dtb_p_reg,
+    v_region_t it_v_reg,
+    word_t extra_bi_size_bits);
+
+void arch_init_irqs(cap_t root_cnode_cap);
+#ifdef CONFIG_ARM_SMMU
+void arch_init_smmu(cap_t root_cnode_cap);
+#endif
+
+#ifdef ENABLE_SMP_SUPPORT
+void arch_release_secondary_cores(void);
+void setup_kernel_on_secondary_core(void);
+#endif /* ENABLE_SMP_SUPPORT */
+
+bool_t setup_kernel(
+    paddr_t ui_p_reg_start,
+    paddr_t ui_p_reg_end,
+    word_t pv_offset,
+    vptr_t  v_entry,
+    paddr_t dtb_phys_addr,
+    word_t  dtb_size);
+
+#endif /* CONFIG_ARCH_ARM || CONFIG_ARCH_RISCV */

--- a/src/arch/arm/kernel/boot.c
+++ b/src/arch/arm/kernel/boot.c
@@ -320,32 +320,6 @@ static BOOT_CODE bool_t try_init_kernel(
     word_t  dtb_size
 )
 {
-    cap_t root_cnode_cap;
-    cap_t it_ap_cap;
-    cap_t it_pd_cap;
-    cap_t ipcbuf_cap;
-    p_region_t ui_p_reg = (p_region_t) {
-        ui_p_reg_start, ui_p_reg_end
-    };
-    region_t ui_reg = paddr_to_pptr_reg(ui_p_reg);
-    word_t extra_bi_size = 0;
-    pptr_t extra_bi_offset = 0;
-    vptr_t extra_bi_frame_vptr;
-    vptr_t bi_frame_vptr;
-    vptr_t ipcbuf_vptr;
-    create_frames_of_region_ret_t create_frames_ret;
-    create_frames_of_region_ret_t extra_bi_ret;
-
-    /* convert from physical addresses to userland vptrs */
-    v_region_t ui_v_reg = {
-        .start = ui_p_reg_start - pv_offset,
-        .end   = ui_p_reg_end   - pv_offset
-    };
-
-    ipcbuf_vptr = ui_v_reg.end;
-    bi_frame_vptr = ipcbuf_vptr + BIT(PAGE_BITS);
-    extra_bi_frame_vptr = bi_frame_vptr + BIT(BI_FRAME_SIZE_BITS);
-
     /* setup virtual memory for the kernel */
     map_kernel_window();
 
@@ -360,6 +334,8 @@ static BOOT_CODE bool_t try_init_kernel(
 
     /* initialise the platform */
     init_plat();
+
+    word_t extra_bi_size = 0;
 
     /* If a DTB was provided, pass the data on as extra bootinfo */
     p_region_t dtb_p_reg = P_REG_EMPTY;
@@ -392,7 +368,24 @@ static BOOT_CODE bool_t try_init_kernel(
         };
     }
 
-    /* The region of the initial thread is the user image + ipcbuf and boot info */
+    /* Setup the region of the initial thread, which consist of
+     *  - the user image
+     *  - the IPC buffer
+     *  - the bootinfo
+     *  - the extra bootinfo
+     */
+    p_region_t ui_p_reg = {
+        .start = ui_p_reg_start,
+        .end   = ui_p_reg_end
+    };
+    /* Convert user image from physical addresses to userland vptrs. */
+    v_region_t ui_v_reg = {
+        .start = ui_p_reg.start - pv_offset,
+        .end   = ui_p_reg.end   - pv_offset
+    };
+    vptr_t ipcbuf_vptr = ui_v_reg.end;
+    vptr_t bi_frame_vptr = ipcbuf_vptr + BIT(PAGE_BITS);
+    vptr_t extra_bi_frame_vptr = bi_frame_vptr + BIT(BI_FRAME_SIZE_BITS);
     word_t extra_bi_size_bits = calculate_extra_bi_size_bits(extra_bi_size);
     v_region_t it_v_reg = {
         .start = ui_v_reg.start,
@@ -415,7 +408,7 @@ static BOOT_CODE bool_t try_init_kernel(
     }
 
     /* create the root cnode */
-    root_cnode_cap = create_root_cnode();
+    cap_t root_cnode_cap = create_root_cnode();
     if (cap_get_capType(root_cnode_cap) == cap_null_cap) {
         printf("ERROR: root c-node creation failed\n");
         return false;
@@ -431,8 +424,9 @@ static BOOT_CODE bool_t try_init_kernel(
     /* initialise the SMMU and provide the SMMU control caps*/
     init_smmu(root_cnode_cap);
 #endif
-    populate_bi_frame(0, CONFIG_MAX_NUM_NODES, ipcbuf_vptr, extra_bi_size);
 
+    populate_bi_frame(0, CONFIG_MAX_NUM_NODES, ipcbuf_vptr, extra_bi_size);
+    pptr_t extra_bi_offset = 0;
     /* put DTB in the bootinfo block, if present. */
     seL4_BootInfoHeader header;
     if (dtb_size > 0) {
@@ -466,7 +460,7 @@ static BOOT_CODE bool_t try_init_kernel(
 
     /* Construct an initial address space with enough virtual addresses
      * to cover the user image + ipc buffer and bootinfo frames */
-    it_pd_cap = create_it_address_space(root_cnode_cap, it_v_reg);
+    cap_t it_pd_cap = create_it_address_space(root_cnode_cap, it_v_reg);
     if (cap_get_capType(it_pd_cap) == cap_null_cap) {
         printf("ERROR: address space creation for initial thread failed\n");
         return false;
@@ -485,7 +479,7 @@ static BOOT_CODE bool_t try_init_kernel(
             .start = rootserver.extra_bi,
             .end = rootserver.extra_bi + extra_bi_size
         };
-        extra_bi_ret =
+        create_frames_of_region_ret_t extra_bi_ret =
             create_frames_of_region(
                 root_cnode_cap,
                 it_pd_cap,
@@ -505,18 +499,19 @@ static BOOT_CODE bool_t try_init_kernel(
 #endif
 
     /* create the initial thread's IPC buffer */
-    ipcbuf_cap = create_ipcbuf_frame_cap(root_cnode_cap, it_pd_cap, ipcbuf_vptr);
+    cap_t ipcbuf_cap = create_ipcbuf_frame_cap(root_cnode_cap, it_pd_cap,
+                                               ipcbuf_vptr);
     if (cap_get_capType(ipcbuf_cap) == cap_null_cap) {
         printf("ERROR: could not create IPC buffer for initial thread\n");
         return false;
     }
 
     /* create all userland image frames */
-    create_frames_ret =
+    create_frames_of_region_ret_t create_frames_ret =
         create_frames_of_region(
             root_cnode_cap,
             it_pd_cap,
-            ui_reg,
+            paddr_to_pptr_reg(ui_p_reg),
             true,
             pv_offset
         );
@@ -527,7 +522,7 @@ static BOOT_CODE bool_t try_init_kernel(
     ndks_boot.bi_frame->userImageFrames = create_frames_ret.region;
 
     /* create/initialise the initial thread's ASID pool */
-    it_ap_cap = create_it_asid_pool(root_cnode_cap);
+    cap_t it_ap_cap = create_it_asid_pool(root_cnode_cap);
     if (cap_get_capType(it_ap_cap) == cap_null_cap) {
         printf("ERROR: could not create ASID pool for initial thread\n");
         return false;
@@ -568,12 +563,11 @@ static BOOT_CODE bool_t try_init_kernel(
     init_core_state(initial);
 
     /* create all of the untypeds. Both devices and kernel window memory */
-    if (!create_untypeds(
-            root_cnode_cap,
-    (region_t) {
-    KERNEL_ELF_BASE, (pptr_t)ki_boot_end
-    } /* reusable boot code/data */
-        )) {
+    region_t boot_mem_reuse_reg = {
+        .start = KERNEL_ELF_BASE,
+        .end   = (pptr_t)ki_boot_end
+    };
+    if (!create_untypeds(root_cnode_cap, boot_mem_reuse_reg)) {
         printf("ERROR: could not create untypteds for kernel image boot memory\n");
         return false;
     }

--- a/src/arch/riscv/kernel/boot.c
+++ b/src/arch/riscv/kernel/boot.c
@@ -51,10 +51,10 @@ BOOT_CODE cap_t create_mapped_it_frame_cap(cap_t pd_cap, pptr_t pptr, vptr_t vpt
     return cap;
 }
 
-BOOT_CODE static bool_t arch_init_freemem(p_region_t ui_p_reg,
-                                          p_region_t dtb_p_reg,
-                                          v_region_t it_v_reg,
-                                          word_t extra_bi_size_bits)
+BOOT_CODE bool_t arch_init_freemem(p_region_t ui_p_reg,
+                                   p_region_t dtb_p_reg,
+                                   v_region_t it_v_reg,
+                                   word_t extra_bi_size_bits)
 {
     /* Reserve the kernel image region. This may look a bit awkward, as the
      * symbols are a reference in the kernel image window, but all allocations
@@ -89,8 +89,11 @@ BOOT_CODE static bool_t arch_init_freemem(p_region_t ui_p_reg,
                         it_v_reg, extra_bi_size_bits);
 }
 
-BOOT_CODE static void init_irqs(cap_t root_cnode_cap)
+BOOT_CODE void arch_init_irqs(cap_t root_cnode_cap)
 {
+    /* Initialize the architecture specific interrupts, The IRQ cap control init
+     * is done in the generic kernel setup once this returns.
+     */
     irq_t i;
 
     for (i = 0; i <= maxIRQ; i++) {
@@ -104,8 +107,6 @@ BOOT_CODE static void init_irqs(cap_t root_cnode_cap)
     setIRQState(IRQIPI, irq_remote_call_ipi);
     setIRQState(IRQIPI, irq_reschedule_ipi);
 #endif
-    /* provide the IRQ control cap */
-    write_slot(SLOT_PTR(pptr_of_cap(root_cnode_cap), seL4_CapIRQControl), cap_irq_control_cap_new());
 }
 
 /* ASM symbol for the CPU initialisation trap. */
@@ -157,22 +158,28 @@ BOOT_CODE static bool_t try_init_kernel_secondary_core(word_t hart_id, word_t co
     fence_r_rw();
 
     init_cpu();
-    NODE_LOCK_SYS;
 
-    ksNumCPUs++;
-    init_core_state(SchedulerAction_ResumeCurrentThread);
-    ifence_local();
+    /* Call the generic kernel setup. It assumes the BKL has been initialized
+     * but this core is not holding it. Eventually, is acquires the BKL and
+     * returns while still holding it. There is no need to release the BKL
+     * explicitly, exiting to user space will do this automatically.
+     */
+    setup_kernel_on_secondary_core();
+
+    ifence_local(); /* ToDo: clarify why this is needed */
+
     return true;
 }
 
-BOOT_CODE static void release_secondary_cores(void)
+BOOT_CODE void arch_release_secondary_cores(void)
 {
+    /* All secondary harts are released at the same time. The generic kernel
+     * boot process will use the BKL eventually to serialize things where this
+     * is necessary.
+     */
+    assert(0 == node_boot_lock);
     node_boot_lock = 1;
     fence_w_r();
-
-    while (ksNumCPUs != CONFIG_MAX_NUM_NODES) {
-        __atomic_signal_fence(__ATOMIC_ACQ_REL);
-    }
 }
 
 #endif
@@ -192,246 +199,22 @@ static BOOT_CODE bool_t try_init_kernel(
     /* initialise the CPU */
     init_cpu();
 
-    printf("Bootstrapping kernel\n");
-
     /* initialize the platform */
     init_plat();
 
-    word_t extra_bi_size = 0;
-    /* If a DTB was provided, pass the data on as extra bootinfo */
-    p_region_t dtb_p_reg = P_REG_EMPTY;
-    if (dtb_size > 0) {
-        paddr_t dtb_phys_end = dtb_phys_addr + dtb_size;
-        if (dtb_phys_end < dtb_phys_addr) {
-            /* An integer overflow happened in DTB end address calculation, the
-             * location or size passed seems invalid.
-             */
-            printf("ERROR: DTB location at %"SEL4_PRIx_word
-                   " len %"SEL4_PRIu_word" invalid\n",
-                   dtb_phys_addr, dtb_size);
-            return false;
-        }
-        /* If the DTB is located in physical memory that is not mapped in the
-         * kernel window we cannot access it.
-         */
-        if (dtb_phys_end >= PADDR_TOP) {
-            printf("ERROR: DTB at [%"SEL4_PRIx_word"..%"SEL4_PRIx_word"] "
-                   "exceeds PADDR_TOP (%"SEL4_PRIx_word")\n",
-                   dtb_phys_addr, dtb_phys_end, PADDR_TOP);
-            return false;
-        }
-        /* DTB seems valid and accessible, pass it on in bootinfo. */
-        extra_bi_size += sizeof(seL4_BootInfoHeader) + dtb_size;
-        /* Remember the memory region it uses. */
-        dtb_p_reg = (p_region_t) {
-            .start = dtb_phys_addr,
-            .end   = dtb_phys_end
-        };
-    }
-
-    /* Setup the region of the initial thread, which consist of
-     *  - the user image
-     *  - the IPC buffer
-     *  - the bootinfo
-     *  - the extra bootinfo
+    /* Call the generic kernel setup. It will release the secondary cores and
+     * boot them. They may have left to userspace already when we return here.
+     * This is fine, because the only thread at this stage is the initial thread
+     * on the primary core. All other cores can just run the idle thread.
      */
-    word_t extra_bi_size_bits = calculate_extra_bi_size_bits(extra_bi_size);
-    p_region_t ui_p_reg = {
-        .start = ui_p_reg_start,
-        .end   = ui_p_reg_end
-    };
-    /* Convert user image from physical addresses to userland vptrs. */
-    v_region_t ui_v_reg = {
-        .start = ui_p_reg.start - pv_offset,
-        .end   = ui_p_reg.end   - pv_offset
-    };
-    vptr_t ipcbuf_vptr = ui_v_reg.end;
-    vptr_t bi_frame_vptr = ipcbuf_vptr + BIT(PAGE_BITS);
-    vptr_t extra_bi_frame_vptr = bi_frame_vptr + BIT(BI_FRAME_SIZE_BITS);
-    v_region_t it_v_reg = {
-        .start = ui_v_reg.start,
-        .end   = extra_bi_frame_vptr + BIT(extra_bi_size_bits)
-    };
-    if (it_v_reg.end >= USER_TOP) {
-        /* Variable arguments for printf() require well defined integer types
-         * to work properly. Unfortunately, the definition of USER_TOP differs
-         * between platforms (int, long), so we have to cast here to play safe.
-         */
-        printf("ERROR: userland image virt [%"SEL4_PRIx_word"..%"SEL4_PRIx_word"]"
-               "exceeds USER_TOP (%"SEL4_PRIx_word")\n",
-               it_v_reg.start, it_v_reg.end, (word_t)USER_TOP);
+    if (!setup_kernel(ui_p_reg_start, ui_p_reg_end, pv_offset, v_entry,
+                      dtb_phys_addr, dtb_size)) {
+        printf("ERROR: kernel initialization failed\n");
         return false;
     }
 
-    /* make the free memory available to alloc_region() */
-    if (!arch_init_freemem(ui_p_reg, dtb_p_reg, it_v_reg, extra_bi_size_bits)) {
-        printf("ERROR: free memory management initialization failed\n");
-        return false;
-    }
+    /* Nothing architecture specific left to be done here. */
 
-    /* create the root cnode */
-    cap_t root_cnode_cap = create_root_cnode();
-    if (cap_get_capType(root_cnode_cap) == cap_null_cap) {
-        printf("ERROR: root c-node creation failed\n");
-        return false;
-    }
-
-    /* create the cap for managing thread domains */
-    create_domain_cap(root_cnode_cap);
-
-    /* initialise the IRQ states and provide the IRQ control cap */
-    init_irqs(root_cnode_cap);
-
-    /* create the bootinfo frame */
-    populate_bi_frame(0, CONFIG_MAX_NUM_NODES, ipcbuf_vptr, extra_bi_size);
-    pptr_t extra_bi_offset = 0;
-    /* put DTB in the bootinfo block, if present. */
-    seL4_BootInfoHeader header;
-    if (dtb_size > 0) {
-        header.id = SEL4_BOOTINFO_HEADER_FDT;
-        header.len = sizeof(header) + dtb_size;
-        *(seL4_BootInfoHeader *)(rootserver.extra_bi + extra_bi_offset) = header;
-        extra_bi_offset += sizeof(header);
-        memcpy((void *)(rootserver.extra_bi + extra_bi_offset),
-               paddr_to_pptr(dtb_phys_addr),
-               dtb_size);
-        extra_bi_offset += dtb_size;
-    }
-
-    if (extra_bi_size > extra_bi_offset) {
-        /* provide a chunk for any leftover padding in the extended boot info */
-        header.id = SEL4_BOOTINFO_HEADER_PADDING;
-        header.len = (extra_bi_size - extra_bi_offset);
-        *(seL4_BootInfoHeader *)(rootserver.extra_bi + extra_bi_offset) = header;
-    }
-
-    /* Construct an initial address space with enough virtual addresses
-     * to cover the user image + ipc buffer and bootinfo frames */
-    cap_t it_pd_cap = create_it_address_space(root_cnode_cap, it_v_reg);
-    if (cap_get_capType(it_pd_cap) == cap_null_cap) {
-        printf("ERROR: address space creation for initial thread failed\n");
-        return false;
-    }
-
-    /* Create and map bootinfo frame cap */
-    create_bi_frame_cap(
-        root_cnode_cap,
-        it_pd_cap,
-        bi_frame_vptr
-    );
-
-    /* create and map extra bootinfo region */
-    if (extra_bi_size > 0) {
-        region_t extra_bi_region = {
-            .start = rootserver.extra_bi,
-            .end = rootserver.extra_bi + extra_bi_size
-        };
-        create_frames_of_region_ret_t extra_bi_ret =
-            create_frames_of_region(
-                root_cnode_cap,
-                it_pd_cap,
-                extra_bi_region,
-                true,
-                pptr_to_paddr((void *)extra_bi_region.start) - extra_bi_frame_vptr
-            );
-        if (!extra_bi_ret.success) {
-            printf("ERROR: mapping extra boot info to initial thread failed\n");
-            return false;
-        }
-        ndks_boot.bi_frame->extraBIPages = extra_bi_ret.region;
-    }
-
-#ifdef CONFIG_KERNEL_MCS
-    init_sched_control(root_cnode_cap, CONFIG_MAX_NUM_NODES);
-#endif
-
-    /* create the initial thread's IPC buffer */
-    cap_t ipcbuf_cap = create_ipcbuf_frame_cap(root_cnode_cap, it_pd_cap,
-                                               ipcbuf_vptr);
-    if (cap_get_capType(ipcbuf_cap) == cap_null_cap) {
-        printf("ERROR: could not create IPC buffer for initial thread\n");
-        return false;
-    }
-
-    /* create all userland image frames */
-    create_frames_of_region_ret_t create_frames_ret =
-        create_frames_of_region(
-            root_cnode_cap,
-            it_pd_cap,
-            paddr_to_pptr_reg(ui_p_reg),
-            true,
-            pv_offset
-        );
-    if (!create_frames_ret.success) {
-        printf("ERROR: could not create all userland image frames\n");
-        return false;
-    }
-    ndks_boot.bi_frame->userImageFrames = create_frames_ret.region;
-
-    /* create the initial thread's ASID pool */
-    cap_t it_ap_cap = create_it_asid_pool(root_cnode_cap);
-    if (cap_get_capType(it_ap_cap) == cap_null_cap) {
-        printf("ERROR: could not create ASID pool for initial thread\n");
-        return false;
-    }
-    write_it_asid_pool(it_ap_cap, it_pd_cap);
-
-#ifdef CONFIG_KERNEL_MCS
-    NODE_STATE(ksCurTime) = getCurrentTime();
-#endif
-
-    /* create the idle thread */
-    if (!create_idle_thread()) {
-        printf("ERROR: could not create idle thread\n");
-        return false;
-    }
-
-    /* create the initial thread */
-    tcb_t *initial = create_initial_thread(
-                         root_cnode_cap,
-                         it_pd_cap,
-                         v_entry,
-                         bi_frame_vptr,
-                         ipcbuf_vptr,
-                         ipcbuf_cap
-                     );
-
-    if (initial == NULL) {
-        printf("ERROR: could not create initial thread\n");
-        return false;
-    }
-
-    init_core_state(initial);
-
-    /* convert the remaining free memory into UT objects and provide the caps */
-    region_t boot_mem_reuse_reg = paddr_to_pptr_reg((p_region_t) {
-        .start = kpptr_to_paddr((void *)KERNEL_ELF_BASE),
-        .end   = kpptr_to_paddr(ki_boot_end)
-    });
-    if (!create_untypeds(root_cnode_cap, boot_mem_reuse_reg)) {
-        printf("ERROR: could not create untypteds for kernel image boot memory\n");
-        return false;
-    }
-
-    /* no shared-frame caps (RISC-V has no multikernel support) */
-    ndks_boot.bi_frame->sharedFrames = S_REG_EMPTY;
-
-    /* finalise the bootinfo frame */
-    bi_finalise();
-
-    ksNumCPUs = 1;
-
-    SMP_COND_STATEMENT(clh_lock_init());
-    SMP_COND_STATEMENT(release_secondary_cores());
-
-    /* All cores are up now, so there can be concurrency. The kernel booting is
-     * supposed to be finished before the secondary cores are released, all the
-     * primary has to do now is schedule the initial thread. Currently there is
-     * nothing that touches any global data structures, nevertheless we grab the
-     * BKL here to play safe. It is released when the kernel is left. */
-    NODE_LOCK_SYS;
-
-    printf("Booting all finished, dropped to user space\n");
     return true;
 }
 


### PR DESCRIPTION
This addresses https://github.com/seL4/seL4/issues/660 and unifies the kernel init boot flow of ARM and RISC-V to share the same code base. Both architectures have been doing almost the same anyway, making this use common code to reduced the maintenance efforts in the future. The kernel initialization is mostly high level C code already. There are just a few placed left with conditional code, they can be unified in a follow-up task after clarifying the details, 

This builds on top of the PRs
- https://github.com/seL4/seL4/pull/699
- https://github.com/seL4/seL4/pull/704
