### PR TITLE
add support for building kernel.elf on MacOS

### DIFF
--- a/config.cmake
+++ b/config.cmake
@@ -152,10 +152,15 @@ if(DEFINED KernelDTSList AND (NOT "${KernelDTSList}" STREQUAL ""))
         if(error)
             message(FATAL_ERROR "Failed to compile DTS to DTB: ${KernelDTBPath}")
         endif()
+        # CMAKE_HOST_APPLE is a built-in CMake variable
+        if(CMAKE_HOST_APPLE)
+            set(STAT_ARGS "-f%z")
+        else()
+            set(STAT_ARGS "-c '%s'")
+        endif()
         # Track the size of the DTB for downstream tools
         execute_process(
-            COMMAND
-                ${STAT_TOOL} -c '%s' ${KernelDTBPath}
+            COMMAND ${STAT_TOOL} ${STAT_ARGS} ${KernelDTBPath}
             OUTPUT_VARIABLE KernelDTBSize
             OUTPUT_STRIP_TRAILING_WHITESPACE
             RESULT_VARIABLE error

--- a/gcc.cmake
+++ b/gcc.cmake
@@ -106,13 +106,9 @@ if("${CROSS_COMPILER_PREFIX}" STREQUAL "")
 
     if("${CROSS_COMPILER_PREFIX}" STREQUAL "")
         # If we haven't set a target above we assume x86_64/ia32 target
-        if(APPLE)
-            # APPLE is a CMake variable that evaluates to True on a Mac OSX system
-            FindPrefixedGCC(
-                CROSS_COMPILER_PREFIX
-                "x86_64-linux-gnu-"
-                "x86_64-unknown-linux-gnu-"
-            )
+        if(CMAKE_HOST_APPLE)
+            # CMAKE_HOST_APPLE is a CMake variable that evaluates to True on a Mac OSX system
+            FindPrefixedGCC(CROSS_COMPILER_PREFIX "x86_64-linux-gnu-" "x86_64-unknown-linux-gnu-")
         endif()
     endif()
 endif()

--- a/gcc.cmake
+++ b/gcc.cmake
@@ -55,9 +55,14 @@ endfunction(FindPrefixedGCC)
 if("${CROSS_COMPILER_PREFIX}" STREQUAL "")
     if(("${arch}" STREQUAL "arm") OR ("${arch}" STREQUAL "x86") OR ("${arch}" STREQUAL "riscv"))
         if(${sel4_arch} STREQUAL "aarch32" OR ${sel4_arch} STREQUAL "arm_hyp")
-            FindPrefixedGCC(CROSS_COMPILER_PREFIX "arm-linux-gnueabi-" "arm-linux-gnu-")
+            FindPrefixedGCC(
+                CROSS_COMPILER_PREFIX
+                "arm-linux-gnueabi-"
+                "arm-linux-gnu-"
+                "arm-none-eabi-"
+            )
         elseif(${sel4_arch} STREQUAL "aarch64")
-            set(CROSS_COMPILER_PREFIX "aarch64-linux-gnu-")
+            FindPrefixedGCC(CROSS_COMPILER_PREFIX "aarch64-linux-gnu-" "aarch64-unknown-linux-gnu-")
         elseif(${arch} STREQUAL "riscv")
             FindPrefixedGCC(
                 CROSS_COMPILER_PREFIX
@@ -71,12 +76,17 @@ if("${CROSS_COMPILER_PREFIX}" STREQUAL "")
         # If initialised with -DCMAKE_TOOLCHAIN_FILE="$SCRIPT_PATH/gcc.cmake" this script
         # understood the following arguments: ARM, AARCH32, AARCH32HF, AARCH64, RISCV32, RISCV64, APPLE
         if(AARCH32 OR ARM)
-            FindPrefixedGCC(CROSS_COMPILER_PREFIX "arm-linux-gnueabi-" "arm-linux-gnu-")
+            FindPrefixedGCC(
+                CROSS_COMPILER_PREFIX
+                "arm-linux-gnueabi-"
+                "arm-linux-gnu-"
+                "arm-none-eabi-"
+            )
             if(ARM)
                 message("ARM flag is deprecated, please use AARCH32")
             endif()
         elseif(AARCH64)
-            set(CROSS_COMPILER_PREFIX "aarch64-linux-gnu-")
+            FindPrefixedGCC(CROSS_COMPILER_PREFIX "aarch64-linux-gnu-" "aarch64-unknown-linux-gnu-")
         elseif(RISCV32 OR RISCV64)
             FindPrefixedGCC(
                 CROSS_COMPILER_PREFIX
@@ -98,7 +108,11 @@ if("${CROSS_COMPILER_PREFIX}" STREQUAL "")
         # If we haven't set a target above we assume x86_64/ia32 target
         if(APPLE)
             # APPLE is a CMake variable that evaluates to True on a Mac OSX system
-            set(CROSS_COMPILER_PREFIX "x86_64-unknown-linux-gnu-")
+            FindPrefixedGCC(
+                CROSS_COMPILER_PREFIX
+                "x86_64-linux-gnu-"
+                "x86_64-unknown-linux-gnu-"
+            )
         endif()
     endif()
 endif()


### PR DESCRIPTION
This has been sitting in my private patch queue for a while -- it turns out if the scope is just `kernel.elf` the changes needed to build `kernel.elf` on MacOS are minimal, so I think it would make sense to include them here. I'm happy to be the maintainer for the foreseeable future.

This PR contains:
 - additional toolchain prefixes to match up defaults on MacOS
 - user `CMAKE_HOST_APPLE` instead of `APPLE` (selects based on host instead of target)
 - produce a slightly different command-line invocation for `stat`, since MacOS X has BSD `stat` not GNU `stat`.

I've tested these with the verified build configurations on MacOS (and all configs on Linux. I don't expect other configs to turn up any problems, but I have not looked at trying to build sel4test or other user-level code.