### PR TITLE
riscv: fpu extension fixes

### DIFF
--- a/include/arch/riscv/arch/machine/fpu.h
+++ b/include/arch/riscv/arch/machine/fpu.h
@@ -27,7 +27,7 @@ static inline void set_fs_off(void)
 
 #define FL "flw"
 #define FS "fsw"
-#define FP_REG_TYPES "4"
+#define FP_REG_BYTES "4"
 
 #endif
 

--- a/src/arch/riscv/config.cmake
+++ b/src/arch/riscv/config.cmake
@@ -68,8 +68,9 @@ elseif(KernelPTLevels EQUAL 4)
 endif()
 
 if(KernelRiscvExtD)
+    # The D extension depends on the base single-precision
+    # instruction subset F.
     set(KernelRiscvExtF ON)
-    set(KernelHaveFPU ON)
 endif()
 
 if(KernelRiscvExtF)


### PR DESCRIPTION
This includes a fix for the riscv F extension as well as a simplification of the riscv `config.cmake`.