### PR TITLE
keep seL4_Word for seL4_BootInfoID

### DIFF
--- a/libsel4/include/sel4/bootinfo_types.h
+++ b/libsel4/include/sel4/bootinfo_types.h
@@ -96,8 +96,8 @@ typedef enum {
 
 /* Common header for all additional bootinfo chunks to describe the chunk. */
 typedef struct seL4_BootInfoHeader {
-    seL4_BootInfoID  id;  /* identifier of the following blob */
-    seL4_Word        len; /* length of the chunk, including this header */
+    seL4_Word id;  /* identifier of the following blob */
+    seL4_Word len; /* length of the chunk, including this header */
 } seL4_BootInfoHeader;
 
 SEL4_COMPILE_ASSERT(


### PR DESCRIPTION
This reverts a small part of 1596aa5857 (#724) which unexpectedly broke the binary verification frontend, because the verification tool chain forces the enum to `int` instead of of `long`.

See also seL4 issue #738 -- when that issue is solved, we may be able to go back to the more specific type.
