### PR TITLE
Add numDomains enumeration constant

### DIFF
--- a/include/api/types.h
+++ b/include/api/types.h
@@ -25,7 +25,11 @@ typedef uint64_t time_t;
 
 enum domainConstants {
     minDom = 0,
-    maxDom = CONFIG_NUM_DOMAINS - 1
+    maxDom = CONFIG_NUM_DOMAINS - 1,
+    /* To analyse branches of control flow decisions based on the number of
+     * domains without knowing their exact number, verification needs a C name
+     * to relate to higher-level specs. */
+    numDomains = CONFIG_NUM_DOMAINS
 };
 
 struct cap_transfer {

--- a/include/kernel/thread.h
+++ b/include/kernel/thread.h
@@ -18,7 +18,7 @@
 
 static inline CONST word_t ready_queues_index(word_t dom, word_t prio)
 {
-    if (CONFIG_NUM_DOMAINS > 1) {
+    if (numDomains > 1) {
         return dom * CONFIG_NUM_PRIORITIES + prio;
     } else {
         assert(dom == 0);
@@ -117,7 +117,7 @@ static inline bool_t PURE isRoundRobin(sched_context_t *sc)
 
 static inline bool_t isCurDomainExpired(void)
 {
-    return CONFIG_NUM_DOMAINS > 1 &&
+    return numDomains > 1 &&
            ksDomainTime == 0;
 }
 
@@ -228,7 +228,7 @@ static inline void updateTimestamp(void)
     assert(NODE_STATE(ksCurTime) < MAX_RELEASE_TIME);
     time_t consumed = (NODE_STATE(ksCurTime) - prev);
     NODE_STATE(ksConsumed) += consumed;
-    if (CONFIG_NUM_DOMAINS > 1) {
+    if (numDomains > 1) {
         if ((consumed + MIN_BUDGET) >= ksDomainTime) {
             ksDomainTime = 0;
         } else {

--- a/src/kernel/thread.c
+++ b/src/kernel/thread.c
@@ -417,7 +417,7 @@ void chooseThread(void)
     word_t dom;
     tcb_t *thread;
 
-    if (CONFIG_NUM_DOMAINS > 1) {
+    if (numDomains > 1) {
         dom = ksCurDomain;
     } else {
         dom = 0;
@@ -577,7 +577,7 @@ void setNextInterrupt(void)
     time_t next_interrupt = NODE_STATE(ksCurTime) +
                             refill_head(NODE_STATE(ksCurThread)->tcbSchedContext)->rAmount;
 
-    if (CONFIG_NUM_DOMAINS > 1) {
+    if (numDomains > 1) {
         next_interrupt = MIN(next_interrupt, NODE_STATE(ksCurTime) + ksDomainTime);
     }
 
@@ -645,7 +645,7 @@ void timerTick(void)
         }
     }
 
-    if (CONFIG_NUM_DOMAINS > 1) {
+    if (numDomains > 1) {
         ksDomainTime--;
         if (ksDomainTime == 0) {
             rescheduleRequired();

--- a/src/object/tcb.c
+++ b/src/object/tcb.c
@@ -1561,9 +1561,9 @@ exception_t decodeDomainInvocation(word_t invLabel, word_t length, word_t *buffe
         return EXCEPTION_SYSCALL_ERROR;
     } else {
         domain = getSyscallArg(0, buffer);
-        if (domain >= CONFIG_NUM_DOMAINS) {
+        if (domain >= numDomains) {
             userError("Domain Configure: invalid domain (%lu >= %u).",
-                      domain, CONFIG_NUM_DOMAINS);
+                      domain, numDomains);
             current_syscall_error.type = seL4_InvalidArgument;
             current_syscall_error.invalidArgumentNumber = 0;
             return EXCEPTION_SYSCALL_ERROR;


### PR DESCRIPTION
Defined to be equal to CONFIG_NUM_DOMAINS. seL4 makes control-flow
decisions based on whether the number of domains is greater than 1. To
perform refinement proofs independent of the number of domains, we need
to follow both branches of these if statements, pretending we don't know
which branch will be taken. This is made significantly harder when
preprocessed C code ends up with comparisons like `if (16 > 1)`.
By adding a numDomains that appears in the C code, we obtain a name we
can point to and link up to higher level specifications.

Signed-off-by: Rafal Kolanski <rafal.kolanski@proofcraft.systems>