### PR TITLE
github: proof test only for most recent push

### DIFF
--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -30,6 +30,8 @@ jobs:
             session: CRefine SimplExportAndRefine
           - arch: X64
             session: CRefine
+    # test only most recent push to PR:
+    concurrency: seL4-PR-C-proofs-${{ github.ref }}-${{ strategy.job-index }}
     steps:
     - name: Proofs
       uses: seL4/ci-actions/aws-proofs@master


### PR DESCRIPTION
By default GitHub spawns a new test for each push to a PR. Since the
proof tests have limited resources, we want only the most recent push
to be triggered, intermediate pushes will be skipped.
