### PR TITLE
 improve SMP boot arch handling and documentation

### DIFF
--- a/include/arch/riscv/arch/machine.h
+++ b/include/arch/riscv/arch/machine.h
@@ -81,11 +81,6 @@ static inline void fence_r_rw(void)
     asm volatile("fence r,rw" ::: "memory");
 }
 
-static inline void fence_w_r(void)
-{
-    asm volatile("fence w,r" ::: "memory");
-}
-
 static inline void ifence_local(void)
 {
     asm volatile("fence.i":::"memory");

--- a/src/arch/arm/kernel/boot.c
+++ b/src/arch/arm/kernel/boot.c
@@ -299,7 +299,7 @@ BOOT_CODE static void release_secondary_cpus(void)
      * On AARCH32 the elfloader uses strongly ordered uncached memory, but seL4
      * has caching enabled, thus explicit cache cleaning is required.
      */
-#ifndef CONFIG_ARCH_AARCH64
+#ifdef CONFIG_ARCH_AARCH32
     cleanInvalidateL1Caches();
     plat_cleanInvalidateL2Cache();
 #endif

--- a/src/arch/arm/kernel/boot.c
+++ b/src/arch/arm/kernel/boot.c
@@ -284,20 +284,22 @@ BOOT_CODE static bool_t try_init_kernel_secondary_core(void)
 
 BOOT_CODE static void release_secondary_cpus(void)
 {
-
     /* release the cpus at the same time */
     node_boot_lock = 1;
 
-#ifndef CONFIG_ARCH_AARCH64
-    /* At this point in time the other CPUs do *not* have the seL4 global pd set.
-     * However, they still have a PD from the elfloader (which is mapping memory
-     * as strongly ordered uncached, as a result we need to explicitly clean
-     * the cache for it to see the update of node_boot_lock
+    /*
+     * At this point in time the primary core (executing this code) already uses
+     * the seL4 MMU/cache setup. However, the secondary cores are still using
+     * the elfloader's MMU/cache setup, and thus any memory updates may not
+     * be visible there.
      *
-     * For ARMv8, the elfloader sets the page table entries as inner shareable
-     * (so is the attribute of the seL4 global PD) when SMP is enabled, and
-     * turns on the cache. Thus, we do not need to clean and invalidate the cache.
+     * On AARCH64, both elfloader and seL4 map memory inner shareable and have
+     * the caches enabled, so no explicit cache maintenance is necessary.
+     *
+     * On AARCH32 the elfloader uses strongly ordered uncached memory, but seL4
+     * has caching enabled, thus explicit cache cleaning is required.
      */
+#ifndef CONFIG_ARCH_AARCH64
     cleanInvalidateL1Caches();
     plat_cleanInvalidateL2Cache();
 #endif

--- a/src/arch/riscv/kernel/boot.c
+++ b/src/arch/riscv/kernel/boot.c
@@ -173,15 +173,9 @@ BOOT_CODE static void release_secondary_cores(void)
      * the seL4 MMU/cache setup. However, the secondary cores are still using
      * the elfloader's MMU/cache setup, and thus the update of node_boot_lock
      * may not be visible there if the setups differ. Currently, the mappings
-     * match, so a write-before-read fence below is all that is needed. It acts
-     * as a barrier to ensure the write really happens and becomes globally
-     * visible to make the secondary harts boot before we start the polling loop
-     * that checks ksNumCPUs to determine when all nodes are up. However, the
-     * RISC-V Unprivileged ISA spec (V20191214-draft, section A.3.6 "Fences")
-     * states that "fence w,r" is one of the uncommon combination and thus not
-     * recommended to be used.
+     * match, so a barrier is all that is needed.
      */
-    fence_w_r();
+    fence_rw_rw();
 
     while (ksNumCPUs != CONFIG_MAX_NUM_NODES) {
 #ifdef ENABLE_SMP_CLOCK_SYNC_TEST_ON_BOOT


### PR DESCRIPTION
- The cache maintenance is needed on `AARCH32`, so check explicitly for this architecture instead of doing this everywhere except `AARCH64`.
- Do nothing on `AARCH64` and add a build breaker for future unknown architectures this code might be compiled for.
- Improve the documentation to describe the potential pitfall here and why/when explicit action might be needed.
- RISC-V: Improve the documentation to describe about the potential pitfall in SMP boot and the non-recommended barrier that is used.