### PR TITLE
risc-v: print kernel entry reason on halt

### DIFF
--- a/src/arch/riscv/idle.c
+++ b/src/arch/riscv/idle.c
@@ -20,7 +20,10 @@ void VISIBLE NO_INLINE halt(void)
 {
 #ifdef CONFIG_PRINTING
     printf("halting...");
-#endif
+#ifdef CONFIG_DEBUG_BUILD
+    debug_printKernelEntryReason();
+#endif /* CONFIG_DEBUG_BUILD */
+#endif /* CONFIG_PRINTING */
 
     sbi_shutdown();
 


### PR DESCRIPTION
This also aligns RISC-V behavior with ARM port.