### PR TITLE
github: use PR number instead of ref

### DIFF
--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -31,7 +31,7 @@ jobs:
           - arch: X64
             session: CRefine
     # test only most recent push to PR:
-    concurrency: seL4-PR-C-proofs-${{ github.ref }}-${{ strategy.job-index }}
+    concurrency: seL4-PR-C-proofs-pr-${{ github.event.number }}-idx-${{ strategy.job-index }}
     steps:
     - name: Proofs
       uses: seL4/ci-actions/aws-proofs@master


### PR DESCRIPTION
`${{github.ref}}` is not what it seems for `pull request target`. It will point to the base branch instead of `refs/pulls/<num>` like the docs would suggest. Using the PR number directly should work.
