### PR TITLE
boot: handle inclusive region end properly

### DIFF
--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -724,18 +724,27 @@ BOOT_CODE static bool_t create_untypeds_for_region(
     seL4_SlotPos first_untyped_slot
 )
 {
+    /* The region end address can be inclusive or exclusive, this must be taken
+     * into account when calculating the region size. An end address is assumed
+     * to be inclusive if the LSB is 1.
+     */
+    word_t reg_size = reg.end - reg.start;
+    if (reg.end & 1) {
+        reg_size++; /* Increment length by 1 for inclusive end addresses. */
+        assert(reg_size > 0); /* Overflows are not expected. */
+    }
+
     /* This code works with regions that wrap (where end < start), because the loop cuts up the
        region into size-aligned chunks, one for each cap. Memory chunks that are size-aligned cannot
        themselves overflow, so they satisfy alignment, size, and overflow conditions. The region
        [0..end) is not necessarily part of the kernel window (depending on the value of PPTR_BASE).
        This is fine for device untypeds. For normal untypeds, the region is assumed to be fully in
        the kernel window. This is not checked here. */
-    while (!is_reg_empty(reg)) {
-
+    while (reg_size > 0) {
         /* Calculate the bit size of the region. This is also correct for end < start: it will
            return the correct size of the set [start..-1] union [0..end). This will then be too
            large for alignment, so the code further down will reduce the size. */
-        unsigned int size_bits = seL4_WordBits - 1 - clzl(reg.end - reg.start);
+        unsigned int size_bits = seL4_WordBits - 1 - clzl(reg_size);
         /* The size can't exceed the largest possible untyped size. */
         if (size_bits > seL4_MaxUntypedBits) {
             size_bits = seL4_MaxUntypedBits;
@@ -758,8 +767,14 @@ BOOT_CODE static bool_t create_untypeds_for_region(
                 return false;
             }
         }
-        reg.start += BIT(size_bits);
+
+        word_t chunk_size = BIT(size_bits);
+        reg.start += chunk_size;
+        assert(reg_size >= chunk_size);
+        reg_size -= chunk_size;
+
     }
+
     return true;
 }
 


### PR DESCRIPTION
The region end address can be inclusive or exclusive. Ensure the length is calculated properly for the inclusive form. Without this the device untypes on e.g. the zynq7000 platform are:
```
...
[0xf8f20000..0xf8f40000] size 2^17
[0xf8f40000..0xf8f80000] size 2^18
[0xf8f80000..0xf9000000] size 2^19
[0xf9000000..0xfa000000] size 2^24
[0xfa000000..0xfc000000] size 2^25
[0xfc000000..0xfe000000] size 2^25
[0xfe000000..0xff000000] size 2^24
[0xff000000..0xff800000] size 2^23
... continues for 2^22 down to 2^7 ...
[0xffffff80..0xffffffc0] size 2^6
[0xffffffc0..0xffffffe0] size 2^5
[0xffffffe0..0xfffffff0] size 2^4
```
And the last 16 bytes are left out. With this change they are:
```
[0xf8f20000..0xf8f40000] size 2^17
[0xf8f40000..0xf8f80000] size 2^18
[0xf8f80000..0xf9000000] size 2^19
[0xf9000000..0xfa000000] size 2^24
[0xfa000000..0xfc000000] size 2^25
[0xfc000000..0x100000000] size 2^26
```

Note that for the top n byte of the physical address space there might be a need to reserve them and not provide untypeds. But this should be done via a reserved region then explicitly and not be hidden in the untyped creation algorithm. 
See also:
- https://sel4.discourse.group/t/device-region-untypeds/328
- https://github.com/seL4/seL4/pull/556