### PR TITLE
trivial: fix examples explaining IRQT_TO_IDX macro

### DIFF
--- a/include/arch/arm/arch/machine/gic_common.h
+++ b/include/arch/arm/arch/machine/gic_common.h
@@ -37,7 +37,7 @@
  * The layout of IRQs into the CNode are all of PPI's for each core first, followed
  * by the global interrupts.  Examples:
  *   core: 0, irq: 12 -> index 12.
- *   core: 2, irq: 16 -> (2 * 32) + 12
+ *   core: 2, irq: 16 -> (2 * 32) + 16
  *   core: 1, irq: 33, (4 total cores) -> (4 * 32) + (33-32).
  */
 #define IRQ_IS_PPI(_irq) (HW_IRQ_IS_PPI(_irq.irq))


### PR DESCRIPTION
This PR just fixes examples given in a comment for how an IRQ gets converted to a CNode index.

Example 2: The IRQ number is not a PPI so the index is `(irq.target_core)*NUM_PPI + (_irq.irq)`, which means it should be `+ 16` not `+ 12`.

Example 3: The IRQ number is a PPI so the index is `(CONFIG_MAX_NUM_NODES-1)*NUM_PPI + (_irq.irq)`, which means it should be `(3 * 32) + 33` since there's 4 cores, not sure where the `(33 - 32)` came from.