### PR TITLE
boot/risc-v: add missing include

### DIFF
--- a/src/arch/riscv/kernel/boot.c
+++ b/src/arch/riscv/kernel/boot.c
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: GPL-2.0-only
  */
 
+#include <config.h>
 #include <assert.h>
 #include <kernel/boot.h>
 #include <machine/io.h>


### PR DESCRIPTION
Explicitly include the config header file as the first thing, don't rely on other headers doing this eventually.