### PR TITLE
calculate CONFIG_MAX_NUM_BOOTINFO_UNTYPED_CAPS

### DIFF
--- a/config.cmake
+++ b/config.cmake
@@ -256,12 +256,6 @@ config_string(
     DEFAULT 8
     UNQUOTE
 )
-config_string(
-    KernelMaxNumBootinfoUntypedCaps MAX_NUM_BOOTINFO_UNTYPED_CAPS
-    "Max number of bootinfo untyped caps"
-    DEFAULT 230
-    UNQUOTE
-)
 config_option(KernelFastpath FASTPATH "Enable IPC fastpath" DEFAULT ON)
 
 config_string(

--- a/include/bootinfo.h
+++ b/include/bootinfo.h
@@ -15,11 +15,3 @@
 #define BI_REF(p) ((word_t)(p))
 
 #define S_REG_EMPTY (seL4_SlotRegion){ .start = 0, .end = 0 }
-
-/* The boot info frame takes at least one page, it must be big enough to hold
- * the seL4_BootInfo data structure. Due to internal restrictions, the boot info
- * frame size must be of the form 2^n. Furthermore, there might still be code
- * that makes the hard-coded assumption the boot info frame is always one page.
- */
-#define BI_FRAME_SIZE_BITS PAGE_BITS
-compile_assert(bi_size, sizeof(seL4_BootInfo) <= BIT(BI_FRAME_SIZE_BITS))

--- a/include/kernel/boot.h
+++ b/include/kernel/boot.h
@@ -41,7 +41,7 @@ static inline bool_t is_reg_empty(region_t reg)
 
 bool_t init_freemem(word_t n_available, const p_region_t *available,
                     word_t n_reserved, const region_t *reserved,
-                    v_region_t it_v_reg, word_t extra_bi_size_bits);
+                    v_region_t it_v_reg, word_t num_bi_pages);
 bool_t reserve_region(p_region_t reg);
 void write_slot(slot_ptr_t slot_ptr, cap_t cap);
 cap_t create_root_cnode(void);
@@ -54,10 +54,10 @@ void bi_finalise(void);
 void create_domain_cap(cap_t root_cnode_cap);
 
 cap_t create_ipcbuf_frame_cap(cap_t root_cnode_cap, cap_t pd_cap, vptr_t vptr);
-word_t calculate_extra_bi_size_bits(word_t extra_size);
 void populate_bi_frame(node_id_t node_id, word_t num_nodes, vptr_t ipcbuf_vptr,
-                       word_t extra_bi_size_bits);
-void create_bi_frame_cap(cap_t root_cnode_cap, cap_t pd_cap, vptr_t vptr);
+                       word_t num_bi_pages, word_t extra_bi_size);
+bool_t create_bi_frame_caps(cap_t root_cnode_cap, cap_t pd_cap, vptr_t vptr,
+                            word_t bi_size);
 
 #ifdef CONFIG_KERNEL_MCS
 bool_t init_sched_control(cap_t root_cnode_cap, word_t num_nodes);
