### PR TITLE
remove usage of ANY in dtd

### DIFF
--- a/libsel4/tools/sel4_idl.dtd
+++ b/libsel4/tools/sel4_idl.dtd
@@ -26,13 +26,13 @@
 <!ATTLIST method manual_name CDATA #IMPLIED>
 <!ATTLIST method manual_label CDATA #IMPLIED>
 
-<!ELEMENT param (#PCDATA|description|error)*>
+<!ELEMENT param (description?, error*)>
 <!ATTLIST param type CDATA #REQUIRED>
 <!ATTLIST param name CDATA #REQUIRED>
 <!ATTLIST param dir CDATA #REQUIRED>
 <!ATTLIST param description CDATA #IMPLIED>
 
-<!ELEMENT error (#PCDATA|description)*>
+<!ELEMENT error (description?)>
 <!ATTLIST error name CDATA #REQUIRED>
 <!ATTLIST error description CDATA #IMPLIED>
 

--- a/libsel4/tools/sel4_idl.dtd
+++ b/libsel4/tools/sel4_idl.dtd
@@ -26,23 +26,23 @@
 <!ATTLIST method manual_name CDATA #IMPLIED>
 <!ATTLIST method manual_label CDATA #IMPLIED>
 
-<!ELEMENT param ANY>
+<!ELEMENT param (#PCDATA|description|error)*>
 <!ATTLIST param type CDATA #REQUIRED>
 <!ATTLIST param name CDATA #REQUIRED>
 <!ATTLIST param dir CDATA #REQUIRED>
 <!ATTLIST param description CDATA #IMPLIED>
 
-<!ELEMENT error ANY>
+<!ELEMENT error (#PCDATA|description)*>
 <!ATTLIST error name CDATA #REQUIRED>
 <!ATTLIST error description CDATA #IMPLIED>
 
-<!ELEMENT brief ANY>
+<!ELEMENT brief (#PCDATA|texttt|docref|shortref|autoref|obj)*>
 
-<!ELEMENT description ANY>
+<!ELEMENT description (#PCDATA|texttt|docref|shortref|autoref|obj)*>
 
-<!ELEMENT return ANY>
+<!ELEMENT return (#PCDATA|texttt|docref|shortref|autoref|obj|errorenumdesc)*>
 
-<!ELEMENT docref ANY>
+<!ELEMENT docref (#PCDATA|texttt|shortref|autoref|obj)*>
 
 <!ELEMENT texttt EMPTY>
 <!ATTLIST texttt text CDATA #REQUIRED>


### PR DESCRIPTION
This patch restricts mixed-content elements from ANY
to the various leaf nodes which are used.

This is intended to allow for easier parsing in languages with
no recursive datatypes like rust.
Since they no longer have to handle things like
```
<description> text
   <description>more text</description>
<description>
```

which the dtd allowed for, but never used.

tested with:
```
for i in {libsel4/arch_include/*/interfaces/,\
libsel4/include/interfaces/,\
libsel4/sel4_arch_include/*/interfaces}/*.xml;
do
     xmllint --noout --dtdvalid libsel4/tools/sel4_idl.dtd $i;
done
```