### PR TITLE
aarch64: Use asid_map_t bitfield to store vspace attributes to free mapping slots

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -38,6 +38,8 @@ Upcoming release: BINARY COMPATIBLE
   constant seL4_GlobalsFrame from libsel4 as well as the IPC buffer in GlobalsFrame caveat from CAVEATS-generic.md
 * Implement KernelArmExportPTMRUser and KernelArmExportVTMRUser options for Arm generic timer use access on aarch32.
 * Removed obsolete define `HAVE_AUTOCONF`
+* Removed user address space reserved slots restriction on 40bit PA platforms when KernelArmHypervisorSupport is set.
+  This change is reflected in the definition of the seL4_UserTop constant that holds the largest user virtual address.
 
 ## Upgrade Notes
 ---

--- a/include/arch/arm/arch/64/mode/fastpath/fastpath.h
+++ b/include/arch/arm/arch/64/mode/fastpath/fastpath.h
@@ -36,7 +36,7 @@ switchToThread_fp(tcb_t *thread, vspace_root_t *vroot, pde_t stored_hw_asid)
         vcpu_switch(thread->tcbArch.tcbVCPU);
     }
     asid = (asid_t)(stored_hw_asid.words[0] & 0xffff);
-    armv_contextSwitch(vroot, asid);
+    armv_contextSwitch_HWASID(vroot, asid);
 
 #ifdef CONFIG_BENCHMARK_TRACK_UTILISATION
     benchmark_utilisation_switch(NODE_STATE(ksCurThread), thread);

--- a/include/arch/arm/arch/64/mode/kernel/vspace.h
+++ b/include/arch/arm/arch/64/mode/kernel/vspace.h
@@ -73,13 +73,11 @@ static const region_t BOOT_RODATA *mode_reserved_region = NULL;
 #define cap_vtable_root_ptr_set_mappedCB(_c, cb) \
     cap_page_upper_directory_cap_ptr_set_capPUDMappedCB(_c, cb)
 #define cap_vtable_cap_new(_a, _v, _m) cap_page_upper_directory_cap_new(_a, _v, _m, 0, CB_INVALID)
-#define vtable_invalid_new(_a, _v) pude_pude_invalid_new(_a, _v, 0)
-#define vtable_invalid_smmu_new(_cb) pude_pude_invalid_new(0, false, _cb)
+#define vtable_invalid_smmu_new(_cb) pude_pude_invalid_new(_cb)
 #define vtable_invalid_get_bind_cb(_v) \
     pude_pude_invalid_get_bind_cb(_v)
 #else
 #define cap_vtable_cap_new(_a, _v, _m) cap_page_upper_directory_cap_new(_a, _v, _m, 0)
-#define vtable_invalid_new(_a, _v) pude_pude_invalid_new(_a, _v)
 #endif  /*!CONFIG_ARM_SMMU*/
 
 #define vtable_invalid_get_stored_asid_valid(_v) \
