### PR TITLE
SMC Capability

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -65,6 +65,8 @@ Upcoming release: BREAKING
   `KernelRiscvUseClintMtime` configuration option which is enabled by default for all current RISC-V
   platforms. With future RISC-V platforms, enabling this configuration option may not actually be an
   optimization.
+* Added SMC Capability (smc_cap) and SMC forwarding for aarch64 platforms. See
+  [RFC-9](https://sel4.atlassian.net/browse/RFC-9).
 
 ## Upgrade Notes
 

--- a/include/arch/arm/arch/64/mode/model/statedata.h
+++ b/include/arch/arm/arch/64/mode/model/statedata.h
@@ -16,6 +16,10 @@
 #include <arch/object/smmu.h>
 #endif
 
+#ifdef CONFIG_ALLOW_SMC_CALLS
+#include <arch/object/smc.h>
+#endif
+
 /* The top level asid mapping table */
 extern asid_pool_t *armKSASIDTable[BIT(asidHighBits)] VISIBLE;
 

--- a/include/arch/arm/arch/64/mode/object/structures.bf
+++ b/include/arch/arm/arch/64/mode/object/structures.bf
@@ -128,7 +128,7 @@ block cb_cap {
 
 #ifdef CONFIG_ALLOW_SMC_CALLS
 block smc_cap {
-    padding        64
+    field capSMCBadge 64
 
     field capType  5
     padding        59

--- a/include/arch/arm/arch/64/mode/object/structures.bf
+++ b/include/arch/arm/arch/64/mode/object/structures.bf
@@ -126,6 +126,15 @@ block cb_cap {
 
 #endif
 
+#ifdef CONFIG_ALLOW_SMC_CALLS
+block smc_cap {
+    padding        64
+
+    field capType  5
+    padding        59
+}
+#endif
+
 -- NB: odd numbers are arch caps (see isArchCap())
 tagged_union cap capType {
     -- 5-bit tag caps
@@ -159,6 +168,9 @@ tagged_union cap capType {
     tag sid_cap                     19
     tag cb_control_cap              21
     tag cb_cap                      23
+#endif
+#ifdef CONFIG_ALLOW_SMC_CALLS
+    tag smc_cap                     25
 #endif
 }
 

--- a/include/arch/arm/arch/object/smc.h
+++ b/include/arch/arm/arch/object/smc.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2021, DornerWorks Ltd.
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#pragma once
+
+#define NUM_SMC_REGS 8
+
+exception_t decodeARMSMCInvocation(word_t label, unsigned int length, cptr_t cptr,
+                                   cte_t *srcSlot, cap_t cap, bool_t call, word_t *buffer);

--- a/include/arch/arm/arch/object/structures.h
+++ b/include/arch/arm/arch/object/structures.h
@@ -12,6 +12,16 @@
 
 static inline bool_t CONST Arch_isCapRevocable(cap_t derivedCap, cap_t srcCap)
 {
+#ifdef CONFIG_ALLOW_SMC_CALLS
+    switch (cap_get_capType(derivedCap)) {
+    case cap_smc_cap:
+        return (cap_smc_cap_get_capSMCBadge(derivedCap) !=
+                cap_smc_cap_get_capSMCBadge(srcCap));
+
+    default:
+        return false;
+    }
+#endif
     return false;
 }
 

--- a/libsel4/arch_include/arm/sel4/arch/types.h
+++ b/libsel4/arch_include/arm/sel4/arch/types.h
@@ -22,6 +22,7 @@ typedef seL4_CPtr seL4_ARM_SIDControl;
 typedef seL4_CPtr seL4_ARM_SID;
 typedef seL4_CPtr seL4_ARM_CBControl;
 typedef seL4_CPtr seL4_ARM_CB;
+typedef seL4_CPtr seL4_ARM_SMC;
 
 typedef enum {
     seL4_ARM_PageCacheable = 0x01,

--- a/libsel4/include/sel4/bootinfo_types.h
+++ b/libsel4/include/sel4/bootinfo_types.h
@@ -27,7 +27,8 @@ enum {
     seL4_CapSMMUSIDControl      = 12, /* global SMMU SID controller cap, null cap if not supported */
     seL4_CapSMMUCBControl       = 13, /* global SMMU CB controller cap, null cap if not supported */
     seL4_CapInitThreadSC        = 14, /* initial thread's scheduling context cap, null cap if not supported */
-    seL4_NumInitialCaps         = 15
+    seL4_CapSMC                 = 15, /* global SMC cap, null cap if not supported */
+    seL4_NumInitialCaps         = 16
 };
 
 /* Legacy code will have assumptions on the vspace root being a Page Directory

--- a/libsel4/sel4_arch_include/aarch64/interfaces/sel4arch.xml
+++ b/libsel4/sel4_arch_include/aarch64/interfaces/sel4arch.xml
@@ -44,6 +44,16 @@
         <member name="tpidr_el0"/>
         <member name="tpidrro_el0"/>
     </struct>
+    <struct name="seL4_ARM_SMCContext">
+        <member name="x0"/>
+        <member name="x1"/>
+        <member name="x2"/>
+        <member name="x3"/>
+        <member name="x4"/>
+        <member name="x5"/>
+        <member name="x6"/>
+        <member name="x7"/>
+    </struct>
     <interface name="seL4_ARM_VSpace" manual_name="Page Global Directory"
         cap_description="Capability to the top level translation table being operated on.">
         <method id="ARMVSpaceClean_Data" name="Clean_Data" manual_label="vspace_clean"
@@ -205,6 +215,22 @@
                     The specified range crosses a page boundary.
                 </description>
             </error>
+        </method>
+    </interface>
+    <interface name="seL4_ARM_SMC" manual_name="SMC" cap_description="Capability to allow threads to make Secure Monitor Calls.">
+        <method id="ARMSMCCall" name="Call" manual_name="SMC Call" manual_label="smc_call">
+            <brief>
+                Tell the microkernel to make the real SMC call.
+            </brief>
+            <description>
+                Takes x0-x7 as arguments to an SMC call which are defined as a seL4_ARM_SMCContext
+                struct. The microkernel makes the SMC call and then returns the results as a
+                new seL4_ARM_SMCContext.
+            </description>
+            <param dir="in" name="smc_args" type="seL4_ARM_SMCContext"
+                description="The structure that has the provided arguments."/>
+            <param dir="out" name="smc_response" type="seL4_ARM_SMCContext"
+                description="The structure to capture the responses."/>
         </method>
     </interface>
 </api>

--- a/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/types.h
+++ b/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/types.h
@@ -22,3 +22,8 @@ typedef struct seL4_UserContext_ {
     /* Thread ID registers */
     seL4_Word tpidr_el0, tpidrro_el0;
 } seL4_UserContext;
+
+typedef struct seL4_ARM_SMCContext_ {
+    /* register arguments */
+    seL4_Word x0, x1, x2, x3, x4, x5, x6, x7;
+} seL4_ARM_SMCContext;

--- a/libsel4/tools/syscall_stub_gen.py
+++ b/libsel4/tools/syscall_stub_gen.py
@@ -291,7 +291,9 @@ def init_arch_types(wordsize, args):
             CapType("seL4_ARM_VCPU", wordsize),
             CapType("seL4_ARM_IOSpace", wordsize),
             CapType("seL4_ARM_IOPageTable", wordsize),
+            CapType("seL4_ARM_SMC", wordsize),
             StructType("seL4_UserContext", wordsize * 36, wordsize),
+            StructType("seL4_ARM_SMCContext", wordsize * 8, wordsize),
         ] + arm_smmu,
 
         "arm_hyp": [

--- a/src/arch/arm/64/object/objecttype.c
+++ b/src/arch/arm/64/object/objecttype.c
@@ -85,6 +85,12 @@ deriveCap_ret_t Arch_deriveCap(cte_t *slot, cap_t cap)
         ret.status = EXCEPTION_NONE;
         return ret;
 #endif
+#ifdef CONFIG_ALLOW_SMC_CALLS
+    case cap_smc_cap:
+        ret.cap = cap;
+        ret.status = EXCEPTION_NONE;
+        return ret;
+#endif
     default:
         /* This assert has no equivalent in haskell,
          * as the options are restricted by type */
@@ -403,6 +409,10 @@ exception_t Arch_decodeInvocation(word_t label, word_t length, cptr_t cptr,
     case cap_cb_cap:
         return decodeARMCBInvocation(label, length, cptr, slot, cap, call, buffer);
 #endif /*CONFIG_ARM_SMMU*/
+#ifdef CONFIG_ALLOW_SMC_CALLS
+    case cap_smc_cap:
+        return decodeARMSMCInvocation(label, length, cptr, slot, cap, call, buffer);
+#endif
     default:
 #else
 {

--- a/src/arch/arm/64/object/objecttype.c
+++ b/src/arch/arm/64/object/objecttype.c
@@ -405,7 +405,7 @@ exception_t Arch_decodeInvocation(word_t label, word_t length, cptr_t cptr,
     /* The C parser cannot handle a switch statement with only a default
      * case. So we need to do some gymnastics to remove the switch if
      * there are no other cases */
-#if defined(CONFIG_ARM_HYPERVISOR_SUPPORT) || defined(CONFIG_ARM_SMMU)
+#if defined(CONFIG_ARM_HYPERVISOR_SUPPORT) || defined(CONFIG_ARM_SMMU) || defined(CONFIG_ALLOW_SMC_CALLS)
     switch (cap_get_capType(cap)) {
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
     case cap_vcpu_cap:

--- a/src/arch/arm/64/object/objecttype.c
+++ b/src/arch/arm/64/object/objecttype.c
@@ -275,6 +275,13 @@ bool_t CONST Arch_sameRegionAs(cap_t cap_a, cap_t cap_b)
         }
         break;
 #endif
+#ifdef CONFIG_ALLOW_SMC_CALLS
+    case cap_smc_cap:
+        if (cap_get_capType(cap_b) == cap_smc_cap) {
+            return true;
+        }
+        break;
+#endif
     }
     return false;
 }

--- a/src/arch/arm/64/object/objecttype.c
+++ b/src/arch/arm/64/object/objecttype.c
@@ -100,7 +100,19 @@ deriveCap_ret_t Arch_deriveCap(cte_t *slot, cap_t cap)
 
 cap_t CONST Arch_updateCapData(bool_t preserve, word_t data, cap_t cap)
 {
-    return cap;
+#ifdef CONFIG_ALLOW_SMC_CALLS
+    if (cap_get_capType(cap) == cap_smc_cap) {
+        if (!preserve && cap_smc_cap_get_capSMCBadge(cap) == 0) {
+            return cap_smc_cap_set_capSMCBadge(cap, data);
+        } else {
+            return cap_null_cap_new();
+        }
+    } else {
+#endif
+        return cap;
+#ifdef CONFIG_ALLOW_SMC_CALLS
+    }
+#endif
 }
 
 cap_t CONST Arch_maskCapRights(seL4_CapRights_t cap_rights_mask, cap_t cap)

--- a/src/arch/arm/config.cmake
+++ b/src/arch/arm/config.cmake
@@ -208,6 +208,16 @@ config_option(
 )
 mark_as_advanced(KernelAArch64SErrorIgnore)
 
+config_option(
+    KernelAllowSMCCalls ALLOW_SMC_CALLS "Allow virtualized guests to make SMC calls. \
+    WARNING: Allowing SMC calls causes a couple of issues. Since seL4 cannot \
+    pre-empt the secure monitor, the WCET is no longer guaranteed. Also, since the \
+    secure monitor is a higher privilege level and can make any change in the \
+    system, the proofs can no longer be guaranteed."
+    DEFAULT OFF
+    DEPENDS "NOT KernelVerificationBuild; KernelArmHypervisorSupport"
+)
+
 if(KernelAArch32FPUEnableContextSwitch OR KernelSel4ArchAarch64)
     set(KernelHaveFPU ON)
 endif()
@@ -253,6 +263,7 @@ add_sources(
         object/iospace.c
         object/vcpu.c
         object/smmu.c
+        object/smc.c
         smp/ipi.c
 )
 

--- a/src/arch/arm/config.cmake
+++ b/src/arch/arm/config.cmake
@@ -209,13 +209,13 @@ config_option(
 mark_as_advanced(KernelAArch64SErrorIgnore)
 
 config_option(
-    KernelAllowSMCCalls ALLOW_SMC_CALLS "Allow virtualized guests to make SMC calls. \
+    KernelAllowSMCCalls ALLOW_SMC_CALLS "Allow components to make SMC calls. \
     WARNING: Allowing SMC calls causes a couple of issues. Since seL4 cannot \
     pre-empt the secure monitor, the WCET is no longer guaranteed. Also, since the \
     secure monitor is a higher privilege level and can make any change in the \
     system, the proofs can no longer be guaranteed."
     DEFAULT OFF
-    DEPENDS "NOT KernelVerificationBuild; KernelArmHypervisorSupport"
+    DEPENDS "NOT KernelVerificationBuild; KernelSel4ArchAarch64"
 )
 
 if(KernelAArch32FPUEnableContextSwitch OR KernelSel4ArchAarch64)

--- a/src/arch/arm/kernel/boot.c
+++ b/src/arch/arm/kernel/boot.c
@@ -165,7 +165,7 @@ BOOT_CODE static void init_smmu(cap_t root_cnode_cap)
 BOOT_CODE static void init_smc(cap_t root_cnode_cap)
 {
     /* Provide the SMC cap*/
-    write_slot(SLOT_PTR(pptr_of_cap(root_cnode_cap), seL4_CapSMC), cap_smc_cap_new());
+    write_slot(SLOT_PTR(pptr_of_cap(root_cnode_cap), seL4_CapSMC), cap_smc_cap_new(0));
 }
 #endif
 

--- a/src/arch/arm/kernel/boot.c
+++ b/src/arch/arm/kernel/boot.c
@@ -161,6 +161,14 @@ BOOT_CODE static void init_smmu(cap_t root_cnode_cap)
 
 #endif
 
+#ifdef CONFIG_ALLOW_SMC_CALLS
+BOOT_CODE static void init_smc(cap_t root_cnode_cap)
+{
+    /* Provide the SMC cap*/
+    write_slot(SLOT_PTR(pptr_of_cap(root_cnode_cap), seL4_CapSMC), cap_smc_cap_new());
+}
+#endif
+
 /** This and only this function initialises the CPU.
  *
  * It does NOT initialise any kernel state.
@@ -436,6 +444,10 @@ static BOOT_CODE bool_t try_init_kernel(
     /* initialise the SMMU and provide the SMMU control caps*/
     init_smmu(root_cnode_cap);
 #endif
+#ifdef CONFIG_ALLOW_SMC_CALLS
+    init_smc(root_cnode_cap);
+#endif
+
     populate_bi_frame(0, CONFIG_MAX_NUM_NODES, ipcbuf_vptr, extra_bi_size);
 
     /* put DTB in the bootinfo block, if present. */

--- a/src/arch/arm/object/smc.c
+++ b/src/arch/arm/object/smc.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021, DornerWorks Ltd.
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+#include <config.h>
+
+#ifdef CONFIG_ALLOW_SMC_CALLS
+#include <arch/object/smc.h>
+
+exception_t decodeARMSMCInvocation(word_t label, unsigned int length, cptr_t cptr,
+                                   cte_t *srcSlot, cap_t cap, bool_t call, word_t *buffer)
+{
+    word_t i;
+    seL4_Word arg[NUM_SMC_REGS];
+    word_t *ipcBuffer;
+
+    switch (label) {
+    case ARMSMCCall:
+        for (i = 0; i < NUM_SMC_REGS; i++) {
+            arg[i] = getSyscallArg(i, buffer);
+        }
+
+        ipcBuffer = lookupIPCBuffer(true, NODE_STATE(ksCurThread));
+
+        register seL4_Word r0 asm("x0") = arg[0];
+        register seL4_Word r1 asm("x1") = arg[1];
+        register seL4_Word r2 asm("x2") = arg[2];
+        register seL4_Word r3 asm("x3") = arg[3];
+        register seL4_Word r4 asm("x4") = arg[4];
+        register seL4_Word r5 asm("x5") = arg[5];
+        register seL4_Word r6 asm("x6") = arg[6];
+        register seL4_Word r7 asm("x7") = arg[7];
+        asm volatile("smc #0\n"
+                     : "+r"(r0), "+r"(r1), "+r"(r2), "+r"(r3),
+                     "+r"(r4), "+r"(r5), "+r"(r6), "+r"(r7)
+                     :: "x8", "x9", "x10", "x11", "x12", "x13", "x14", "x15", "x16", "x17", "memory");
+
+        arg[0] = r0;
+        arg[1] = r1;
+        arg[2] = r2;
+        arg[3] = r3;
+        arg[4] = r4;
+        arg[5] = r5;
+        arg[6] = r6;
+        arg[7] = r7;
+
+        for (i = 0; i < n_msgRegisters; i++) {
+            setRegister(NODE_STATE(ksCurThread), msgRegisters[i], arg[i]);
+        }
+
+        if (ipcBuffer != NULL && i < NUM_SMC_REGS) {
+            for (; i < NUM_SMC_REGS; i++) {
+                ipcBuffer[i + 1] = arg[i];
+            }
+        }
+
+        setRegister(NODE_STATE(ksCurThread), msgInfoRegister, wordFromMessageInfo(
+                        seL4_MessageInfo_new(0, 0, 0, i)));
+
+        setThreadState(NODE_STATE(ksCurThread), ThreadState_Restart);
+        return EXCEPTION_NONE;
+
+    default:
+        userError("ARMSMCInvocation: Illegal operation.");
+        current_syscall_error.type = seL4_IllegalOperation;
+        return EXCEPTION_SYSCALL_ERROR;
+    }
+}
+
+#endif

--- a/src/arch/arm/object/smc.c
+++ b/src/arch/arm/object/smc.c
@@ -8,55 +8,75 @@
 #ifdef CONFIG_ALLOW_SMC_CALLS
 #include <arch/object/smc.h>
 
-exception_t decodeARMSMCInvocation(word_t label, unsigned int length, cptr_t cptr,
-                                   cte_t *srcSlot, cap_t cap, bool_t call, word_t *buffer)
+static exception_t performSMCCall(word_t *buffer)
 {
     word_t i;
     seL4_Word arg[NUM_SMC_REGS];
     word_t *ipcBuffer;
 
+    for (i = 0; i < NUM_SMC_REGS; i++) {
+        arg[i] = getSyscallArg(i, buffer);
+    }
+
+    ipcBuffer = lookupIPCBuffer(true, NODE_STATE(ksCurThread));
+
+    register seL4_Word r0 asm("x0") = arg[0];
+    register seL4_Word r1 asm("x1") = arg[1];
+    register seL4_Word r2 asm("x2") = arg[2];
+    register seL4_Word r3 asm("x3") = arg[3];
+    register seL4_Word r4 asm("x4") = arg[4];
+    register seL4_Word r5 asm("x5") = arg[5];
+    register seL4_Word r6 asm("x6") = arg[6];
+    register seL4_Word r7 asm("x7") = arg[7];
+    asm volatile("smc #0\n"
+                 : "+r"(r0), "+r"(r1), "+r"(r2), "+r"(r3),
+                 "+r"(r4), "+r"(r5), "+r"(r6), "+r"(r7)
+                 :: "x8", "x9", "x10", "x11", "x12", "x13", "x14", "x15", "x16", "x17", "memory");
+
+    arg[0] = r0;
+    arg[1] = r1;
+    arg[2] = r2;
+    arg[3] = r3;
+    arg[4] = r4;
+    arg[5] = r5;
+    arg[6] = r6;
+    arg[7] = r7;
+
+    for (i = 0; i < n_msgRegisters; i++) {
+        setRegister(NODE_STATE(ksCurThread), msgRegisters[i], arg[i]);
+    }
+
+    if (ipcBuffer != NULL && i < NUM_SMC_REGS) {
+        for (; i < NUM_SMC_REGS; i++) {
+            ipcBuffer[i + 1] = arg[i];
+        }
+    }
+    setRegister(NODE_STATE(ksCurThread), msgInfoRegister, wordFromMessageInfo(
+                    seL4_MessageInfo_new(0, 0, 0, i)));
+
+    return EXCEPTION_NONE;
+}
+
+exception_t decodeARMSMCInvocation(word_t label, unsigned int length, cptr_t cptr,
+                                   cte_t *srcSlot, cap_t cap, bool_t call, word_t *buffer)
+{
+    word_t badge;
+    word_t smc_func_id;
+
     switch (label) {
     case ARMSMCCall:
-        for (i = 0; i < NUM_SMC_REGS; i++) {
-            arg[i] = getSyscallArg(i, buffer);
+        badge = cap_smc_cap_get_capSMCBadge(cap);
+        smc_func_id = getSyscallArg(0, buffer);
+
+        if (badge == smc_func_id) {
+            performSMCCall(buffer);
+        } else if (badge == 0) {
+            performSMCCall(buffer);
+        } else {
+            userError("ARMSMCInvocation: Illegal operation.");
+            current_syscall_error.type = seL4_IllegalOperation;
+            return EXCEPTION_SYSCALL_ERROR;
         }
-
-        ipcBuffer = lookupIPCBuffer(true, NODE_STATE(ksCurThread));
-
-        register seL4_Word r0 asm("x0") = arg[0];
-        register seL4_Word r1 asm("x1") = arg[1];
-        register seL4_Word r2 asm("x2") = arg[2];
-        register seL4_Word r3 asm("x3") = arg[3];
-        register seL4_Word r4 asm("x4") = arg[4];
-        register seL4_Word r5 asm("x5") = arg[5];
-        register seL4_Word r6 asm("x6") = arg[6];
-        register seL4_Word r7 asm("x7") = arg[7];
-        asm volatile("smc #0\n"
-                     : "+r"(r0), "+r"(r1), "+r"(r2), "+r"(r3),
-                     "+r"(r4), "+r"(r5), "+r"(r6), "+r"(r7)
-                     :: "x8", "x9", "x10", "x11", "x12", "x13", "x14", "x15", "x16", "x17", "memory");
-
-        arg[0] = r0;
-        arg[1] = r1;
-        arg[2] = r2;
-        arg[3] = r3;
-        arg[4] = r4;
-        arg[5] = r5;
-        arg[6] = r6;
-        arg[7] = r7;
-
-        for (i = 0; i < n_msgRegisters; i++) {
-            setRegister(NODE_STATE(ksCurThread), msgRegisters[i], arg[i]);
-        }
-
-        if (ipcBuffer != NULL && i < NUM_SMC_REGS) {
-            for (; i < NUM_SMC_REGS; i++) {
-                ipcBuffer[i + 1] = arg[i];
-            }
-        }
-
-        setRegister(NODE_STATE(ksCurThread), msgInfoRegister, wordFromMessageInfo(
-                        seL4_MessageInfo_new(0, 0, 0, i)));
 
         setThreadState(NODE_STATE(ksCurThread), ThreadState_Restart);
         return EXCEPTION_NONE;

--- a/src/object/cnode.c
+++ b/src/object/cnode.c
@@ -800,9 +800,8 @@ bool_t PURE isMDBParentOf(cte_t *cte_a, cte_t *cte_b)
         if (badge == 0) {
             return true;
         }
-        return
-            (badge == cap_notification_cap_get_capNtfnBadge(cte_b->cap)) &&
-            !mdb_node_get_mdbFirstBadged(cte_b->cteMDBNode);
+        return (badge == cap_notification_cap_get_capNtfnBadge(cte_b->cap)) &&
+               !mdb_node_get_mdbFirstBadged(cte_b->cteMDBNode);
         break;
     }
 
@@ -814,9 +813,8 @@ bool_t PURE isMDBParentOf(cte_t *cte_a, cte_t *cte_b)
         if (badge == 0) {
             return true;
         }
-        return
-            (badge == cap_smc_cap_get_capSMCBadge(cte_b->cap)) &&
-            !mdb_node_get_mdbFirstBadged(cte_b->cteMDBNode);
+        return (badge == cap_smc_cap_get_capSMCBadge(cte_b->cap)) &&
+               !mdb_node_get_mdbFirstBadged(cte_b->cteMDBNode);
         break;
     }
 #endif

--- a/src/object/cnode.c
+++ b/src/object/cnode.c
@@ -806,6 +806,21 @@ bool_t PURE isMDBParentOf(cte_t *cte_a, cte_t *cte_b)
         break;
     }
 
+#ifdef CONFIG_ALLOW_SMC_CALLS
+    case cap_smc_cap: {
+        word_t badge;
+
+        badge = cap_smc_cap_get_capSMCBadge(cte_a->cap);
+        if (badge == 0) {
+            return true;
+        }
+        return
+            (badge == cap_smc_cap_get_capSMCBadge(cte_b->cap)) &&
+            !mdb_node_get_mdbFirstBadged(cte_b->cteMDBNode);
+        break;
+    }
+#endif
+
     default:
         return true;
         break;


### PR DESCRIPTION
Add a new capability which certain threads can invoke so seL4 can make SMC calls on ARM platforms in EL2 (virtualized mode) on the thread’s behalf.

See https://sel4.atlassian.net/browse/RFC-9