### PR TITLE
benchmark/trace: remove conditional else block

### DIFF
--- a/src/arch/x86/machine/breakpoint.c
+++ b/src/arch/x86/machine/breakpoint.c
@@ -590,8 +590,6 @@ exception_t handleUserLevelDebugException(int int_vector)
 #if defined(CONFIG_DEBUG_BUILD) || defined(CONFIG_BENCHMARK_TRACK_KERNEL_ENTRIES)
     ksKernelEntry.path = Entry_UserLevelFault;
     ksKernelEntry.word = int_vector;
-#else
-    (void)int_vector;
 #endif /* DEBUG */
 
 #ifdef CONFIG_BENCHMARK_TRACK_KERNEL_ENTRIES


### PR DESCRIPTION
The conditional else-block with the dummy reference might have been added once to avoid a compiler warning about unreferenced parameters. However, 'int_vector' is used in the code now, so this is obsolete.