### PR TITLE
github: let hw test run to completion on failure

### DIFF
--- a/.github/workflows/sel4test-deploy.yml
+++ b/.github/workflows/sel4test-deploy.yml
@@ -92,6 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [sim, the_matrix]
     strategy:
+      fail-fast: false
       matrix: ${{ fromJson(needs.the_matrix.outputs.matrix) }}
     # do not run concurrently with other workflows, but do run concurrently in the build matrix
     concurrency: hw-run-${{ strategy.job-index }}


### PR DESCRIPTION
Merge to master is infrequent enough that we can let the hardware test
suite run to completion even if one of the tests failed. This will
provide more information in the history on which boards worked for
which commits, even if the test for one is broken for some time.
