### PR TITLE
trivial: Convert UTF-8 character to ASCII

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -13,7 +13,7 @@
 #ifdef __ASSEMBLER__
 
 /* Provide a helper macro to define integer constants that are not of the
- * default type 'ìnt', but 'unsigned long [long]'. When such constants are
+ * default type 'int', but 'unsigned long [long]'. When such constants are
  * shared between assembly and C code, some assemblers will fail because they
  * don't support C-style integer suffixes like 'ul'. Using a macro works around
  * this, as the suffix is only applied when the C compiler is used and dropped

--- a/src/machine/io.c
+++ b/src/machine/io.c
@@ -5,7 +5,7 @@
  *
  * Portions derived from musl:
  *
- * Copyright © 2005-2020 Rich Felker, et al.
+ * Copyright (c) 2005-2020 Rich Felker, et al.
  *
  * SPDX-License-Identifier: MIT
  */


### PR DESCRIPTION
When building seL4 on a host whose default encoding is not UTF-8,
tools/bitfield_gen.py complains, as with the following log from
Python 3.6 on a Ubuntu 18.04 host says:

```
  Traceback (most recent call last):
    File "tools/bitfield_gen.py",
  line 2773, in <module>
      string = f.read()
    File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
      return codecs.ascii_decode(input, self.errors)[0]
  UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 607543: ordinal not in range(128)
```

As the Python 3 doc for open() [1] says the default encoding is
platform dependent, such build error may happen on some hosts.
We can either updating tools/bitfield_gen.py to call open() with
an explicit encoding="utf-8" parameter, or avoiding UTF-8 characters
in the source codes.

After inspecting the two places in current source tree that use UTF-8
characters, none of them is absolutely necessary. Let's convert
them to ASCII characters.

[1] https://docs.python.org/3.6/library/functions.html#open

Signed-off-by: Bin Meng <bmeng.cn@gmail.com>