### PR TITLE
github: add AARCH64 to preprocess test

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -39,10 +39,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [ARM, ARM_HYP, RISCV64, X64]
+        arch: [ARM, ARM_HYP, AARCH64, RISCV64, X64]
         feature: ["", MCS]
         exclude:
           - arch: ARM_HYP
+            feature: MCS
+          - arch: AARCH64
             feature: MCS
           - arch: X64
             feature: MCS

--- a/.github/workflows/preprocess-deploy.yml
+++ b/.github/workflows/preprocess-deploy.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: [ARM, ARM_HYP, RISCV64, X64]
+        arch: [ARM, ARM_HYP, AARCH64, RISCV64, X64]
         # no MCS here, auto-updating mcs.xml should be a separate job.
     steps:
     - uses: seL4/ci-actions/preprocess@master


### PR DESCRIPTION
There is now an `AARCH64_verified` configuration which is used in ongoing verification of the seL4 Aarch64 port. This commit enables the preprocess check for this config so that verification impact becomes visible on pull requests.
