### PR TITLE
boot: check index before accessing element

### DIFF
--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -874,7 +874,7 @@ BOOT_CODE bool_t init_freemem(word_t n_available, const p_region_t *available,
         return false;
     }
     /* skip any empty regions */
-    for (; is_reg_empty(ndks_boot.freemem[i]) && i >= 0; i--);
+    for (; i >= 0 && is_reg_empty(ndks_boot.freemem[i]); i--);
 
     /* try to grab the last available p region to create the root server objects
      * from. If possible, retain any left over memory as an extra p region */


### PR DESCRIPTION
The loop is counting down and must check if the index is valid first. Only when the index is greater or equal zero, the element at this index can be accesses for a content check. IN the corner case where no free memory is available, the old order tries to access the element -1. Changing the order ensures that this element is not accessed, because the short-circuit evaluation rules apply.

Note that I have also seen a slightly disturbing behavior with the old code, as it still seems to enter the following (`for (; i >= 0; i--) { ...create root server objects ...`) on completely invalid array indices - even if `i` clearly is negative now. It should not run the loop at all actually.  When adding `printf("i 0x%x, is_neg %d\n", i, i<0);` even in the loop it says "`i 0xffffffff, is_neg 0`" (counting doe, and the assembly code contains an explicit `mov r2, #0` there, so the check is really optimized out). 
With the swapped expression from this patch it says (before the loop) "`i 0xffffffff, is_neg 1`" and in the assembly there is `mov r2, #1`. Still an optimizatin, but this time it's valid.
I see this on AARCH32 (gcc 8.3) and RISC-V (gcc 10.2). AARCH64 (gcc 8.3) does not enter the following loop, but a print statement still says "i=0xffffffff, is_neg 0". AARCH32 Clang 8.0.1 seems to work correctly,  it does a `lsr r2, r1, #31` that simply extract the sign bit. It's all happening at `-O2`, so gcc tries to inline a lot and really insists on its internal opinion this can't be negative. Using a custom function that does not get inlined eventually makes the assert trigger as expected:
```
bool_t VISIBLE my_assert(int i) {
    printf("i=0x%x, is_neg %d\n", i, i<0);
    assert(i >= 0);
    return true;
}
```
and says "`i=0xffffffff, is_neg 1`" with the assembly code doing `mov r4, r0; lsr r2, r4, #31` to check the sign bit. 

I always assumed the there is sequence point after a for-loop's increment-statement, so all side effects on non-loop-local variables are visible before the condition is evaluated. Furthermore, the condition contents do not impact the variable update this. Inner loop optmization can happen, but the outer state must be sane again when the loop terminates. Now I wonder,
is there no such guarantee because this is undefined behavior? I could not find anything in the c99 standard.