### PR TITLE
make boot info allocation simpler and more flexible

### DIFF
--- a/include/bootinfo.h
+++ b/include/bootinfo.h
@@ -15,11 +15,3 @@
 #define BI_REF(p) ((word_t)(p))
 
 #define S_REG_EMPTY (seL4_SlotRegion){ .start = 0, .end = 0 }
-
-/* The boot info frame takes at least one page, it must be big enough to hold
- * the seL4_BootInfo data structure. Due to internal restrictions, the boot info
- * frame size must be of the form 2^n. Furthermore, there might still be code
- * that makes the hard-coded assumption the boot info frame is always one page.
- */
-#define BI_FRAME_SIZE_BITS PAGE_BITS
-compile_assert(bi_size, sizeof(seL4_BootInfo) <= BIT(BI_FRAME_SIZE_BITS))

--- a/include/kernel/boot.h
+++ b/include/kernel/boot.h
@@ -41,7 +41,7 @@ static inline bool_t is_reg_empty(region_t reg)
 
 bool_t init_freemem(word_t n_available, const p_region_t *available,
                     word_t n_reserved, const region_t *reserved,
-                    v_region_t it_v_reg, word_t extra_bi_size_bits);
+                    v_region_t it_v_reg, word_t num_bi_pages);
 bool_t reserve_region(p_region_t reg);
 void write_slot(slot_ptr_t slot_ptr, cap_t cap);
 cap_t create_root_cnode(void);
@@ -54,10 +54,10 @@ void bi_finalise(void);
 void create_domain_cap(cap_t root_cnode_cap);
 
 cap_t create_ipcbuf_frame_cap(cap_t root_cnode_cap, cap_t pd_cap, vptr_t vptr);
-word_t calculate_extra_bi_size_bits(word_t extra_size);
 void populate_bi_frame(node_id_t node_id, word_t num_nodes, vptr_t ipcbuf_vptr,
-                       word_t extra_bi_size_bits);
-void create_bi_frame_cap(cap_t root_cnode_cap, cap_t pd_cap, vptr_t vptr);
+                       word_t num_bi_pages);
+bool_t create_bi_frame_caps(cap_t root_cnode_cap, cap_t pd_cap, vptr_t vptr,
+                            word_t bi_size);
 
 #ifdef CONFIG_KERNEL_MCS
 bool_t init_sched_control(cap_t root_cnode_cap, word_t num_nodes);
