### PR TITLE
use unreachable instead of returning something

### DIFF
--- a/src/kernel/cspace.c
+++ b/src/kernel/cspace.c
@@ -191,6 +191,5 @@ resolveAddressBits_ret_t resolveAddressBits(cap_t nodeCap, cptr_t capptr, word_t
         }
     }
 
-    ret.status = EXCEPTION_NONE;
-    return ret;
+    UNREACHABLE();
 }


### PR DESCRIPTION
The loop is always left by a direct return from the body, any code after the loop is not reachable.
