### PR TITLE
consolidate idle and arch thread prototypes

### DIFF
--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -31,7 +31,7 @@ jobs:
           - arch: X64
             session: CRefine
     # test only most recent push to PR:
-    concurrency: seL4-PR-C-proofs-${{ github.ref }}-${{ strategy.job-index }}
+    concurrency: seL4-PR-C-proofs-pr-${{ github.event.number }}-idx-${{ strategy.job-index }}
     steps:
     - name: Proofs
       uses: seL4/ci-actions/aws-proofs@master

--- a/include/arch/arm/arch/kernel/thread.h
+++ b/include/arch/arm/arch/kernel/thread.h
@@ -6,11 +6,4 @@
 
 #pragma once
 
-#include <object.h>
 #include <mode/kernel/thread.h>
-
-void Arch_switchToThread(tcb_t *tcb);
-void Arch_switchToIdleThread(void);
-void Arch_configureIdleThread(tcb_t *tcb);
-void Arch_activateIdleThread(tcb_t *tcb);
-

--- a/include/arch/arm/arch/kernel/vspace.h
+++ b/include/arch/arm/arch/kernel/vspace.h
@@ -26,9 +26,6 @@ void write_it_asid_pool(cap_t it_ap_cap, cap_t it_pd_cap);
 
 /* ==================== BOOT CODE FINISHES HERE ==================== */
 
-void idle_thread(void);
-#define idleThreadStart (&idle_thread)
-
 /* need a fake array to get the pointer from the linker script */
 extern char arm_vector_table[1];
 

--- a/include/arch/riscv/arch/kernel/thread.h
+++ b/include/arch/riscv/arch/kernel/thread.h
@@ -9,11 +9,6 @@
 
 #include <object.h>
 
