### PR TITLE
github: standalone-compilation for AARCH64

### DIFF
--- a/.github/workflows/compilation-checks.yml
+++ b/.github/workflows/compilation-checks.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [ARM, ARM_HYP, RISCV64, X64]
+        arch: [ARM, ARM_HYP, AARCH64, RISCV64, X64]
         compiler: [gcc, llvm]
         exclude:
           # llvm RISCV64 compilation is not currently supported


### PR DESCRIPTION
Use the AARCH64_verified config for the standalone kernel compilation check.

(This is the counter part to seL4/ci-actions#183)