### PR TITLE
cmake: invoke python3 explicitly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -557,7 +557,7 @@ cppfile(
 
 add_custom_command(
     OUTPUT circular_includes_valid
-    COMMAND ${CIRCULAR_INCLUDES} --ignore kernel_all_copy.c < kernel_all.i
+    COMMAND ${PYTHON3} ${CIRCULAR_INCLUDES} --ignore kernel_all_copy.c < kernel_all.i
     COMMAND touch circular_includes_valid
     DEPENDS kernel_i_wrapper kernel_all.i
 )


### PR DESCRIPTION
When running a python script from CMake, explicitly invoke Python via
the `PYTHON3` variable defined in the seL4 CMake config, rather than
relying on the script to specify its interpreter with `#!`.

This makes it easier to override the Python interpreter used for all
Python scripts called from CMake builds.