### PR TITLE
clean up compile_assert()

### DIFF
--- a/include/assert.h
+++ b/include/assert.h
@@ -42,14 +42,28 @@ void _assert_fail(
 
 #endif /* DEBUG */
 
-/* Create an assert that will trigger a compile error if it fails. */
+/* Create an assert that triggers a compile error if the condition fails. We do
+ * not include sel4/macros.h that provides SEL4_COMPILE_ASSERT() for two
+ * reasons:
+ * - The kernel's source internals shall not have any unnecessary dependency on
+ *     the user interface headers.
+ * - The kernel user API headers aims to be compiler agnostic and stick to the
+ *     standard(s). As _Static_assert() is a c11 feature, the c99 used for
+ *     kernel compilation would use a helper macros. While this works, it
+ *     creates strange error messages then the condition fails.. Since kernel
+ *     compilation supports just gcc and clang, and both are know to provide
+ *     _Static_assert() even in c99, we can just use this.
+ *
+ * Unfortunately, the C parser does not understand _Static_assert(), so there is
+ * still the need for the helper macro there. In addition, the macro
+ * unverified_compile_assert() exists, because some compile asserts contain
+ * expressions that the C parser cannot handle, too.
+ */
+#ifdef CONFIG_VERIFICATION_BUILD
 #define compile_assert(name, expr) \
         typedef int __assert_failed_##name[(expr) ? 1 : -1] UNUSED;
-
-/* Sometimes compile asserts contain expressions that the C parser cannot
- * handle. For such expressions unverified_compile_assert should be used. */
-#ifdef CONFIG_VERIFICATION_BUILD
 #define unverified_compile_assert(name, expr)
-#else
-#define unverified_compile_assert compile_assert
-#endif
+#else /* not CONFIG_VERIFICATION_BUILD */
+#define compile_assert(name, expr) _Static_assert(expr, #name);
+#define unverified_compile_assert(name, expr) compile_assert(name, expr)
+#endif /* [not] CONFIG_VERIFICATION_BUILD */

--- a/libsel4/include/sel4/assert.h
+++ b/libsel4/include/sel4/assert.h
@@ -13,6 +13,9 @@
  */
 
 #pragma once
+
+#include <sel4/macros.h>
+
 /**
  * Hidden function, use the macros seL4_Fail or seL4_Assert.
  */
@@ -34,12 +37,7 @@ void __assert_fail(const char  *str, const char *file, int line, const char *fun
 /**
  * An assert that tests that the expr is a compile time constant and
  * evaluates to true.
- *
- * This code is similar to compile_time_assert in libutils/include/utils/compile_time.h,
- * we may want to have only one. Also, using __COUNTER__ its not necessary to have name
- * for uniqueness so I've removed it, although maybe there is another reason for it, like
- * some compilers don't support __COUNTER__.
  */
 #define seL4_CompileTimeAssert(expr) \
-    extern char __seL4_CompileTimeAssertFailed_ ## __COUNTER__[__builtin_constant_p(expr) ? ((expr) ? 1 : -1) : -1] __attribute__((unused))
+    SEL4_COMPILE_ASSERT(seL4_CompileTimeAssert, expr)
 


### PR DESCRIPTION
- use `_Static_assert()` in kernel builds (except verification) to have nicer error messages. Both gcc and clang support it even for c99.
- simplify macro `seL4_CompileTimeAssert()` to use `SEL4_COMPILE_ASSERT()`
