### PR TITLE
benchmark/track: avoid ambiguous values

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -38,6 +38,8 @@ Upcoming release: BINARY COMPATIBLE
   constant seL4_GlobalsFrame from libsel4 as well as the IPC buffer in GlobalsFrame caveat from CAVEATS-generic.md
 * Implement KernelArmExportPTMRUser and KernelArmExportVTMRUser options for Arm generic timer use access on aarch32.
 * Removed obsolete define `HAVE_AUTOCONF`
+* The value for 'Entry_VMExit' has changed. This make the values in the benchmark/tracking enum 'entry_type_t'
+  unique across all architectures to avoid ambiguity.
 
 ## Upgrade Notes
 ---

--- a/include/api/debug.h
+++ b/include/api/debug.h
@@ -59,7 +59,7 @@ static inline void debug_printKernelEntryReason(void)
         break;
 #endif
     default:
-        printf("Unknown\n");
+        printf("Unknown (%u)\n", ksKernelEntry.path);
         break;
 
     }

--- a/libsel4/include/sel4/benchmark_track_types.h
+++ b/libsel4/include/sel4/benchmark_track_types.h
@@ -21,12 +21,8 @@ typedef enum {
     Entry_VMFault,
     Entry_Syscall,
     Entry_UnimplementedDevice,
-#ifdef CONFIG_ARCH_ARM
-    Entry_VCPUFault,
-#endif
-#ifdef CONFIG_ARCH_X86
-    Entry_VMExit,
-#endif
+    Entry_VCPUFault, /* currently used on ARM only */
+    Entry_VMExit, /* currently used on x86 only */
 } entry_type_t;
 
 /**


### PR DESCRIPTION
- Using unique values across all architectures avoids having ambiguous values. This allows adding more values without creating more ambiguity, which will become confusion for generic userland tools.
- The value for `Entry_VMExit` changes.
- Print entry path ID in case of unknown values.

The ambiguity has been introduced in https://github.com/seL4/seL4/commit/fc0f1eec76fbf623e34aeb0f774c777c3690223e, this also introduced `Entry_VMExit`. Unfortunately, there is no explanation if this was intended for some reason or if this was just done because the values are used on one architecture only.