### PR TITLE
trivial: remove duplicate headers

### DIFF
--- a/include/object.h
+++ b/include/object.h
@@ -12,7 +12,6 @@
 #include <object/cnode.h>
 #include <object/endpoint.h>
 #include <object/interrupt.h>
-#include <object/objecttype.h>
 #include <object/structures.h>
 #include <object/tcb.h>
 #include <object/untyped.h>


### PR DESCRIPTION
Remove the duplicate objecttype.h in include/object.h

Signed-off-by: Cao Jianlong <caojianlong@outlook.com>