### PR TITLE
smmu+manual: typo and small sentence tune

### DIFF
--- a/manual/parts/io.tex
+++ b/manual/parts/io.tex
@@ -316,9 +316,9 @@ VSpace used by the bank with the following API:
 
 \begin{description}
     \item[\apifunc{seL4\_ARM\_CB\_AssignVspace}{arm_cb_assignvspace}] configures
-        the context bank to use the provided VSapce root for translations.
+        the context bank to use the provided VSpace root for translations.
     \item[\apifunc{seL4\_ARM\_CB\_UnassignVspace}{arm_cb_unassignvspace}] removes
-        the configured VSpace and conducting a TLB invalidation.
+        the configured VSpace and invalidates the TLB.
 \end{description}
 
 The SMMU-v2 uses the same paging structure as the MMU (AArch\_64 and AArch\_32

--- a/src/arch/arm/64/model/statedata.c
+++ b/src/arch/arm/64/model/statedata.c
@@ -118,7 +118,7 @@ compile_assert(smmuStateSIDCNodeSize, sizeof(smmuStateSIDNode) >= ((SMMU_MAX_SID
 
 /*recording the state of the created cb caps*/
 bool_t smmuStateCBTable[SMMU_MAX_CB];
-/* CNode containing the vcapce root cap that is assigned to sids*/
+/* CNode containing the vspace root cap that is assigned to sids*/
 cte_t smmuStateCBNode[BIT(SMMU_CB_CNODE_SLOT_BITS)] ALIGN(BIT(SMMU_CB_CNODE_SLOT_BITS + seL4_SlotBits));
 compile_assert(smmuStateCBCNodeSize, sizeof(smmuStateCBNode) >= ((SMMU_MAX_CB) * sizeof(cte_t)));
 /*recording the context bank to ASID relationship*/

--- a/src/arch/arm/object/smmu.c
+++ b/src/arch/arm/object/smmu.c
@@ -361,7 +361,7 @@ exception_t smmu_delete_cb(cap_t cap)
 
 void smmu_cb_delete_vspace(word_t cb, asid_t asid)
 {
-    /* Deleting the vsapce cap stored in context bank's CNode, causing:
+    /* Deleting the vspace cap stored in context bank's CNode, causing:
      * -reset the relationship between context bank and vspace's ASID
      * -disabe the context bank as its vspace no longer exists*/
     smmuStateCBAsidTable[cb] = ASID_INVALID;


### PR DESCRIPTION
Came across these looking at SMMU. Not 100% on "and conducting a
TLB invalidation", but this is my guess. Cross-check?

It's possible that "invalidates the TLB" is wrong here, and "conducts a TLB invalidation" is what we want.