### PR TITLE
bitfield_gen: allow _ in integer literals

### DIFF
--- a/tools/bitfield_gen.py
+++ b/tools/bitfield_gen.py
@@ -108,8 +108,8 @@ def t_IDENTIFIER(t):
 
 
 def t_INTLIT(t):
-    r'([1-9][0-9]*|0[oO]?[0-7]+|0[xX][0-9a-fA-F]+|0[bB][01]+|0)[lL]?'
-    t.value = int(t.value, 0)
+    r'([1-9][0-9_]*|0[oO]?[0-7_]+|0[xX][0-9a-fA-F_]+|0[bB][01_]+|0)[lL]?'
+    t.value = int(t.value.replace('_', ''), 0)
     return t
 
 


### PR DESCRIPTION
This allows optional ignored `_` at any position in any integer literals (dec, oct, hex, bin) for better readability. For example

`0xFFFF_FFFF_FFFF_FF00 = 0xFFFFFFFFFFFFFF00`
`0b0000_0000_0001_0000 = 0b0000000000010000`
`1_000_000 = 1000000`

This is a syntax addition only, no semantic changes.