### PR TITLE
risc-v: remove misleading comment

### DIFF
--- a/src/arch/riscv/common_riscv.lds
+++ b/src/arch/riscv/common_riscv.lds
@@ -39,7 +39,6 @@ SECTIONS
 
     .text . : AT(ADDR(.text) - KERNEL_OFFSET)
     {
-        /* Sit inside a large frame */
         . = ALIGN(4K);
 
 


### PR DESCRIPTION
The comment seems to be a copy/paste fragment from the ARM port. 