### PR TITLE
tools/bitfield_gen.py: Ensure UTF-8 encoding for the open() call

### DIFF
--- a/tools/bitfield_gen.py
+++ b/tools/bitfield_gen.py
@@ -2768,7 +2768,7 @@ if __name__ == '__main__':
 
         pruned_names = set()
         for filename in options.prune_files:
-            f = open(filename)
+            f = open(filename, encoding="utf-8")
             string = f.read()
 
             matched_tokens = set(search_re.findall(string))


### PR DESCRIPTION
There are cases to have UTF-8 characters in the source codes, hence
tools/bitfield_gen.py must be able to handle them correctly. Let's
explicitly pass encoding="utf-8" to the open() call.

Signed-off-by: Bin Meng <bmeng.cn@gmail.com>