### PR TITLE
use enum for SEL4_BOOTINFO_HEADER_xxx

### DIFF
--- a/libsel4/include/sel4/bootinfo_types.h
+++ b/libsel4/include/sel4/bootinfo_types.h
@@ -78,7 +78,9 @@ typedef struct seL4_BootInfo {
  * bootinfo structures. Bootinfo structures are arch/platform specific and may or may not
  * exist in any given execution. */
 typedef struct seL4_BootInfoHeader {
-    /* identifier of the following chunk. IDs are arch/platform specific */
+    /* Identifier of the following chunk. IDs are arch/platform specific and defined in
+     * the enum seL4_BootInfoID below.
+     */
     seL4_Word id;
     /* length of the chunk, including this header */
     seL4_Word len;
@@ -86,11 +88,14 @@ typedef struct seL4_BootInfoHeader {
 
 /* Bootinfo identifiers share a global namespace, even if they are arch or platform specific
  * and are enumerated here */
-#define SEL4_BOOTINFO_HEADER_PADDING 0
-#define SEL4_BOOTINFO_HEADER_X86_VBE 1
-#define SEL4_BOOTINFO_HEADER_X86_MBMMAP 2
-#define SEL4_BOOTINFO_HEADER_X86_ACPI_RSDP 3
-#define SEL4_BOOTINFO_HEADER_X86_FRAMEBUFFER 4
-#define SEL4_BOOTINFO_HEADER_X86_TSC_FREQ 5 // frequency is in mhz
-#define SEL4_BOOTINFO_HEADER_FDT 6
-#define SEL4_BOOTINFO_HEADER_NUM SEL4_BOOTINFO_HEADER_FDT + 1
+typedef enum {
+    SEL4_BOOTINFO_HEADER_PADDING            = 0,
+    SEL4_BOOTINFO_HEADER_X86_VBE            = 1,
+    SEL4_BOOTINFO_HEADER_X86_MBMMAP         = 2,
+    SEL4_BOOTINFO_HEADER_X86_ACPI_RSDP      = 3,
+    SEL4_BOOTINFO_HEADER_X86_FRAMEBUFFER    = 4,
+    SEL4_BOOTINFO_HEADER_X86_TSC_FREQ       = 5, /* frequency is in MHz */
+    SEL4_BOOTINFO_HEADER_FDT                = 6, /* device tree */
+    /* add more IDs here */
+    SEL4_BOOTINFO_HEADER_NUM
+} seL4_BootInfoID;


### PR DESCRIPTION
- use enum for `SEL4_BOOTINFO_HEADER_xxx` to keep some semantic information
- Also add more comments.