-void Arch_switchToThread(tcb_t *tcb);
-void Arch_switchToIdleThread(void);
-void Arch_configureIdleThread(tcb_t *tcb);
-void Arch_activateIdleThread(tcb_t *tcb);
-
 static inline bool_t CONST Arch_getSanitiseRegisterInfo(tcb_t *thread)
 {
     return 0;

--- a/include/arch/riscv/arch/kernel/vspace.h
+++ b/include/arch/riscv/arch/kernel/vspace.h
@@ -24,9 +24,6 @@ void write_it_asid_pool(cap_t it_ap_cap, cap_t it_lvl1pt_cap);
 /* ==================== BOOT CODE FINISHES HERE ==================== */
 #define IT_ASID 1
 
-void idle_thread(void);
-#define idleThreadStart (&idle_thread)
-
 struct lookupPTSlot_ret {
     pte_t *ptSlot;
     word_t ptBitsLeft;

--- a/include/arch/x86/arch/kernel/thread.h
+++ b/include/arch/x86/arch/kernel/thread.h
@@ -8,10 +8,6 @@
 
 #include <object.h>
 
-void Arch_switchToThread(tcb_t *tcb);
-void Arch_switchToIdleThread(void);
-void Arch_configureIdleThread(tcb_t *tcb);
-void Arch_activateIdleThread(tcb_t *tcb);
 word_t sanitiseRegister(register_t reg, word_t v, bool_t archInfo);
 
 static inline bool_t CONST Arch_getSanitiseRegisterInfo(tcb_t *thread)

--- a/include/arch/x86/arch/kernel/vspace.h
+++ b/include/arch/x86/arch/kernel/vspace.h
@@ -67,9 +67,6 @@ cap_t create_it_address_space(cap_t root_cnode_cap, v_region_t it_v_reg);
 
 /* ==================== BOOT CODE FINISHES HERE ==================== */
 
-void idle_thread(void);
-#define idleThreadStart (&idle_thread)
-
 bool_t isVTableRoot(cap_t cap);
 
 asid_map_t findMapForASID(asid_t asid);

--- a/include/kernel/thread.h
+++ b/include/kernel/thread.h
@@ -165,6 +165,8 @@ void Arch_switchToIdleThread(void);
 void Arch_configureIdleThread(tcb_t *tcb);
 void Arch_activateIdleThread(tcb_t *tcb);
 
+void idle_thread(void);
+
 void configureIdleThread(tcb_t *tcb);
 void activateThread(void);
 void suspend(tcb_t *target);

--- a/include/kernel/thread.h
+++ b/include/kernel/thread.h
@@ -160,6 +160,11 @@ static inline bool_t PURE isSchedulable(const tcb_t *thread)
 #define isSchedulable isRunnable
 #endif
 
+void Arch_switchToThread(tcb_t *tcb);
+void Arch_switchToIdleThread(void);
+void Arch_configureIdleThread(tcb_t *tcb);
+void Arch_activateIdleThread(tcb_t *tcb);
+
 void configureIdleThread(tcb_t *tcb);
 void activateThread(void);
 void suspend(tcb_t *target);

--- a/src/arch/arm/32/kernel/thread.c
+++ b/src/arch/arm/32/kernel/thread.c
@@ -25,7 +25,7 @@ void Arch_switchToThread(tcb_t *tcb)
 BOOT_CODE void Arch_configureIdleThread(tcb_t *tcb)
 {
     setRegister(tcb, CPSR, CPSR_IDLETHREAD);
-    setRegister(tcb, NextIP, (word_t)idleThreadStart);
+    setRegister(tcb, NextIP, (word_t)&idle_thread);
 }
 
 void Arch_switchToIdleThread(void)

--- a/src/arch/arm/64/kernel/thread.c
+++ b/src/arch/arm/64/kernel/thread.c
@@ -22,7 +22,7 @@ void Arch_switchToThread(tcb_t *tcb)
 BOOT_CODE void Arch_configureIdleThread(tcb_t *tcb)
 {
     setRegister(tcb, SPSR_EL1, PSTATE_IDLETHREAD);
-    setRegister(tcb, ELR_EL1, (word_t)idleThreadStart);
+    setRegister(tcb, ELR_EL1, (word_t)&idle_thread);
 }
 
 void Arch_switchToIdleThread(void)

--- a/src/arch/riscv/kernel/thread.c
+++ b/src/arch/riscv/kernel/thread.c
@@ -22,7 +22,7 @@ void Arch_switchToThread(tcb_t *tcb)
 
 BOOT_CODE void Arch_configureIdleThread(tcb_t *tcb)
 {
-    setRegister(tcb, NextIP, (word_t)idleThreadStart);
+    setRegister(tcb, NextIP, (word_t)&idle_thread);
 
     /* Enable interrupts and keep working in supervisor mode */
     setRegister(tcb, SSTATUS, (word_t) SSTATUS_SPP | SSTATUS_SPIE);

--- a/src/arch/x86/32/kernel/thread.c
+++ b/src/arch/x86/32/kernel/thread.c
@@ -27,7 +27,7 @@ void Arch_switchToThread(tcb_t *tcb)
 BOOT_CODE void Arch_configureIdleThread(tcb_t *tcb)
 {
     setRegister(tcb, FLAGS, FLAGS_USER_DEFAULT);
-    setRegister(tcb, NextIP, (word_t)idleThreadStart);
+    setRegister(tcb, NextIP, (word_t)&idle_thread);
     setRegister(tcb, CS, SEL_CS_0);
     setRegister(tcb, SS, SEL_DS_0);
     setRegister(tcb, FS_BASE, 0);

--- a/src/arch/x86/64/kernel/thread.c
+++ b/src/arch/x86/64/kernel/thread.c
@@ -33,7 +33,7 @@ void Arch_switchToThread(tcb_t *tcb)
 BOOT_CODE void Arch_configureIdleThread(tcb_t *tcb)
 {
     setRegister(tcb, FLAGS, FLAGS_USER_DEFAULT);
-    setRegister(tcb, NextIP, (uint64_t)idleThreadStart);
+    setRegister(tcb, NextIP, (word_t)&idle_thread);
     setRegister(tcb, CS, SEL_CS_0);
     setRegister(tcb, SS, SEL_DS_0);
     /* We set the RSP to 0, even though the idle thread will never touch it, as it


### PR DESCRIPTION
Consolidate arch thread function prototypes. They are the same on all architectures and thus there is no need to duplicate this in the architecture specific headers