### PR TITLE
Remove globals frame caveat

### DIFF
--- a/CAVEATS-generic.md
+++ b/CAVEATS-generic.md
@@ -50,14 +50,6 @@ provides principled access control for execution time, but its formal
 verification is currently still in progress.
 
 
-## IPC buffer in globals frame may be stale
-
-When a thread invokes its own TCB object to (re-)register its IPC buffer and
-the thread is re-scheduled immediately, the userland IPC buffer pointer in the
-globals frame may still show the old value. It is updated on the next thread
-switch.
-
-
 ## Re-using Address Spaces (ARM and x86):
 
 Before an ASID/page directory/page table can be reused, all frame caps

--- a/CHANGES
+++ b/CHANGES
@@ -35,7 +35,7 @@ Upcoming release: BINARY COMPATIBLE
 * Remove ARM1136JF_S and ARMv6 support. This architecture version is being removed as it is sufficiently old and
   unused. See https://sel4.atlassian.net/browse/RFC-8.
 * Remove ARMv6 specific configs: KernelGlobalsFrame and KernelDangerousCodeInjectionOnUndefInstr. This removes the
-  constant seL4_GlobalsFrame from libsel4.
+  constant seL4_GlobalsFrame from libsel4 as well as the IPC buffer in GlobalsFrame caveat from CAVEATS-generic.md
 * Implement KernelArmExportPTMRUser and KernelArmExportVTMRUser options for Arm generic timer use access on aarch32.
 * Removed obsolete define `HAVE_AUTOCONF`
 


### PR DESCRIPTION
There is no longer a globals frame and thus no longer a caveat about it.
The globals frame was removed when ARMv6 support was removed recently.

Signed-off-by: Kent McLeod <kent@kry10.com>