@@ -104,7 +104,6 @@ typedef struct {
     pptr_t asid_pool;
     pptr_t ipc_buf;
     pptr_t boot_info;
-    pptr_t extra_bi;
     pptr_t tcb;
 #ifdef CONFIG_KERNEL_MCS
     pptr_t sc;

--- a/libsel4/include/sel4/bootinfo_types.h
+++ b/libsel4/include/sel4/bootinfo_types.h
@@ -52,6 +52,10 @@ typedef struct seL4_UntypedDesc {
     seL4_Uint8 padding[sizeof(seL4_Word) - 2 * sizeof(seL4_Uint8)];
 } seL4_UntypedDesc;
 
+SEL4_COMPILE_ASSERT(
+    invalid_seL4_UntypedDesc,
+    sizeof(seL4_UntypedDesc) == 2 * sizeof(seL4_Word));
+
 typedef struct seL4_BootInfo {
     seL4_Word         extraLen;        /* length of any additional bootinfo information */
     seL4_NodeId       nodeID;          /* ID [0..numNodes-1] of the seL4 node (0 if uniprocessor) */

--- a/libsel4/include/sel4/bootinfo_types.h
+++ b/libsel4/include/sel4/bootinfo_types.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <autoconf.h>
-#include <sel4/macros.h>
+#include <sel4/sel4_arch/constants.h>
 
 /* caps with fixed slot positions in the root CNode */
 enum {
@@ -79,11 +79,26 @@ typedef struct seL4_BootInfo {
      * to make this struct easier to represent in other languages */
 } seL4_BootInfo;
 
-/* If extraLen > 0, then 4K after the start of bootinfo there is a region of the
- * size extraLen that contains additional boot info data chunks. They are
- * arch/platform specific and may or may not exist in any given execution. Each
- * chunk has a header that contains an ID to describe the chunk. All IDs share a
- * global namespace to ensure uniqueness.
+/* The boot info frame size is usually exactly one page. As she page size is
+ * 4 KiByte on x86, ARM and RISC-V, some userland code seems to have a hard
+ * coded assumption that the boot info frame size is 4 KiByte. New code should
+ * avoid this and use SEL4_BI_FRAME_SIZE instead. This allows the boot info page
+ * to become larger in case CONFIG_MAX_NUM_BOOTINFO_UNTYPED_CAPS needs to be
+ * increased. Keep in mind that a larger boot info frame might break older
+ * userland code and libs then.
+ */
+#define SEL4_BI_FRAME_PAGES  1
+#define SEL4_BI_FRAME_SIZE   (SEL4_BI_FRAME_PAGES * LIBSEL4_BIT(seL4_PageBits))
+
+SEL4_COMPILE_ASSERT(
+    invalid_SEL4_BI_FRAME_SIZE,
+    sizeof(seL4_BootInfo) <= SEL4_BI_FRAME_SIZE)
+
+/* If extraLen > 0, then at the offset SEL4_BI_FRAME_SIZE after the start of
+ * bootinfo there is a region of the size extraLen that contains additional boot
+ * info data chunks. They are arch/platform specific and may or may not exist in
+ * any given execution. Each chunk has a header that contains an ID to describe
+ * the chunk. All IDs share a global namespace to ensure uniqueness.
  */
 typedef enum {
     SEL4_BOOTINFO_HEADER_PADDING            = 0,

--- a/libsel4/include/sel4/bootinfo_types.h
+++ b/libsel4/include/sel4/bootinfo_types.h
@@ -74,9 +74,8 @@ typedef struct seL4_BootInfo {
     seL4_SlotRegion   schedcontrol;    /* Caps to sched_control for each node */
 #endif
     seL4_SlotRegion   untyped;         /* untyped-object caps (untyped caps) */
-    seL4_UntypedDesc  untypedList[CONFIG_MAX_NUM_BOOTINFO_UNTYPED_CAPS]; /* information about each untyped */
-    /* the untypedList should be the last entry in this struct, in order
-     * to make this struct easier to represent in other languages */
+    seL4_UntypedDesc  untypedList[];   /* information about each untyped */
+    /* the untypedList[] must be the last entry */
 } seL4_BootInfo;
 
 /* The boot info frame size is usually exactly one page. As she page size is
@@ -93,6 +92,23 @@ typedef struct seL4_BootInfo {
 SEL4_COMPILE_ASSERT(
     invalid_SEL4_BI_FRAME_SIZE,
     sizeof(seL4_BootInfo) <= SEL4_BI_FRAME_SIZE)
+
+/* The number of elements in untypedList[] is limited by the by the remaining
+ * space in the boot info frame. Currently, all remaining space is used. The
+ * calculation below is safe, because the size of the open array untypedList[]
+ * counts as zero for sizeof(seL4_BootInfo), but this still takes into account
+ * padding after the field 'untyped' to ensure a proper alignment of the array.
+ */
+#define MAX_NUM_BOOTINFO_UNTYPED_CAPS \
+    ((SEL4_BI_FRAME_SIZE - sizeof(seL4_BootInfo)) / sizeof(seL4_UntypedDesc))
+
+/* The constant CONFIG_MAX_NUM_BOOTINFO_UNTYPED_CAPS was a CMake configuration
+ * parameter that allowed defining the size of the array untypedList[]. However,
+ * since the boot info frame always take full pages the array uses the remaining
+ * space. Thus, the configuration option has been dropped and the define is
+ * provided here for legacy compatibility.
+ */
+#define CONFIG_MAX_NUM_BOOTINFO_UNTYPED_CAPS  MAX_NUM_BOOTINFO_UNTYPED_CAPS
 
 /* If extraLen > 0, then at the offset SEL4_BI_FRAME_SIZE after the start of
  * bootinfo there is a region of the size extraLen that contains additional boot

--- a/libsel4/include/sel4/bootinfo_types.h
+++ b/libsel4/include/sel4/bootinfo_types.h
@@ -23,8 +23,8 @@ enum {
     seL4_CapBootInfoFrame       =  9, /* bootinfo frame cap */
     seL4_CapInitThreadIPCBuffer = 10, /* initial thread's IPC buffer frame cap */
     seL4_CapDomain              = 11, /* global domain controller cap */
-    seL4_CapSMMUSIDControl      = 12,  /*global SMMU SID controller cap, null cap if not supported*/
-    seL4_CapSMMUCBControl       = 13,  /*global SMMU CB controller cap, null cap if not supported*/
+    seL4_CapSMMUSIDControl      = 12, /* global SMMU SID controller cap, null cap if not supported */
+    seL4_CapSMMUCBControl       = 13, /* global SMMU CB controller cap, null cap if not supported */
 #ifdef CONFIG_KERNEL_MCS
     seL4_CapInitThreadSC        = 14, /* initial thread's scheduling context cap */
     seL4_NumInitialCaps         = 15
@@ -46,9 +46,9 @@ typedef struct seL4_SlotRegion {
 } seL4_SlotRegion;
 
 typedef struct seL4_UntypedDesc {
-    seL4_Word  paddr;   /* physical address of untyped cap  */
-    seL4_Uint8 sizeBits;/* size (2^n) bytes of each untyped */
-    seL4_Uint8 isDevice;/* whether the untyped is a device  */
+    seL4_Word  paddr;    /* physical address of untyped cap  */
+    seL4_Uint8 sizeBits; /* size (2^n) bytes of each untyped */
+    seL4_Uint8 isDevice; /* whether the untyped is a device  */
     seL4_Uint8 padding[sizeof(seL4_Word) - 2 * sizeof(seL4_Uint8)];
 } seL4_UntypedDesc;
 
@@ -67,7 +67,7 @@ typedef struct seL4_BootInfo {
     seL4_Word         initThreadCNodeSizeBits; /* initial thread's root CNode size (2^n slots) */
     seL4_Domain       initThreadDomain; /* Initial thread's domain ID */
 #ifdef CONFIG_KERNEL_MCS
-    seL4_SlotRegion   schedcontrol; /* Caps to sched_control for each node */
+    seL4_SlotRegion   schedcontrol;    /* Caps to sched_control for each node */
 #endif
     seL4_SlotRegion   untyped;         /* untyped-object caps (untyped caps) */
     seL4_UntypedDesc  untypedList[CONFIG_MAX_NUM_BOOTINFO_UNTYPED_CAPS]; /* information about each untyped */

--- a/manual/parts/bootup.tex
+++ b/manual/parts/bootup.tex
@@ -118,14 +118,15 @@ of slots in the initial thread's CNode, starting with CPTR \texttt{start} and wi
   \end{center}
 \end{table}
 
-Depending on the architecture and platform there might be additional pieces of boot
-information. If \texttt{extraLen} is greater than zero, then 4K after the start of bootinfo
-is a region of extraLen bytes containing additional bootinfo structures. Each chunk starts
-with a \texttt{seL4\_BootInfoHeader}, described in \autoref{tab:bi_header_struct}, that
-describes what the chunk is and how long it is, where the length includes the header. The
-length can be used to skip over chunks that you do not understand. The only generally
-defined chunk type is \texttt{SEL4\_BOOTINFO\_HEADER\_PADDING} and describes an empty
-chunk that has no data, any other types are platform or architecture specific. The
+The size of the fixed Boot Info Frame is \texttt{SEL4\_BI\_FRAME\_SIZE}. In the standard
+configuration, this is one page, which is 4 KiByte on x86, ARM and RISC-V. Depending on the
+architecture and platform, there might be additional pieces of variable boot information
+following afterwards. The overall size of this data is \texttt{extraLen}, it contains a
+sequence of blobs, where each one start with a \texttt{seL4\_BootInfoHeader} described in
+\autoref{tab:bi_header_struct}. This header describes what the blob is and how long it is,
+where the length includes the header. Thus, the length can be used to skip over unknown
+chunks. The only generally defined chunk type is \texttt{SEL4\_BOOTINFO\_HEADER\_PADDING}
+and describes a blob where any payload data exists for padding only. The
 \texttt{extraBIPages} slot region gives the frames capabilities for the pages that make up
 the additional boot info region.
 

--- a/src/arch/arm/kernel/boot.c
+++ b/src/arch/arm/kernel/boot.c
@@ -113,6 +113,43 @@ BOOT_CODE static bool_t arch_init_freemem(p_region_t ui_p_reg,
                         it_v_reg, extra_bi_size_bits);
 }
 
+BOOT_CODE static void populate_boot_info(pptr_t extra_bi,
+                                         word_t extra_bi_size,
+                                         vptr_t ipcbuf_vptr,
+                                         paddr_t dtb_phys_addr,
+                                         word_t dtb_size)
+{
+    pptr_t extra_bi_end = extra_bi + extra_bi_size;
+
+    /* Populate the bootinfo frame. */
+    populate_bi_frame(0, CONFIG_MAX_NUM_NODES, ipcbuf_vptr, extra_bi_size);
+
+    /* Put DTB in the extra bootinfo block, if present. */
+    if (dtb_size > 0) {
+        seL4_BootInfoHeader header = {
+            .id = SEL4_BOOTINFO_HEADER_FDT,
+            .len = sizeof(header) + dtb_size
+        };
+        assert(extra_bi_end > extra_bi);
+        assert(header.len >= extra_bi_end - extra_bi);
+        *(seL4_BootInfoHeader *)extra_bi = header;
+        extra_bi += sizeof(header);
+        memcpy((void *)extra_bi, paddr_to_pptr(dtb_phys_addr), dtb_size);
+        extra_bi += dtb_size;
+    }
+
+    /* provide a chunk for any leftover padding in the extended boot info */
+    if (extra_bi_end > extra_bi) {
+        seL4_BootInfoHeader header = {
+            .id = SEL4_BOOTINFO_HEADER_PADDING,
+            .len = extra_bi_end - extra_bi
+        };
+        /* Write the header only if there is enough space. */
+        if (header.len >= sizeof(header)) {
+            *(seL4_BootInfoHeader *)extra_bi = header;
+        }
+    }
+}
 
 BOOT_CODE static void init_irqs(cap_t root_cnode_cap)
 {
@@ -329,7 +366,6 @@ static BOOT_CODE bool_t try_init_kernel(
     };
     region_t ui_reg = paddr_to_pptr_reg(ui_p_reg);
     word_t extra_bi_size = 0;
-    pptr_t extra_bi_offset = 0;
     vptr_t extra_bi_frame_vptr;
     vptr_t bi_frame_vptr;
     vptr_t ipcbuf_vptr;
@@ -431,27 +467,9 @@ static BOOT_CODE bool_t try_init_kernel(
     /* initialise the SMMU and provide the SMMU control caps*/
     init_smmu(root_cnode_cap);
 #endif
-    populate_bi_frame(0, CONFIG_MAX_NUM_NODES, ipcbuf_vptr, extra_bi_size);
 
-    /* put DTB in the bootinfo block, if present. */
-    seL4_BootInfoHeader header;
-    if (dtb_size > 0) {
-        header.id = SEL4_BOOTINFO_HEADER_FDT;
-        header.len = sizeof(header) + dtb_size;
-        *(seL4_BootInfoHeader *)(rootserver.extra_bi + extra_bi_offset) = header;
-        extra_bi_offset += sizeof(header);
-        memcpy((void *)(rootserver.extra_bi + extra_bi_offset),
-               paddr_to_pptr(dtb_phys_addr),
-               dtb_size);
-        extra_bi_offset += dtb_size;
-    }
-
-    if (extra_bi_size > extra_bi_offset) {
-        /* provide a chunk for any leftover padding in the extended boot info */
-        header.id = SEL4_BOOTINFO_HEADER_PADDING;
-        header.len = (extra_bi_size - extra_bi_offset);
-        *(seL4_BootInfoHeader *)(rootserver.extra_bi + extra_bi_offset) = header;
-    }
+    populate_boot_info(rootserver.extra_bi, extra_bi_size, ipcbuf_vptr,
+                       dtb_phys_addr, dtb_size);
 
     if (config_set(CONFIG_TK1_SMMU)) {
         ndks_boot.bi_frame->ioSpaceCaps = create_iospace_caps(root_cnode_cap);

--- a/src/arch/x86/kernel/boot.c
+++ b/src/arch/x86/kernel/boot.c
@@ -81,6 +81,93 @@ BOOT_CODE static bool_t arch_init_freemem(p_region_t ui_p_reg,
                         reserved, it_v_reg, extra_bi_size_bits);
 }
 
+BOOT_CODE static void populate_boot_info(pptr_t extra_bi,
+                                         word_t extra_bi_size,
+                                         vptr_t ipcbuf_vptr,
+                                         seL4_X86_BootInfo_VBE *vbe,
+                                         acpi_rsdp_t *acpi_rsdp,
+                                         seL4_X86_BootInfo_fb_t *fb_info,
+                                         seL4_X86_BootInfo_mmap_t *mb_mmap,
+                                         uint32_t tsc_freq)
+{
+    /* extra_bi_size is not the calculated length of all extra boot info chunks,
+     * but the size of the whole region we have allocated for extra boot info.
+     */
+    pptr_t extra_bi_end = extra_bi + extra_bi_size;
+
+    /* populate the bootinfo frame */
+    populate_bi_frame(0, ksNumCPUs, ipcbuf_vptr, extra_bi_size);
+
+    /* populate vbe info block */
+    if (vbe->vbeMode != -1) {
+        vbe->header.id = SEL4_BOOTINFO_HEADER_X86_VBE;
+        vbe->header.len = sizeof(seL4_X86_BootInfo_VBE);
+        memcpy((void *)extra_bi, vbe, vbe->header.len);
+        extra_bi += vbe->header.len;
+    }
+
+    /* populate acpi rsdp block */
+    if (acpi_rsdp) {
+        seL4_BootInfoHeader header = {
+            .id = SEL4_BOOTINFO_HEADER_X86_ACPI_RSDP,
+            .len = sizeof(header) + sizeof(*acpi_rsdp)
+        };
+        assert(extra_bi_end > extra_bi);
+        assert(header.len >= extra_bi_end - extra_bi);
+        *(seL4_BootInfoHeader *)extra_bi = header;
+        extra_bi += sizeof(header);
+        memcpy((void *)extra_bi, acpi_rsdp, sizeof(*acpi_rsdp));
+        extra_bi += sizeof(*acpi_rsdp);
+    }
+
+    /* populate framebuffer information block */
+    if (fb_info && fb_info->addr) {
+        seL4_BootInfoHeader header = {
+            .id = SEL4_BOOTINFO_HEADER_X86_FRAMEBUFFER,
+            .len = sizeof(header) + sizeof(*fb_info)
+        };
+        assert(extra_bi_end > extra_bi);
+        assert(header.len >= extra_bi_end - extra_bi);
+        *(seL4_BootInfoHeader *)extra_bi = header;
+        extra_bi += sizeof(header);
+        memcpy((void *)extra_bi, fb_info, sizeof(*fb_info));
+        extra_bi += sizeof(*fb_info);
+    }
+
+    /* populate multiboot mmap block */
+    mb_mmap->header.id = SEL4_BOOTINFO_HEADER_X86_MBMMAP;
+    mb_mmap->header.len = sizeof(seL4_X86_BootInfo_mmap_t);
+    memcpy((void *)extra_bi, mb_mmap, mb_mmap->header.len);
+    extra_bi += mb_mmap->header.len;
+
+    /* populate tsc frequency block */
+    {
+        word_t datalen = sizeof(uint32_t);
+        seL4_BootInfoHeader header = {
+            .id = SEL4_BOOTINFO_HEADER_X86_TSC_FREQ,
+            .len = sizeof(header) + datalen
+        };
+        assert(extra_bi_end > extra_bi);
+        assert(header.len >= extra_bi_end - extra_bi);
+        *(seL4_BootInfoHeader *)extra_bi = header;
+        extra_bi += sizeof(header);
+        *(uint32_t *)extra_bi = tsc_freq;
+        extra_bi += datalen;
+    }
+
+    /* provide a chunk for any leftover padding in the extended boot info */
+    if (extra_bi_end > extra_bi) {
+        seL4_BootInfoHeader header = {
+            .id = SEL4_BOOTINFO_HEADER_PADDING,
+            .len = extra_bi_end - extra_bi
+        };
+        /* Write the header only if there is enough space. */
+        if (header.len >= sizeof(header)) {
+            *(seL4_BootInfoHeader *)extra_bi = header;
+        }
+    }
+}
+
 /* This function initialises a node's kernel state. It does NOT initialise the CPU. */
 
 BOOT_CODE bool_t init_sys_state(
@@ -106,7 +193,6 @@ BOOT_CODE bool_t init_sys_state(
     cap_t         it_ap_cap;
     cap_t         ipcbuf_cap;
     word_t        extra_bi_size = sizeof(seL4_BootInfoHeader);
-    pptr_t        extra_bi_offset = 0;
     uint32_t      tsc_freq;
     create_frames_of_region_ret_t create_frames_ret;
     create_frames_of_region_ret_t extra_bi_ret;
@@ -135,8 +221,7 @@ BOOT_CODE bool_t init_sys_state(
         extra_bi_size += sizeof(seL4_BootInfoHeader) + sizeof(*fb_info);
     }
 
-    word_t mb_mmap_size = sizeof(seL4_X86_BootInfo_mmap_t);
-    extra_bi_size += mb_mmap_size;
+    extra_bi_size += sizeof(seL4_X86_BootInfo_mmap_t);
 
     // room for tsc frequency
     extra_bi_size += sizeof(seL4_BootInfoHeader) + 4;
@@ -174,65 +259,13 @@ BOOT_CODE bool_t init_sys_state(
 
     tsc_freq = tsc_init();
 
-    /* populate the bootinfo frame */
-    populate_bi_frame(0, ksNumCPUs, ipcbuf_vptr, extra_bi_size);
     region_t extra_bi_region = {
         .start = rootserver.extra_bi,
-        .end = rootserver.extra_bi + BIT(extra_bi_size_bits)
+        .end   = rootserver.extra_bi + BIT(extra_bi_size_bits)
     };
+    populate_boot_info(rootserver.extra_bi, BIT(extra_bi_size_bits),
+                       ipcbuf_vptr, vbe, acpi_rsdp, fb_info, mb_mmap, tsc_freq);
 
-    /* populate vbe info block */
-    if (vbe->vbeMode != -1) {
-        vbe->header.id = SEL4_BOOTINFO_HEADER_X86_VBE;
-        vbe->header.len = sizeof(seL4_X86_BootInfo_VBE);
-        memcpy((void *)(rootserver.extra_bi + extra_bi_offset), vbe, sizeof(seL4_X86_BootInfo_VBE));
-        extra_bi_offset += sizeof(seL4_X86_BootInfo_VBE);
-    }
-
-    /* populate acpi rsdp block */
-    if (acpi_rsdp) {
-        seL4_BootInfoHeader header;
-        header.id = SEL4_BOOTINFO_HEADER_X86_ACPI_RSDP;
-        header.len = sizeof(header) + sizeof(*acpi_rsdp);
-        *(seL4_BootInfoHeader *)(rootserver.extra_bi + extra_bi_offset) = header;
-        extra_bi_offset += sizeof(header);
-        memcpy((void *)(rootserver.extra_bi + extra_bi_offset), acpi_rsdp, sizeof(*acpi_rsdp));
-        extra_bi_offset += sizeof(*acpi_rsdp);
-    }
-
-    /* populate framebuffer information block */
-    if (fb_info && fb_info->addr) {
-        seL4_BootInfoHeader header;
-        header.id = SEL4_BOOTINFO_HEADER_X86_FRAMEBUFFER;
-        header.len = sizeof(header) + sizeof(*fb_info);
-        *(seL4_BootInfoHeader *)(rootserver.extra_bi + extra_bi_offset) = header;
-        extra_bi_offset += sizeof(header);
-        memcpy((void *)(rootserver.extra_bi + extra_bi_offset), fb_info, sizeof(*fb_info));
-        extra_bi_offset += sizeof(*fb_info);
-    }
-
-    /* populate multiboot mmap block */
-    mb_mmap->header.id = SEL4_BOOTINFO_HEADER_X86_MBMMAP;
-    mb_mmap->header.len = mb_mmap_size;
-    memcpy((void *)(rootserver.extra_bi + extra_bi_offset), mb_mmap, mb_mmap_size);
-    extra_bi_offset += mb_mmap_size;
-
-    /* populate tsc frequency block */
-    {
-        seL4_BootInfoHeader header;
-        header.id = SEL4_BOOTINFO_HEADER_X86_TSC_FREQ;
-        header.len = sizeof(header) + 4;
-        *(seL4_BootInfoHeader *)(extra_bi_region.start + extra_bi_offset) = header;
-        extra_bi_offset += sizeof(header);
-        *(uint32_t *)(extra_bi_region.start + extra_bi_offset) = tsc_freq;
-        extra_bi_offset += 4;
-    }
-
-    /* provde a chunk for any leftover padding in the extended boot info */
-    seL4_BootInfoHeader padding_header;
-    padding_header.id = SEL4_BOOTINFO_HEADER_PADDING;
-    padding_header.len = (extra_bi_region.end - extra_bi_region.start) - extra_bi_offset;
-    *(seL4_BootInfoHeader *)(extra_bi_region.start + extra_bi_offset) = padding_header;
 
 #ifdef CONFIG_KERNEL_MCS
     /* set up sched control for each core */

--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -596,7 +596,7 @@ BOOT_CODE static bool_t provide_untyped_cap(
     bool_t ret;
     cap_t ut_cap;
     word_t i = ndks_boot.slot_pos_cur - first_untyped_slot;
-    if (i < CONFIG_MAX_NUM_BOOTINFO_UNTYPED_CAPS) {
+    if (i < MAX_NUM_BOOTINFO_UNTYPED_CAPS) {
         ndks_boot.bi_frame->untypedList[i] = (seL4_UntypedDesc) {
             pptr_to_paddr((void *)pptr), size_bits, device_memory, {0}
         };
@@ -604,6 +604,13 @@ BOOT_CODE static bool_t provide_untyped_cap(
                                      device_memory, size_bits, pptr);
         ret = provide_cap(root_cnode_cap, ut_cap);
     } else {
+        /* If we ever end up here, then BI_FRAME_PAGES needs to be increased.
+         * This is doable, but it could break some helper libraries. By default,
+         * the boot info is one page and userland code out there that does not
+         * use BI_FRAME_SIZE might have the hard coded assumption that the boot
+         * info page is 4 KiByte. Since the extra boot info starts afterwards,
+         * such code will read garbage then.
+         */
         printf("Kernel init: Too many untyped regions for boot info\n");
         ret = true;
     }

--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -205,6 +205,7 @@ BOOT_CODE static void create_rootserver_objects(pptr_t start, v_region_t it_v_re
     /* at this point we are up to creating 4k objects - which is the min size of
      * extra_bi so this is the last chance to allocate it */
     maybe_alloc_extra_bi(seL4_PageBits, extra_bi_size_bits);
+    compile_assert(invalid_seL4_ASIDPoolBits, seL4_ASIDPoolBits == seL4_PageBits);
     rootserver.asid_pool = alloc_rootserver_obj(seL4_ASIDPoolBits, 1);
     rootserver.ipc_buf = alloc_rootserver_obj(seL4_PageBits, 1);
     rootserver.boot_info = alloc_rootserver_obj(BI_FRAME_SIZE_BITS, 1);


### PR DESCRIPTION
Calculate the value from the remaining space in boot info frame instead of explicitly defining it. Provide the define for userland in libsel4 to avoid breaking existing code.

See also https://github.com/seL4/seL4/issues/716