### PR TITLE
benchmark: fail log buffer setup if not enabled

### DIFF
--- a/include/benchmark/benchmark.h
+++ b/include/benchmark/benchmark.h
@@ -18,7 +18,9 @@
 exception_t handle_SysBenchmarkFlushCaches(void);
 exception_t handle_SysBenchmarkResetLog(void);
 exception_t handle_SysBenchmarkFinalizeLog(void);
+#ifdef CONFIG_ENABLE_KERNEL_LOG_BUFFER
 exception_t handle_SysBenchmarkSetLogBuffer(void);
+#endif /* CONFIG_ENABLE_KERNEL_LOG_BUFFER */
 #ifdef CONFIG_BENCHMARK_TRACK_UTILISATION
 exception_t handle_SysBenchmarkGetThreadUtilisation(void);
 exception_t handle_SysBenchmarkResetThreadUtilisation(void);

--- a/src/api/syscall.c
+++ b/src/api/syscall.c
@@ -181,8 +181,10 @@ exception_t handleUnknownSyscall(word_t w)
         return handle_SysBenchmarkResetLog();
     case SysBenchmarkFinalizeLog:
         return handle_SysBenchmarkFinalizeLog();
+#ifdef CONFIG_ENABLE_KERNEL_LOG_BUFFER
     case SysBenchmarkSetLogBuffer:
         return handle_SysBenchmarkSetLogBuffer();
+#endif /* CONFIG_ENABLE_KERNEL_LOG_BUFFER */
 #ifdef CONFIG_BENCHMARK_TRACK_UTILISATION
     case SysBenchmarkGetThreadUtilisation:
         return handle_SysBenchmarkGetThreadUtilisation();

--- a/src/benchmark/benchmark.c
+++ b/src/benchmark/benchmark.c
@@ -72,24 +72,19 @@ exception_t handle_SysBenchmarkFinalizeLog(void)
     return EXCEPTION_NONE;
 }
 
+#ifdef CONFIG_ENABLE_KERNEL_LOG_BUFFER
 exception_t handle_SysBenchmarkSetLogBuffer(void)
 {
-#ifdef CONFIG_ENABLE_KERNEL_LOG_BUFFER
     word_t cptr_userFrame = getRegister(NODE_STATE(ksCurThread), capRegister);
     if (benchmark_arch_map_logBuffer(cptr_userFrame) != EXCEPTION_NONE) {
         setRegister(NODE_STATE(ksCurThread), capRegister, seL4_IllegalOperation);
         return EXCEPTION_SYSCALL_ERROR;
     }
-#endif /* CONFIG_ENABLE_KERNEL_LOG_BUFFER */
 
-    /* ToDo: If CONFIG_ENABLE_KERNEL_LOG_BUFFER is not set it might be better to
-     *       fail the syscall or even call halt(), because the system setup or
-     *       the configuration seems broken. Silently ignoring this pretending
-     *       the log buffer got set up might be confusing.
-     */
     setRegister(NODE_STATE(ksCurThread), capRegister, seL4_NoError);
     return EXCEPTION_NONE;
 }
+#endif /* CONFIG_ENABLE_KERNEL_LOG_BUFFER */
 
 #ifdef CONFIG_BENCHMARK_TRACK_UTILISATION
 


### PR DESCRIPTION
Follow up from comment https://github.com/seL4/seL4/pull/676#discussion_r780857025

Fail the log buffer setup syscall completely (and invoke a fault hander is one is set up) if `CONFIG_ENABLE_KERNEL_LOG_BUFFER` is not set. The old behavior of silently ignoring this is confusing, as a caller would never know if this worked or not.