@@ -90,7 +88,11 @@ static inline exception_t performASIDPoolInvocation(asid_t asid, asid_pool_t *po
 {
     cap_page_upper_directory_cap_ptr_set_capPUDMappedASID(&cte->cap, asid);
     cap_page_upper_directory_cap_ptr_set_capPUDIsMapped(&cte->cap, 1);
+#ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
+    asid_map_t asid_map = asid_map_asid_map_vspace_new(cap_page_upper_directory_cap_get_capPUDBasePtr(cte->cap), 0, false);
+#else
     asid_map_t asid_map = asid_map_asid_map_vspace_new(cap_page_upper_directory_cap_get_capPUDBasePtr(cte->cap));
+#endif
     poolPtr->array[asid & MASK(asidLowBits)] = asid_map;
 #ifdef CONFIG_ARM_SMMU
     vspace_root_t *vtable = (vspace_root_t *)cap_page_upper_directory_cap_get_capPUDBasePtr(cte->cap);
@@ -116,14 +118,12 @@ static inline exception_t performASIDPoolInvocation(asid_t asid, asid_pool_t *po
     cap_page_global_directory_cap_ptr_set_capPGDMappedCB(_c, cb)
 #define cap_vtable_cap_new(_a, _v, _m) \
     cap_page_global_directory_cap_new(_a, _v, _m, CB_INVALID)
-#define vtable_invalid_new(_a, _v) pgde_pgde_invalid_new(_a, _v, 0)
-#define vtable_invalid_smmu_new(_cb) pgde_pgde_invalid_new(0, false, _cb)
+#define vtable_invalid_smmu_new(_cb) pgde_pgde_invalid_new(_cb)
 #define vtable_invalid_get_bind_cb(_v) \
     pgde_pgde_invalid_get_bind_cb(_v)
 #else
 #define cap_vtable_cap_new(_a, _v, _m) \
     cap_page_global_directory_cap_new(_a, _v, _m)
-#define vtable_invalid_new(_a, _v) pgde_pgde_invalid_new(_a, _v)
 #endif /*!CONFIG_ARM_SMMU*/
 
 #define vtable_invalid_get_stored_asid_valid(_v) \
@@ -134,7 +134,11 @@ static inline exception_t performASIDPoolInvocation(asid_t asid, asid_pool_t *po
 {
     cap_page_global_directory_cap_ptr_set_capPGDMappedASID(&cte->cap, asid);
     cap_page_global_directory_cap_ptr_set_capPGDIsMapped(&cte->cap, 1);
+#ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
+    asid_map_t asid_map = asid_map_asid_map_vspace_new(cap_page_global_directory_cap_get_capPGDBasePtr(cte->cap), 0, false);
+#else
     asid_map_t asid_map = asid_map_asid_map_vspace_new(cap_page_global_directory_cap_get_capPGDBasePtr(cte->cap));
+#endif
     poolPtr->array[asid & MASK(asidLowBits)] = asid_map;
 
 #ifdef CONFIG_ARM_SMMU

--- a/include/arch/arm/arch/64/mode/kernel/vspace.h
+++ b/include/arch/arm/arch/64/mode/kernel/vspace.h
@@ -14,22 +14,6 @@
 #define activate_global_pd activate_kernel_vspace
 #define MODE_RESERVED 0
 
-/* The VTABLE_VMID_SLOT in user-level applications's vspace root
- * is reserved for storing its allocated hardware 8-bit VMID
- * when running EL2. Note that this assumes that the IPA size for S2
- * translation and the VA size for the S1 translation do not use full
- * 48-bit. Please see the definition of seL4_UserTop for details.
- */
-#define VTABLE_VMID_SLOT   MASK(seL4_VSpaceIndexBits)
-
-/* The VTABLE_SMMU_SLOT in user-level applications's vspace root is reserved
- * for storing the number of context banks bound with this vspace when the
- * SMMU feature is enabled. This assumes the user-level address space do not
- * use the second last entry in the vspace root, which is preserved by the
- * seL4_UserTop.
- */
-#define VTABLE_SMMU_SLOT   (MASK(seL4_VSpaceIndexBits) - 1)
-
 /* ==================== BOOT CODE FINISHES HERE ==================== */
 
 bool_t CONST isVTableRoot(cap_t cap);

--- a/include/arch/arm/arch/64/mode/object/structures.bf
+++ b/include/arch/arm/arch/64/mode/object/structures.bf
@@ -244,10 +244,17 @@ block asid_map_none {
     field type                      1
 }
 
+--- hw_vmids are required in hyp mode
 block asid_map_vspace {
     padding                         16
     field_high vspace_root          36
+#ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
+    padding                         2
+    field stored_hw_vmid            8
+    field stored_vmid_valid         1
+#else
     padding                         11
+#endif
     field type                      1
 }
 
@@ -259,15 +266,12 @@ tagged_union asid_map type {
 -- PGDE, PUDE, PDEs and PTEs, assuming 48-bit physical address
 base 64(48,0)
 
--- hw_asids are required in hyp mode
 block pgde_invalid {
-    field stored_hw_asid            8
-    field stored_asid_valid         1
 #ifdef CONFIG_ARM_SMMU
     field bind_cb                   12
-    padding                         41
+    padding                         50
 #else
-    padding                         53
+    padding                         62
 #endif
     field pgde_type                 2
 }
@@ -285,13 +289,11 @@ tagged_union pgde pgde_type {
 }
 
 block pude_invalid {
-    field stored_hw_asid            8
-    field stored_asid_valid         1
- #ifdef CONFIG_ARM_SMMU
+#ifdef CONFIG_ARM_SMMU
     field bind_cb                   12
-    padding                         41
+    padding                         50
 #else
-    padding                         53
+    padding                         62
 #endif
     field pude_type                 2
 }

--- a/include/arch/arm/arch/64/mode/object/structures.bf
+++ b/include/arch/arm/arch/64/mode/object/structures.bf
@@ -65,8 +65,8 @@ block page_upper_directory_cap {
     field capPUDIsMapped             1
     field_high capPUDMappedAddress   10
 #if defined (CONFIG_ARM_SMMU)  && defined (AARCH64_VSPACE_S2_START_L1)
-    field capPUDMappedCB             12
-    padding                          36
+    field capPUDMappedCB             8
+    padding                          40
 #else 
     padding                          48
 #endif 
@@ -80,8 +80,8 @@ block page_global_directory_cap {
     field capType                    5
     field capPGDIsMapped             1
 #ifdef CONFIG_ARM_SMMU 
-    field capPGDMappedCB             12
-    padding                          46
+    field capPGDMappedCB             8
+    padding                          50
 #else 
     padding                          58
 #endif 
@@ -143,9 +143,9 @@ block cb_control_cap {
 
 block cb_cap {
 
-    padding               40
+    padding               44
     field capBindSID      12
-    field capCB           12
+    field capCB           8
 
 
     field capType         5
@@ -246,7 +246,12 @@ block asid_map_none {
 
 --- hw_vmids are required in hyp mode
 block asid_map_vspace {
+#ifdef CONFIG_ARM_SMMU
+    field bind_cb                   8
+    padding                         8
+#else
     padding                         16
+#endif
     field_high vspace_root          36
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
     padding                         2
@@ -267,12 +272,7 @@ tagged_union asid_map type {
 base 64(48,0)
 
 block pgde_invalid {
-#ifdef CONFIG_ARM_SMMU
-    field bind_cb                   12
-    padding                         50
-#else
     padding                         62
-#endif
     field pgde_type                 2
 }
 
@@ -289,12 +289,7 @@ tagged_union pgde pgde_type {
 }
 
 block pude_invalid {
-#ifdef CONFIG_ARM_SMMU
-    field bind_cb                   12
-    padding                         50
-#else
     padding                         62
-#endif
     field pude_type                 2
 }
 

--- a/include/arch/arm/arch/64/mode/object/structures.bf
+++ b/include/arch/arm/arch/64/mode/object/structures.bf
@@ -239,6 +239,23 @@ block vm_attributes {
 
 ---- ARM-specific object types
 
+block asid_map_none {
+    padding                         63
+    field type                      1
+}
+
+block asid_map_vspace {
+    padding                         16
+    field_high vspace_root          36
+    padding                         11
+    field type                      1
+}
+
+tagged_union asid_map type {
+    tag asid_map_none 0
+    tag asid_map_vspace 1
+}
+
 -- PGDE, PUDE, PDEs and PTEs, assuming 48-bit physical address
 base 64(48,0)
 

--- a/include/arch/arm/arch/64/mode/object/structures.h
+++ b/include/arch/arm/arch/64/mode/object/structures.h
@@ -103,7 +103,7 @@ typedef pgde_t vspace_root_t;
 #define VCPU_REF(p)       ((word_t)(p))
 
 struct asid_pool {
-    vspace_root_t *array[BIT(asidLowBits)];
+    asid_map_t array[BIT(asidLowBits)];
 };
 typedef struct asid_pool asid_pool_t;
 

--- a/include/arch/arm/armv/armv8-a/64/armv/context_switch.h
+++ b/include/arch/arm/armv/armv8-a/64/armv/context_switch.h
@@ -9,6 +9,12 @@
 #include <config.h>
 #include <arch/kernel/vspace.h>
 
+
+static inline void armv_contextSwitch_HWASID(vspace_root_t *vspace, asid_t asid)
+{
+    setCurrentUserVSpaceRoot(ttbr_new(asid, pptr_to_paddr(vspace)));
+}
+
 /*
  * In AARCH64, hardware and virtual asids are the same and are written
  * when updating the translation table base register.

--- a/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
@@ -253,14 +253,6 @@ SEL4_SIZE_SANITY(seL4_PUDEntryBits, seL4_PUDIndexBits, seL4_PUDBits);
 #define seL4_IPCBufferSizeBits 10
 
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
-#ifndef CONFIG_ARM_SMMU
-/* 1 slot at the end of the vspace is used to hold the VMID assigned to the vspace */
-#define seL4_VSpaceReservedSlots 1
-#else /*CONFIG_ARM_SMMU*/
-/* 1 slot at the end of the vspace is used to hold the VMID assigned to the vspace */
-/* 1 slot at the end of the vspace is used to hold the number of SMMU CBs assigned to the vspace */
-#define seL4_VSpaceReservedSlots 2
-#endif /*CONFIG_ARM_SMMU*/
 
 /* The userspace occupies the range 0x0 to 0xfffffffffff.
  * The stage-1 translation is disabled, and the stage-2
@@ -273,10 +265,7 @@ SEL4_SIZE_SANITY(seL4_PUDEntryBits, seL4_PUDIndexBits, seL4_PUDBits);
 #if defined(CONFIG_ARM_PA_SIZE_BITS_44)
 #define seL4_UserTop 0x00000fffffffffff
 #elif defined(CONFIG_ARM_PA_SIZE_BITS_40)
-/* Currently other definitions of seL4_UserTop already have free slots at the end and don't need to subtract for seL4_VSpaceReservedSlots.
- * Each slot used requires subtracting 1GiB from the top address.
- */
-#define seL4_UserTop (0x000000ffffffffff - seL4_VSpaceReservedSlots * 0x40000000)
+#define seL4_UserTop 0x000000ffffffffff
 #else
 #error "Unknown physical address width"
 #endif

--- a/src/arch/arm/64/kernel/vspace.c
+++ b/src/arch/arm/64/kernel/vspace.c
@@ -551,7 +551,11 @@ BOOT_CODE void activate_kernel_vspace(void)
 BOOT_CODE void write_it_asid_pool(cap_t it_ap_cap, cap_t it_vspace_cap)
 {
     asid_pool_t *ap = ASID_POOL_PTR(pptr_of_cap(it_ap_cap));
-    asid_map_t asid_map = asid_map_asid_map_vspace_new(pptr_of_cap(it_vspace_cap));
+#ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
+    asid_map_t asid_map = asid_map_asid_map_vspace_new((word_t)cap_vtable_root_get_basePtr(it_vspace_cap), 0, false);
+#else
+    asid_map_t asid_map = asid_map_asid_map_vspace_new((word_t)cap_vtable_root_get_basePtr(it_vspace_cap));
+#endif
     ap->array[IT_ASID] = asid_map;
     armKSASIDTable[IT_ASID >> asidLowBits] = ap;
 #ifdef CONFIG_ARM_SMMU
@@ -1074,51 +1078,36 @@ pude_t *pageDirectoryMapped(asid_t asid, vptr_t vaddr, pde_t *pd)
 
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
 
-static void invalidateASID(asid_t asid)
+static asid_map_t *getMapRefForASID(asid_t asid)
 {
-    asid_pool_t *asidPool;
+    asid_pool_t *poolPtr;
 
-    asidPool = armKSASIDTable[asid >> asidLowBits];
-    assert(asidPool);
+    poolPtr = armKSASIDTable[asid >> asidLowBits];
+    assert(poolPtr != NULL);
 
-    asid_map_t asid_map = asidPool->array[asid & MASK(asidLowBits)];
-    assert(asid_map_get_type(asid_map) == asid_map_asid_map_vspace);
-
-    vspace_root_t *vtable = (vspace_root_t *)asid_map_asid_map_vspace_get_vspace_root(asid_map);
-
-    vtable[VTABLE_VMID_SLOT] = vtable_invalid_new(0, false);
+    return &poolPtr->array[asid & MASK(asidLowBits)];
 }
 
-static vspace_root_t PURE loadHWASID(asid_t asid)
+static void invalidateASID(asid_t asid)
 {
-    asid_pool_t *asidPool;
+    asid_map_t *asid_map;
 
-    asidPool = armKSASIDTable[asid >> asidLowBits];
-    assert(asidPool);
+    asid_map = getMapRefForASID(asid);
+    assert(asid_map_get_type(*asid_map) == asid_map_asid_map_vspace);
 
-    asid_map_t asid_map = asidPool->array[asid & MASK(asidLowBits)];
-    assert(asid_map_get_type(asid_map) == asid_map_asid_map_vspace);
-
-    vspace_root_t *vtable = (vspace_root_t *)asid_map_asid_map_vspace_get_vspace_root(asid_map);
-
-    return vtable[VTABLE_VMID_SLOT];
+    asid_map_asid_map_vspace_ptr_set_stored_hw_vmid(asid_map, 0);
+    asid_map_asid_map_vspace_ptr_set_stored_vmid_valid(asid_map, false);
 }
 
 static void storeHWASID(asid_t asid, hw_asid_t hw_asid)
 {
-    asid_pool_t *asidPool;
+    asid_map_t *asid_map;
 
-    asidPool = armKSASIDTable[asid >> asidLowBits];
-    assert(asidPool);
+    asid_map = getMapRefForASID(asid);
+    assert(asid_map_get_type(*asid_map) == asid_map_asid_map_vspace);
 
-    asid_map_t asid_map = asidPool->array[asid & MASK(asidLowBits)];
-    assert(asid_map_get_type(asid_map) == asid_map_asid_map_vspace);
-
-    vspace_root_t *vtable = (vspace_root_t *)asid_map_asid_map_vspace_get_vspace_root(asid_map);
-
-    /* Store HW VMID in the last entry
-       Masquerade as an invalid PDGE */
-    vtable[VTABLE_VMID_SLOT] = vtable_invalid_new(hw_asid, true);
+    asid_map_asid_map_vspace_ptr_set_stored_hw_vmid(asid_map, hw_asid);
+    asid_map_asid_map_vspace_ptr_set_stored_vmid_valid(asid_map, true);
 
     armKSHWASIDTable[hw_asid] = asid;
 }
@@ -1155,11 +1144,11 @@ static hw_asid_t findFreeHWASID(void)
 
 hw_asid_t getHWASID(asid_t asid)
 {
-    vspace_root_t stored_hw_asid;
+    asid_map_t asid_map;
 
-    stored_hw_asid = loadHWASID(asid);
-    if (vtable_invalid_get_stored_asid_valid(stored_hw_asid)) {
-        return vtable_invalid_get_stored_hw_asid(stored_hw_asid);
+    asid_map = findMapForASID(asid);
+    if (asid_map_asid_map_vspace_get_stored_vmid_valid(asid_map)) {
+        return asid_map_asid_map_vspace_get_stored_hw_vmid(asid_map);
     } else {
         hw_asid_t new_hw_asid;
 
@@ -1171,11 +1160,11 @@ hw_asid_t getHWASID(asid_t asid)
 
 static void invalidateASIDEntry(asid_t asid)
 {
-    vspace_root_t stored_hw_asid;
+    asid_map_t asid_map;
 
-    stored_hw_asid = loadHWASID(asid);
-    if (vtable_invalid_get_stored_asid_valid(stored_hw_asid)) {
-        armKSHWASIDTable[vtable_invalid_get_stored_hw_asid(stored_hw_asid)] =
+    asid_map = findMapForASID(asid);
+    if (asid_map_asid_map_vspace_get_stored_vmid_valid(asid_map)) {
+        armKSHWASIDTable[asid_map_asid_map_vspace_get_stored_hw_vmid(asid_map)] =
             asidInvalid;
     }
     invalidateASID(asid);
@@ -1246,13 +1235,13 @@ static inline void invalidateTLBByASID(asid_t asid)
     }
 #endif
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
-    vspace_root_t stored_hw_asid;
+    asid_map_t asid_map;
 
-    stored_hw_asid = loadHWASID(asid);
-    if (!vtable_invalid_get_stored_asid_valid(stored_hw_asid)) {
+    asid_map = findMapForASID(asid);
+    if (!asid_map_asid_map_vspace_get_stored_vmid_valid(asid_map)) {
         return;
     }
-    invalidateTranslationASID(vtable_invalid_get_stored_hw_asid(stored_hw_asid));
+    invalidateTranslationASID(asid_map_asid_map_vspace_get_stored_hw_vmid(asid_map));
 #else
     invalidateTranslationASID(asid);
 #endif
@@ -1267,13 +1256,13 @@ static inline void invalidateTLBByASIDVA(asid_t asid, vptr_t vaddr)
     }
 #endif
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
-    vspace_root_t stored_hw_asid;
+    asid_map_t asid_map;
 
-    stored_hw_asid = loadHWASID(asid);
-    if (!vtable_invalid_get_stored_asid_valid(stored_hw_asid)) {
+    asid_map = findMapForASID(asid);
+    if (!asid_map_asid_map_vspace_get_stored_vmid_valid(asid_map)) {
         return;
     }
-    uint64_t hw_asid = vtable_invalid_get_stored_hw_asid(stored_hw_asid);
+    uint64_t hw_asid = asid_map_asid_map_vspace_get_stored_hw_vmid(asid_map);
     invalidateTranslationSingle((hw_asid << 48) | vaddr >> seL4_PageBits);
 #else
     invalidateTranslationSingle((asid << 48) | vaddr >> seL4_PageBits);
@@ -1310,9 +1299,9 @@ void unmapPageUpperDirectory(asid_t asid, vptr_t vaddr, pude_t *pud)
     pgdSlot = pageUpperDirectoryMapped(asid, vaddr, pud);
     if (likely(pgdSlot != NULL)) {
 #ifdef CONFIG_ARM_SMMU
-        *pgdSlot = pgde_pgde_invalid_new(0, false, 0);
+        *pgdSlot = pgde_pgde_invalid_new(0);
 #else
-        *pgdSlot = pgde_pgde_invalid_new(0, false);
+        *pgdSlot = pgde_pgde_invalid_new();
 #endif
         cleanByVA_PoU((vptr_t)pgdSlot, pptr_to_paddr(pgdSlot));
         invalidateTLBByASID(asid);


### PR DESCRIPTION
Use the asid_map bitfield from x86 for aarch64 to map from ASID to an intermediate asid_map object that can hold a vspace object reference plus additional related attributes.  This can free up reserved slots in the top level page table for use at user level. 

This PR uses some commits from https://github.com/seL4/seL4/pull/579 but is only targeting aarch64.

More background: https://sel4.atlassian.net/browse/SELFOUR-1840