### PR TITLE
boot/risc-v: pv_offset cannot be uint32_t

### DIFF
--- a/src/arch/riscv/kernel/boot.c
+++ b/src/arch/riscv/kernel/boot.c
@@ -181,7 +181,7 @@ BOOT_CODE static void release_secondary_cores(void)
 static BOOT_CODE bool_t try_init_kernel(
     paddr_t ui_p_reg_start,
     paddr_t ui_p_reg_end,
-    uint32_t pv_offset,
+    sword_t pv_offset,
     vptr_t  v_entry,
     paddr_t dtb_phys_addr,
     word_t  dtb_size


### PR DESCRIPTION
The phys/virt translation fails on 64-bit systems when uint32_t is used. With `virt_address = 0xc0000000` and `phys_address = 0x0` the calculation
```
   pv_offset = phys_address - virt_address
             = 0x0 - 0xc0000000 = 0xffffffff40000000
````
result truncated to `uint32_t` is `0x40000000`. Then the phys-to-virt reverse calculation
```
  virt_address = phys_address - pv_offset
               = 0 - 0x40000000 = fffffffc0000000
```
results in a wrong virtual address. Using the proper `(s)word_t` type
```
  virt_address = phys_address - pv_offset
               = 0 - 0xffffffff40000000 = 0xc0000000
```
gives the correct result.
Note that the C rules define that sword_t is converted to word_t in this operation automatically, thus using sword_t or word_t does not make any difference here. Using a signed type for offset is just more intuitive and aligned with what is done in the ARM port of this code.