@@ -104,7 +104,6 @@ typedef struct {
     pptr_t asid_pool;
     pptr_t ipc_buf;
     pptr_t boot_info;
-    pptr_t extra_bi;
     pptr_t tcb;
 #ifdef CONFIG_KERNEL_MCS
     pptr_t sc;

--- a/libsel4/include/sel4/bootinfo_types.h
+++ b/libsel4/include/sel4/bootinfo_types.h
@@ -8,6 +8,7 @@
 
 #include <autoconf.h>
 #include <sel4/macros.h>
+#include <sel4/sel4_arch/constants.h>
 
 /* caps with fixed slot positions in the root CNode */
 enum {
@@ -79,11 +80,23 @@ typedef struct seL4_BootInfo {
      * to make this struct easier to represent in other languages */
 } seL4_BootInfo;
 
-/* If extraLen > 0, then 4K after the start of bootinfo there is a region of the
- * size extraLen that contains additional boot info data chunks. They are
- * arch/platform specific and may or may not exist in any given execution. Each
- * chunk has a header that contains an ID to describe the chunk. All IDs share a
- * global namespace to ensure uniqueness.
+/* The fixed boot info frame size is one page. As the page size is 4 KiByte on
+ * x86, ARM and RISC-V, lots of userland code has a hard coded assumption that
+ * the boot info frame size is 4 KiByte, but it should use SEL4_BI_FRAME_SIZE
+ * actually.
+ */
+#define BI_FRAME_SIZE_BITS  seL4_PageBits
+#define SEL4_BI_FRAME_SIZE  LIBSEL4_BIT(BI_FRAME_SIZE_BITS)
+
+SEL4_COMPILE_ASSERT(
+    invalid_SEL4_BI_FRAME_SIZE,
+    sizeof(seL4_BootInfo) <= SEL4_BI_FRAME_SIZE)
+
+/* If extraLen > 0, then at the offset SEL4_BI_FRAME_SIZE after the start of
+ * bootinfo there is a region of the size extraLen that contains additional boot
+ * info data chunks. They are arch/platform specific and may or may not exist in
+ * any given execution. Each chunk has a header that contains an ID to describe
+ * the chunk. All IDs share a global namespace to ensure uniqueness.
  */
 typedef enum {
     SEL4_BOOTINFO_HEADER_PADDING            = 0,

--- a/libsel4/include/sel4/bootinfo_types.h
+++ b/libsel4/include/sel4/bootinfo_types.h
@@ -80,13 +80,16 @@ typedef struct seL4_BootInfo {
      * to make this struct easier to represent in other languages */
 } seL4_BootInfo;
 
-/* The fixed boot info frame size is one page. As the page size is 4 KiByte on
- * x86, ARM and RISC-V, lots of userland code has a hard coded assumption that
- * the boot info frame size is 4 KiByte, but it should use SEL4_BI_FRAME_SIZE
- * actually.
+/* The boot info frame size is usually exactly one page. As the page size is
+ * 4 KiByte on x86, ARM and RISC-V, some userland code seems to have a hard
+ * coded assumption that the boot info frame size is 4 KiByte. New code should
+ * avoid this and use SEL4_BI_FRAME_SIZE instead. This allows the boot info page
+ * to become larger in case CONFIG_MAX_NUM_BOOTINFO_UNTYPED_CAPS needs to be
+ * increased. Keep in mind that a larger boot info frame might break older
+ * userland code and libs then.
  */
-#define BI_FRAME_SIZE_BITS  seL4_PageBits
-#define SEL4_BI_FRAME_SIZE  LIBSEL4_BIT(BI_FRAME_SIZE_BITS)
+#define SEL4_BI_FRAME_PAGES  1
+#define SEL4_BI_FRAME_SIZE   (SEL4_BI_FRAME_PAGES * LIBSEL4_BIT(seL4_PageBits))
 
 SEL4_COMPILE_ASSERT(
     invalid_SEL4_BI_FRAME_SIZE,

--- a/libsel4/include/sel4/bootinfo_types.h
+++ b/libsel4/include/sel4/bootinfo_types.h
@@ -52,6 +52,10 @@ typedef struct seL4_UntypedDesc {
     seL4_Uint8 padding[sizeof(seL4_Word) - 2 * sizeof(seL4_Uint8)];
 } seL4_UntypedDesc;
 
+SEL4_COMPILE_ASSERT(
+    invalid_seL4_UntypedDesc,
+    sizeof(seL4_UntypedDesc) == 2 * sizeof(seL4_Word));
+
 typedef struct seL4_BootInfo {
     seL4_Word         extraLen;        /* length of any additional bootinfo information */
     seL4_NodeId       nodeID;          /* ID [0..numNodes-1] of the seL4 node (0 if uniprocessor) */

--- a/libsel4/include/sel4/bootinfo_types.h
+++ b/libsel4/include/sel4/bootinfo_types.h
@@ -23,8 +23,8 @@ enum {
     seL4_CapBootInfoFrame       =  9, /* bootinfo frame cap */
     seL4_CapInitThreadIPCBuffer = 10, /* initial thread's IPC buffer frame cap */
     seL4_CapDomain              = 11, /* global domain controller cap */
-    seL4_CapSMMUSIDControl      = 12,  /*global SMMU SID controller cap, null cap if not supported*/
-    seL4_CapSMMUCBControl       = 13,  /*global SMMU CB controller cap, null cap if not supported*/
+    seL4_CapSMMUSIDControl      = 12, /* global SMMU SID controller cap, null cap if not supported */
+    seL4_CapSMMUCBControl       = 13, /* global SMMU CB controller cap, null cap if not supported */
 #ifdef CONFIG_KERNEL_MCS
     seL4_CapInitThreadSC        = 14, /* initial thread's scheduling context cap */
     seL4_NumInitialCaps         = 15
@@ -46,9 +46,9 @@ typedef struct seL4_SlotRegion {
 } seL4_SlotRegion;
 
 typedef struct seL4_UntypedDesc {
-    seL4_Word  paddr;   /* physical address of untyped cap  */
-    seL4_Uint8 sizeBits;/* size (2^n) bytes of each untyped */
-    seL4_Uint8 isDevice;/* whether the untyped is a device  */
+    seL4_Word  paddr;    /* physical address of untyped cap  */
+    seL4_Uint8 sizeBits; /* size (2^n) bytes of each untyped */
+    seL4_Uint8 isDevice; /* whether the untyped is a device  */
     seL4_Uint8 padding[sizeof(seL4_Word) - 2 * sizeof(seL4_Uint8)];
 } seL4_UntypedDesc;
 
@@ -67,7 +67,7 @@ typedef struct seL4_BootInfo {
     seL4_Word         initThreadCNodeSizeBits; /* initial thread's root CNode size (2^n slots) */
     seL4_Domain       initThreadDomain; /* Initial thread's domain ID */
 #ifdef CONFIG_KERNEL_MCS
-    seL4_SlotRegion   schedcontrol; /* Caps to sched_control for each node */
+    seL4_SlotRegion   schedcontrol;    /* Caps to sched_control for each node */
 #endif
     seL4_SlotRegion   untyped;         /* untyped-object caps (untyped caps) */
     seL4_UntypedDesc  untypedList[CONFIG_MAX_NUM_BOOTINFO_UNTYPED_CAPS]; /* information about each untyped */

--- a/manual/parts/bootup.tex
+++ b/manual/parts/bootup.tex
@@ -118,14 +118,15 @@ of slots in the initial thread's CNode, starting with CPTR \texttt{start} and wi
   \end{center}
 \end{table}
 
-Depending on the architecture and platform there might be additional pieces of boot
-information. If \texttt{extraLen} is greater than zero, then 4K after the start of bootinfo
-is a region of extraLen bytes containing additional bootinfo structures. Each chunk starts
-with a \texttt{seL4\_BootInfoHeader}, described in \autoref{tab:bi_header_struct}, that
-describes what the chunk is and how long it is, where the length includes the header. The
-length can be used to skip over chunks that you do not understand. The only generally
-defined chunk type is \texttt{SEL4\_BOOTINFO\_HEADER\_PADDING} and describes an empty
-chunk that has no data, any other types are platform or architecture specific. The
+The size of the fixed Boot Info Frame is \texttt{SEL4\_BI\_FRAME\_SIZE}. In the standard
+configuration, this is one page, which is 4 KiByte on x86, ARM and RISC-V. Depending on the
+architecture and platform, there might be additional pieces of variable boot information
+following afterwards. The overall size of this data is \texttt{extraLen}, it contains a
+sequence of blobs, where each one start with a \texttt{seL4\_BootInfoHeader} described in
+\autoref{tab:bi_header_struct}. This header describes what the blob is and how long it is,
+where the length includes the header. Thus, the length can be used to skip over unknown
+chunks. The only generally defined chunk type is \texttt{SEL4\_BOOTINFO\_HEADER\_PADDING}
+and describes a blob where any payload data exists for padding only. The
 \texttt{extraBIPages} slot region gives the frames capabilities for the pages that make up
 the additional boot info region.
 

--- a/src/arch/arm/kernel/boot.c
+++ b/src/arch/arm/kernel/boot.c
@@ -39,7 +39,7 @@ BOOT_BSS static region_t reserved[NUM_RESERVED_REGIONS];
 BOOT_CODE static bool_t arch_init_freemem(p_region_t ui_p_reg,
                                           p_region_t dtb_p_reg,
                                           v_region_t it_v_reg,
-                                          word_t extra_bi_size_bits)
+                                          word_t num_bi_pages)
 {
     /* reserve the kernel image region */
     reserved[0].start = KERNEL_ELF_BASE;
@@ -109,23 +109,25 @@ BOOT_CODE static bool_t arch_init_freemem(p_region_t ui_p_reg,
 
     /* avail_p_regs comes from the auto-generated code */
     return init_freemem(ARRAY_SIZE(avail_p_regs), avail_p_regs,
-                        index, reserved,
-                        it_v_reg, extra_bi_size_bits);
+                        index, reserved, it_v_reg, num_bi_pages);
 }
 
-BOOT_CODE static void populate_boot_info(region_t extra_bi_reg,
+BOOT_CODE static void populate_boot_info(pptr_t bi_pptr,
+                                         word_t num_bi_pages,
                                          vptr_t ipcbuf_vptr,
                                          paddr_t dtb_phys_addr,
                                          word_t dtb_size)
 {
-    /* Initialize the boot info frame and set the extraLen to the size that was
-     * allocated. It will be set to the actual size later when all extra data
-     * was written.
+    /* Initialize the boot info frame, extraLen will be updated later when all
+     * extra data was written.
      */
-    assert(extra_bi_reg.start <= extra_bi_reg.end);
-    populate_bi_frame(0, CONFIG_MAX_NUM_NODES, ipcbuf_vptr,
-                      extra_bi_reg.end - extra_bi_reg.start);
+    populate_bi_frame(0, CONFIG_MAX_NUM_NODES, ipcbuf_vptr, num_bi_pages);
 
+    region_t extra_bi_reg = {
+        .start = bi_pptr + SEL4_BI_FRAME_SIZE,
+        .end   = bi_pptr + num_bi_pages * BIT(PAGE_BITS)
+    };
+    assert(extra_bi_reg.start <= extra_bi_reg.end);
     pptr_t extra_bi = extra_bi_reg.start;
 
     /* Put DTB in the extra bootinfo block, if present. */
@@ -370,21 +372,7 @@ static BOOT_CODE bool_t try_init_kernel(
     };
     region_t ui_reg = paddr_to_pptr_reg(ui_p_reg);
     word_t extra_bi_size = 0;
-    vptr_t extra_bi_frame_vptr;
-    vptr_t bi_frame_vptr;
-    vptr_t ipcbuf_vptr;
     create_frames_of_region_ret_t create_frames_ret;
-    create_frames_of_region_ret_t extra_bi_ret;
-
-    /* convert from physical addresses to userland vptrs */
-    v_region_t ui_v_reg = {
-        .start = ui_p_reg_start - pv_offset,
-        .end   = ui_p_reg_end   - pv_offset
-    };
-
-    ipcbuf_vptr = ui_v_reg.end;
-    bi_frame_vptr = ipcbuf_vptr + BIT(PAGE_BITS);
-    extra_bi_frame_vptr = bi_frame_vptr + BIT(BI_FRAME_SIZE_BITS);
 
     /* setup virtual memory for the kernel */
     map_kernel_window();
@@ -432,11 +420,20 @@ static BOOT_CODE bool_t try_init_kernel(
         };
     }
 
-    /* The region of the initial thread is the user image + ipcbuf and boot info */
-    word_t extra_bi_size_bits = calculate_extra_bi_size_bits(extra_bi_size);
+    /* Convert from physical addresses to userland vptrs. The region of the
+     * initial thread is the user image + ipcbuf + boot info + extra.
+     */
+    v_region_t ui_v_reg = {
+        .start = ui_p_reg_start - pv_offset,
+        .end   = ui_p_reg_end   - pv_offset
+    };
+    vptr_t ipcbuf_vptr = ui_v_reg.end;
+    vptr_t bi_frame_vptr = ipcbuf_vptr + BIT(PAGE_BITS);
+    word_t num_bi_pages = SEL4_BI_FRAME_PAGES +
+                          (ROUND_UP(extra_bi_size, PAGE_BITS) / BIT(PAGE_BITS));
     v_region_t it_v_reg = {
         .start = ui_v_reg.start,
-        .end   = extra_bi_frame_vptr + BIT(extra_bi_size_bits)
+        .end   = bi_frame_vptr + num_bi_pages * BIT(PAGE_BITS)
     };
     if (it_v_reg.end >= USER_TOP) {
         /* Variable arguments for printf() require well defined integer types to
@@ -449,7 +446,7 @@ static BOOT_CODE bool_t try_init_kernel(
         return false;
     }
 
-    if (!arch_init_freemem(ui_p_reg, dtb_p_reg, it_v_reg, extra_bi_size_bits)) {
+    if (!arch_init_freemem(ui_p_reg, dtb_p_reg, it_v_reg, num_bi_pages)) {
         printf("ERROR: free memory management initialization failed\n");
         return false;
     }
@@ -473,11 +470,8 @@ static BOOT_CODE bool_t try_init_kernel(
 #endif
 
     /* populate the bootinfo frame(s) */
-    region_t extra_bi_region = {
-        .start = rootserver.extra_bi,
-        .end   = rootserver.extra_bi + BIT(extra_bi_size_bits)
-    };
-    populate_boot_info(extra_bi_region, ipcbuf_vptr, dtb_phys_addr, dtb_size);
+    populate_boot_info(rootserver.boot_info, num_bi_pages, ipcbuf_vptr,
+                       dtb_phys_addr, dtb_size);
 
     if (config_set(CONFIG_TK1_SMMU)) {
         ndks_boot.bi_frame->ioSpaceCaps = create_iospace_caps(root_cnode_cap);
@@ -498,28 +492,10 @@ static BOOT_CODE bool_t try_init_kernel(
         return false;
     }
 
-    /* Create and map bootinfo frame cap */
-    create_bi_frame_cap(
-        root_cnode_cap,
-        it_pd_cap,
-        bi_frame_vptr
-    );
-
-    /* create and map extra bootinfo region */
-    if (extra_bi_size > 0) {
-        extra_bi_ret =
-            create_frames_of_region(
-                root_cnode_cap,
-                it_pd_cap,
-                extra_bi_region,
-                true,
-                pptr_to_paddr((void *)extra_bi_region.start) - extra_bi_frame_vptr
-            );
-        if (!extra_bi_ret.success) {
-            printf("ERROR: mapping extra boot info to initial thread failed\n");
-            return false;
-        }
-        ndks_boot.bi_frame->extraBIPages = extra_bi_ret.region;
+    if (!create_bi_frame_caps(root_cnode_cap, it_pd_cap, bi_frame_vptr,
+                              num_bi_pages)) {
+        printf("ERROR: could not create boot info frames\n");
+        return false;
     }
 
 #ifdef CONFIG_KERNEL_MCS

--- a/src/arch/riscv/kernel/boot.c
+++ b/src/arch/riscv/kernel/boot.c
@@ -54,7 +54,7 @@ BOOT_CODE cap_t create_mapped_it_frame_cap(cap_t pd_cap, pptr_t pptr, vptr_t vpt
 BOOT_CODE static bool_t arch_init_freemem(region_t ui_reg,
                                           p_region_t dtb_p_reg,
                                           v_region_t it_v_reg,
-                                          word_t extra_bi_size_bits)
+                                          word_t num_bi_pages)
 {
     /* Reserve the kernel image region. This may look a bit awkward, as the
      * symbols are a reference in the kernel image window, but all allocations
@@ -85,23 +85,25 @@ BOOT_CODE static bool_t arch_init_freemem(region_t ui_reg,
 
     /* avail_p_regs comes from the auto-generated code */
     return init_freemem(ARRAY_SIZE(avail_p_regs), avail_p_regs,
-                        index, res_reg,
-                        it_v_reg, extra_bi_size_bits);
+                        index, res_reg, it_v_reg, num_bi_pages);
 }
 
-BOOT_CODE static void populate_boot_info(region_t extra_bi_reg,
+BOOT_CODE static void populate_boot_info(pptr_t bi_pptr,
+                                         word_t num_bi_pages,
                                          vptr_t ipcbuf_vptr,
                                          paddr_t dtb_phys_addr,
                                          word_t dtb_size)
 {
-    /* Initialize the boot info frame and set the extraLen to the size that was
-     * allocated. It will be set to the actual size later when all extra data
-     * was written.
+    /* Initialize the boot info frame, extraLen will be updated later when all
+     * extra data was written.
      */
-    assert(extra_bi_reg.start <= extra_bi_reg.end);
-    populate_bi_frame(0, CONFIG_MAX_NUM_NODES, ipcbuf_vptr,
-                      extra_bi_reg.end - extra_bi_reg.start);
+    populate_bi_frame(0, CONFIG_MAX_NUM_NODES, ipcbuf_vptr, num_bi_pages);
 
+    region_t extra_bi_reg = {
+        .start = bi_pptr + SEL4_BI_FRAME_SIZE,
+        .end   = bi_pptr + num_bi_pages * BIT(PAGE_BITS)
+    };
+    assert(extra_bi_reg.start <= extra_bi_reg.end);
     pptr_t extra_bi = extra_bi_reg.start;
 
     /* put DTB in the extra bootinfo block, if present. */
@@ -241,21 +243,7 @@ static BOOT_CODE bool_t try_init_kernel(
         ui_p_reg_start, ui_p_reg_end
     });
     word_t extra_bi_size = 0;
-    vptr_t extra_bi_frame_vptr;
-    vptr_t bi_frame_vptr;
-    vptr_t ipcbuf_vptr;
     create_frames_of_region_ret_t create_frames_ret;
-    create_frames_of_region_ret_t extra_bi_ret;
-
-    /* convert from physical addresses to userland vptrs */
-    v_region_t ui_v_reg = {
-        .start = ui_p_reg_start - pv_offset,
-        .end   = ui_p_reg_end   - pv_offset
-    };
-
-    ipcbuf_vptr = ui_v_reg.end;
-    bi_frame_vptr = ipcbuf_vptr + BIT(PAGE_BITS);
-    extra_bi_frame_vptr = bi_frame_vptr + BIT(BI_FRAME_SIZE_BITS);
 
     map_kernel_window();
 
@@ -305,11 +293,20 @@ static BOOT_CODE bool_t try_init_kernel(
         };
     }
 
-    /* The region of the initial thread is the user image + ipcbuf + boot info + extra */
-    word_t extra_bi_size_bits = calculate_extra_bi_size_bits(extra_bi_size);
+    /* Convert from physical addresses to userland vptrs. The region of the
+     * initial thread is the user image + ipcbuf + boot info + extra.
+     */
+    v_region_t ui_v_reg = {
+        .start = ui_p_reg_start - pv_offset,
+        .end   = ui_p_reg_end   - pv_offset
+    };
+    vptr_t ipcbuf_vptr = ui_v_reg.end;
+    vptr_t bi_frame_vptr = ipcbuf_vptr + BIT(PAGE_BITS);
+    word_t num_bi_pages = SEL4_BI_FRAME_PAGES +
+                          (ROUND_UP(extra_bi_size, PAGE_BITS) / BIT(PAGE_BITS));
     v_region_t it_v_reg = {
         .start = ui_v_reg.start,
-        .end   = extra_bi_frame_vptr + BIT(extra_bi_size_bits)
+        .end   = bi_frame_vptr + num_bi_pages * BIT(PAGE_BITS)
     };
     if (it_v_reg.end >= USER_TOP) {
         /* Variable arguments for printf() require well defined integer types
@@ -323,7 +320,7 @@ static BOOT_CODE bool_t try_init_kernel(
     }
 
     /* make the free memory available to alloc_region() */
-    if (!arch_init_freemem(ui_reg, dtb_p_reg, it_v_reg, extra_bi_size_bits)) {
+    if (!arch_init_freemem(ui_reg, dtb_p_reg, it_v_reg, num_bi_pages)) {
         printf("ERROR: free memory management initialization failed\n");
         return false;
     }
@@ -342,11 +339,8 @@ static BOOT_CODE bool_t try_init_kernel(
     init_irqs(root_cnode_cap);
 
     /* populate the bootinfo frame(s) */
-    region_t extra_bi_region = {
-        .start = rootserver.extra_bi,
-        .end   = rootserver.extra_bi + BIT(extra_bi_size_bits)
-    };
-    populate_boot_info(extra_bi_region, ipcbuf_vptr, dtb_phys_addr, dtb_size);
+    populate_boot_info(rootserver.boot_info, num_bi_pages, ipcbuf_vptr,
+                       dtb_phys_addr, dtb_size);
 
     /* Construct an initial address space with enough virtual addresses
      * to cover the user image + ipc buffer and bootinfo frames */
@@ -356,28 +350,10 @@ static BOOT_CODE bool_t try_init_kernel(
         return false;
     }
 
-    /* Create and map bootinfo frame cap */
-    create_bi_frame_cap(
-        root_cnode_cap,
-        it_pd_cap,
-        bi_frame_vptr
-    );
-
-    /* create and map extra bootinfo region */
-    if (extra_bi_size > 0) {
-        extra_bi_ret =
-            create_frames_of_region(
-                root_cnode_cap,
-                it_pd_cap,
-                extra_bi_region,
-                true,
-                pptr_to_paddr((void *)extra_bi_region.start) - extra_bi_frame_vptr
-            );
-        if (!extra_bi_ret.success) {
-            printf("ERROR: mapping extra boot info to initial thread failed\n");
-            return false;
-        }
-        ndks_boot.bi_frame->extraBIPages = extra_bi_ret.region;
+    if (!create_bi_frame_caps(root_cnode_cap, it_pd_cap, bi_frame_vptr,
+                              num_bi_pages)) {
+        printf("ERROR: could not create boot info frames\n");
+        return false;
     }
 
 #ifdef CONFIG_KERNEL_MCS

--- a/src/arch/riscv/kernel/boot.c
+++ b/src/arch/riscv/kernel/boot.c
@@ -89,6 +89,44 @@ BOOT_CODE static bool_t arch_init_freemem(region_t ui_reg,
                         it_v_reg, extra_bi_size_bits);
 }
 
+BOOT_CODE static void populate_boot_info(region_t extra_bi_reg,
+                                         vptr_t ipcbuf_vptr,
+                                         paddr_t dtb_phys_addr,
+                                         word_t dtb_size)
+{
+    /* Initialize the boot info frame and set the extraLen to the size that was
+     * allocated. It will be set to the actual size later when all extra data
+     * was written.
+     */
+    assert(extra_bi_reg.start <= extra_bi_reg.end);
+    populate_bi_frame(0, CONFIG_MAX_NUM_NODES, ipcbuf_vptr,
+                      extra_bi_reg.end - extra_bi_reg.start);
+
+    pptr_t extra_bi = extra_bi_reg.start;
+
+    /* put DTB in the extra bootinfo block, if present. */
+    if (dtb_size > 0) {
+        seL4_BootInfoHeader header = {
+            .id = SEL4_BOOTINFO_HEADER_FDT,
+            .len = sizeof(header) + dtb_size
+        };
+        assert(header.len <= extra_bi_reg.end - extra_bi);
+        *(seL4_BootInfoHeader *)extra_bi = header;
+        extra_bi += sizeof(header);
+        memcpy((void *)extra_bi, paddr_to_pptr(dtb_phys_addr), dtb_size);
+        extra_bi += dtb_size;
+    }
+
+    /* Update boot info frame with the actual amount of extra data. There could
+     * be unused space left in the extra boot info region. On x86 a padding
+     * chunk is put there, but the reason is unclear, because the amount of
+     * extra data size is given in the boot info frame. On RISC-V and ARM there
+     * was also code to put a padding chunk there, but the calculation was
+     * broken and no padding chunk was ever really written.
+     */
+    BI_PTR(rootserver.boot_info)->extraLen = extra_bi - extra_bi_reg.start;
+}
+
 BOOT_CODE static void init_irqs(cap_t root_cnode_cap)
 {
     irq_t i;
@@ -203,7 +241,6 @@ static BOOT_CODE bool_t try_init_kernel(
         ui_p_reg_start, ui_p_reg_end
     });
     word_t extra_bi_size = 0;
-    pptr_t extra_bi_offset = 0;
     vptr_t extra_bi_frame_vptr;
     vptr_t bi_frame_vptr;
     vptr_t ipcbuf_vptr;
@@ -304,28 +341,12 @@ static BOOT_CODE bool_t try_init_kernel(
     /* initialise the IRQ states and provide the IRQ control cap */
     init_irqs(root_cnode_cap);
 
-    /* create the bootinfo frame */
-    populate_bi_frame(0, CONFIG_MAX_NUM_NODES, ipcbuf_vptr, extra_bi_size);
-
-    /* put DTB in the bootinfo block, if present. */
-    seL4_BootInfoHeader header;
-    if (dtb_size > 0) {
-        header.id = SEL4_BOOTINFO_HEADER_FDT;
-        header.len = sizeof(header) + dtb_size;
-        *(seL4_BootInfoHeader *)(rootserver.extra_bi + extra_bi_offset) = header;
-        extra_bi_offset += sizeof(header);
-        memcpy((void *)(rootserver.extra_bi + extra_bi_offset),
-               paddr_to_pptr(dtb_phys_addr),
-               dtb_size);
-        extra_bi_offset += dtb_size;
-    }
-
-    if (extra_bi_size > extra_bi_offset) {
-        /* provide a chunk for any leftover padding in the extended boot info */
-        header.id = SEL4_BOOTINFO_HEADER_PADDING;
-        header.len = (extra_bi_size - extra_bi_offset);
-        *(seL4_BootInfoHeader *)(rootserver.extra_bi + extra_bi_offset) = header;
-    }
+    /* populate the bootinfo frame(s) */
+    region_t extra_bi_region = {
+        .start = rootserver.extra_bi,
+        .end   = rootserver.extra_bi + BIT(extra_bi_size_bits)
+    };
+    populate_boot_info(extra_bi_region, ipcbuf_vptr, dtb_phys_addr, dtb_size);
 
     /* Construct an initial address space with enough virtual addresses
      * to cover the user image + ipc buffer and bootinfo frames */
@@ -344,10 +365,6 @@ static BOOT_CODE bool_t try_init_kernel(
 
     /* create and map extra bootinfo region */
     if (extra_bi_size > 0) {
-        region_t extra_bi_region = {
-            .start = rootserver.extra_bi,
-            .end = rootserver.extra_bi + extra_bi_size
-        };
         extra_bi_ret =
             create_frames_of_region(
                 root_cnode_cap,

--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -144,22 +144,22 @@ BOOT_CODE static pptr_t alloc_rootserver_obj(word_t size_bits, word_t n)
     return allocated;
 }
 
-BOOT_CODE static word_t rootserver_max_size_bits(word_t extra_bi_size_bits)
+BOOT_CODE static word_t rootserver_max_size_bits(void)
 {
+    /* the largest object is the PD or the root cnode. */
     word_t cnode_size_bits = CONFIG_ROOT_CNODE_SIZE_BITS + seL4_SlotBits;
-    word_t max = MAX(cnode_size_bits, seL4_VSpaceBits);
-    return MAX(max, extra_bi_size_bits);
+    return MAX(cnode_size_bits, seL4_VSpaceBits);
 }
 
-BOOT_CODE static word_t calculate_rootserver_size(v_region_t it_v_reg, word_t extra_bi_size_bits)
+BOOT_CODE static word_t calculate_rootserver_size(v_region_t it_v_reg,
+                                                  word_t num_bi_pages)
 {
     /* work out how much memory we need for root server objects */
     word_t size = BIT(CONFIG_ROOT_CNODE_SIZE_BITS + seL4_SlotBits);
     size += BIT(seL4_TCBBits); // root thread tcb
     size += BIT(seL4_PageBits); // ipc buf
-    size += BIT(BI_FRAME_SIZE_BITS); // boot info
+    size += num_bi_pages * BIT(seL4_PageBits);
     size += BIT(seL4_ASIDPoolBits);
-    size += extra_bi_size_bits > 0 ? BIT(extra_bi_size_bits) : 0;
     size += BIT(seL4_VSpaceBits); // root vspace
 #ifdef CONFIG_KERNEL_MCS
     size += BIT(seL4_MinSchedContextBits); // root sched context
@@ -168,48 +168,33 @@ BOOT_CODE static word_t calculate_rootserver_size(v_region_t it_v_reg, word_t ex
     return size + arch_get_n_paging(it_v_reg) * BIT(seL4_PageTableBits);
 }
 
-BOOT_CODE static void maybe_alloc_extra_bi(word_t cmp_size_bits, word_t extra_bi_size_bits)
-{
-    if (extra_bi_size_bits >= cmp_size_bits && rootserver.extra_bi == 0) {
-        rootserver.extra_bi = alloc_rootserver_obj(extra_bi_size_bits, 1);
-    }
-}
-
 /* Create pptrs for all root server objects, starting at a give start address,
  * to cover the virtual memory region v_reg, and any extra boot info.
  */
 BOOT_CODE static void create_rootserver_objects(pptr_t start, v_region_t it_v_reg,
-                                                word_t extra_bi_size_bits)
+                                                word_t num_bi_pages)
 {
-    /* the largest object the PD, the root cnode, or the extra boot info */
+    word_t size = calculate_rootserver_size(it_v_reg, num_bi_pages);
     word_t cnode_size_bits = CONFIG_ROOT_CNODE_SIZE_BITS + seL4_SlotBits;
-    word_t max = rootserver_max_size_bits(extra_bi_size_bits);
 
-    word_t size = calculate_rootserver_size(it_v_reg, extra_bi_size_bits);
     rootserver_mem.start = start;
     rootserver_mem.end = start + size;
-
-    maybe_alloc_extra_bi(max, extra_bi_size_bits);
 
     /* the root cnode is at least 4k, so it could be larger or smaller than a pd. */
 #if (CONFIG_ROOT_CNODE_SIZE_BITS + seL4_SlotBits) > seL4_VSpaceBits
     rootserver.cnode = alloc_rootserver_obj(cnode_size_bits, 1);
-    maybe_alloc_extra_bi(seL4_VSpaceBits, extra_bi_size_bits);
     rootserver.vspace = alloc_rootserver_obj(seL4_VSpaceBits, 1);
 #else
     rootserver.vspace = alloc_rootserver_obj(seL4_VSpaceBits, 1);
-    maybe_alloc_extra_bi(cnode_size_bits, extra_bi_size_bits);
     rootserver.cnode = alloc_rootserver_obj(cnode_size_bits, 1);
 #endif
 
     /* at this point we are up to creating 4k objects - which is the min size of
      * extra_bi so this is the last chance to allocate it */
-    maybe_alloc_extra_bi(seL4_PageBits, extra_bi_size_bits);
     compile_assert(invalid_seL4_ASIDPoolBits, seL4_ASIDPoolBits == seL4_PageBits);
     rootserver.asid_pool = alloc_rootserver_obj(seL4_ASIDPoolBits, 1);
     rootserver.ipc_buf = alloc_rootserver_obj(seL4_PageBits, 1);
-    compile_assert(invalid_BI_FRAME_SIZE_BITS, BI_FRAME_SIZE_BITS == seL4_PageBits);
-    rootserver.boot_info = alloc_rootserver_obj(BI_FRAME_SIZE_BITS, 1);
+    rootserver.boot_info = alloc_rootserver_obj(seL4_PageBits, num_bi_pages);
 
     /* TCBs on aarch32 can be larger than page tables in certain configs */
 #if seL4_TCBBits >= seL4_PageTableBits
@@ -296,38 +281,63 @@ BOOT_CODE cap_t create_ipcbuf_frame_cap(cap_t root_cnode_cap, cap_t pd_cap, vptr
     return cap;
 }
 
-BOOT_CODE void create_bi_frame_cap(cap_t root_cnode_cap, cap_t pd_cap, vptr_t vptr)
+BOOT_CODE bool_t create_bi_frame_caps(cap_t root_cnode_cap, cap_t it_vspace_cap,
+                                      vptr_t bi_frame_vptr, word_t num_bi_pages)
 {
-    /* create a cap of it and write it into the root CNode */
-    cap_t cap = create_mapped_it_frame_cap(pd_cap, rootserver.boot_info, vptr, IT_ASID, false, false);
-    write_slot(SLOT_PTR(pptr_of_cap(root_cnode_cap), seL4_CapBootInfoFrame), cap);
-}
+    assert(num_bi_pages >= 1);
+    assert(0 == (bi_frame_vptr % BIT(seL4_PageBits)));
 
-BOOT_CODE word_t calculate_extra_bi_size_bits(word_t extra_size)
-{
-    if (extra_size == 0) {
-        return 0;
+    pptr_t bi_frame_pptr = rootserver.boot_info;
+    assert(0 == (bi_frame_pptr % BIT(seL4_PageBits)));
+
+    seL4_SlotRegion *bi_slots = &(ndks_boot.bi_frame->extraBIPages);
+
+    for (word_t i = 0; i < num_bi_pages; i++) {
+        /* Create a cap for a page mapped to the initial thread. The mapping is
+         * non-executable with read/write access. Ideally, we function would
+         * also allow making it read-only.
+         */
+        word_t offset = i * BIT(seL4_PageBits);
+        cap_t bi_page_cap = create_mapped_it_frame_cap(
+                                it_vspace_cap,
+                                bi_frame_pptr + offset,
+                                bi_frame_vptr + offset,
+                                IT_ASID,  false, false);
+        /* The cap for the first page is stored at a well known place in the
+         * root C-Node. The slots of the other frame caps are given via the boot
+         * info data structure in the boot info page.
+         */
+        if (0 == i) {
+            write_slot(
+                SLOT_PTR(pptr_of_cap(root_cnode_cap), seL4_CapBootInfoFrame),
+                bi_page_cap);
+        } else {
+            if (1 == i) {
+                bi_slots->start = ndks_boot.slot_pos_cur;
+            }
+
+            if (!provide_cap(root_cnode_cap, bi_page_cap)) {
+                printf("ERROR: mapping extra boot info failed\n");
+                return false;
+            }
+
+            /* provide_cap() has updated ndks_boot.slot_pos_cur */
+            bi_slots->end = ndks_boot.slot_pos_cur;
+        }
     }
 
-    word_t clzl_ret = clzl(ROUND_UP(extra_size, seL4_PageBits));
-    word_t msb = seL4_WordBits - 1 - clzl_ret;
-    /* If region is bigger than a page, make sure we overallocate rather than
-     * underallocate
-     */
-    if (extra_size > BIT(msb)) {
-        msb++;
-    }
-    return msb;
+    return true;
 }
 
 BOOT_CODE void populate_bi_frame(node_id_t node_id, word_t num_nodes,
-                                 vptr_t ipcbuf_vptr, word_t extra_bi_size)
+                                 vptr_t ipcbuf_vptr, word_t num_bi_pages)
 {
-    /* clear boot info memory */
-    clearMemory((void *)rootserver.boot_info, BI_FRAME_SIZE_BITS);
-    if (extra_bi_size) {
-        clearMemory((void *)rootserver.extra_bi,
-                    calculate_extra_bi_size_bits(extra_bi_size));
+    assert(num_bi_pages >= 1);
+    /* properly clean memory before any user-level access. */
+    for (word_t i = 0; i < num_bi_pages; i++) {
+        clearMemory(
+            (void *)(rootserver.boot_info + i * BIT(seL4_PageBits)),
+            seL4_PageBits);
     }
 
     /* initialise bootinfo-related global state */
@@ -338,7 +348,7 @@ BOOT_CODE void populate_bi_frame(node_id_t node_id, word_t num_nodes,
     bi->ipcBuffer = (seL4_IPCBuffer *)ipcbuf_vptr;
     bi->initThreadCNodeSizeBits = CONFIG_ROOT_CNODE_SIZE_BITS;
     bi->initThreadDomain = ksDomSchedule[ksDomScheduleIdx].domain;
-    bi->extraLen = extra_bi_size;
+    bi->extraLen = BIT(seL4_PageBits) * (num_bi_pages - 1);
 
     ndks_boot.bi_frame = bi;
     ndks_boot.slot_pos_cur = seL4_NumInitialCaps;
@@ -810,7 +820,7 @@ BOOT_BSS static region_t avail_reg[MAX_NUM_FREEMEM_REG];
  */
 BOOT_CODE bool_t init_freemem(word_t n_available, const p_region_t *available,
                               word_t n_reserved, const region_t *reserved,
-                              v_region_t it_v_reg, word_t extra_bi_size_bits)
+                              v_region_t it_v_reg, word_t num_bi_pages)
 {
 
     if (!check_available_memory(n_available, available)) {
@@ -901,8 +911,8 @@ BOOT_CODE bool_t init_freemem(word_t n_available, const p_region_t *available,
 
     /* try to grab the last available p region to create the root server objects
      * from. If possible, retain any left over memory as an extra p region */
-    word_t size = calculate_rootserver_size(it_v_reg, extra_bi_size_bits);
-    word_t max = rootserver_max_size_bits(extra_bi_size_bits);
+    word_t size = calculate_rootserver_size(it_v_reg, num_bi_pages);
+    word_t max = rootserver_max_size_bits();
     for (; i >= 0; i--) {
         /* Invariant: both i and (i + 1) are valid indices in ndks_boot.freemem. */
         assert(i < ARRAY_SIZE(ndks_boot.freemem) - 1);
@@ -925,7 +935,7 @@ BOOT_CODE bool_t init_freemem(word_t n_available, const p_region_t *available,
          * then we've found a region that fits the root server objects. */
         if (unaligned_start <= ndks_boot.freemem[i].end
             && start >= ndks_boot.freemem[i].start) {
-            create_rootserver_objects(start, it_v_reg, extra_bi_size_bits);
+            create_rootserver_objects(start, it_v_reg, num_bi_pages);
             /* There may be leftovers before and after the memory we used. */
             /* Shuffle the after leftover up to the empty slot (i + 1). */
             ndks_boot.freemem[empty_index] = (region_t) {


### PR DESCRIPTION
This PR collects several commit that improve the boot info frame handling.

- allocate all boot info pages together using page alignment. There is no need to require a higher alignment.
- allow static boot info to use more than one page
- mark all boot info pages non-executable (https://github.com/seL4/seL4/issues/734)
- make `SEL4_BI_FRAME_SIZE` available to userland.
- code cleanup: create helper functions for boot info data 
- drop dead ARM/RISC-V code that was supposed to write a padding chunk. Seems this was a copy/paste from x86 but it never wrote any padding block practically. And on x86 this also seems a bit artificial given the valid data length is known.
- more sanity checks when populating the boot info data
- add compile assert for `seL4_UntypedDesc` size. This header file is shared by kernel and userland. We can control the kernel compiler setting, but userland might use an arbitrary setup. Put a safeguard in place that things works as expected.
- add compile time checks for `seL4_ASIDPoolBits`: The root server object allocation only works if `seL4_ASIDPoolBits` is exactly one page. Add a build breaker if this does not hold here.
- add more comments
- trivial: align comment formatting 

It's also follow up on the rejected PR https://github.com/seL4/seL4/pull/751 and provides a way to extend the hard limits of `CONFIG_MAX_NUM_BOOTINFO_UNTYPED_CAPS` for special porting configurations.