### PR TITLE
Signal fastpath v2

### DIFF
--- a/config.cmake
+++ b/config.cmake
@@ -287,6 +287,13 @@ config_string(
     UNQUOTE
 )
 
+config_option(
+    KernelSignalFastpath SIGNAL_FASTPATH "Enable notification signal fastpath"
+    DEFAULT OFF
+    DEPENDS "KernelIsMCS; KernelFastpath; KernelSel4ArchAarch64; NOT KernelVerificationBuild"
+    DEFAULT_DISABLED OFF
+)
+
 find_file(
     KernelDomainSchedule default_domain.c
     PATHS src/config

--- a/include/arch/arm/arch/fastpath/fastpath.h
+++ b/include/arch/arm/arch/fastpath/fastpath.h
@@ -14,6 +14,12 @@
 void slowpath(syscall_t syscall)
 NORETURN;
 
+#ifdef CONFIG_SIGNAL_FASTPATH
+static inline
+void fastpath_signal(word_t cptr, word_t msgInfo)
+NORETURN;
+#endif
+
 static inline
 void fastpath_call(word_t cptr, word_t r_msgInfo)
 NORETURN;

--- a/include/arch/arm/arch/kernel/traps.h
+++ b/include/arch/arm/arch/kernel/traps.h
@@ -29,6 +29,9 @@ VISIBLE SECTION(".vectors.text");
 void c_handle_fastpath_call(word_t cptr, word_t msgInfo)
 VISIBLE SECTION(".vectors.text");
 
+void c_handle_fastpath_signal(word_t cptr, word_t msgInfo)
+VISIBLE SECTION(".vectors.text");
+
 #ifdef CONFIG_KERNEL_MCS
 void c_handle_fastpath_reply_recv(word_t cptr, word_t msgInfo, word_t reply)
 #else

--- a/include/fastpath/fastpath.h
+++ b/include/fastpath/fastpath.h
@@ -6,6 +6,70 @@
 
 #pragma once
 
+#ifdef CONFIG_KERNEL_MCS
+#include <object/reply.h>
+#include <object/notification.h>
+#endif
+
+#ifdef CONFIG_SIGNAL_FASTPATH
+/* Equivalent to schedContext_donate without migrateTCB() */
+static inline void maybeDonateSchedContext_fp(tcb_t *dest, sched_context_t *sc)
+{
+    if (!dest->tcbSchedContext) {
+        sc->scTcb = dest;
+        dest->tcbSchedContext = sc;
+    }
+
+#ifdef ENABLE_SMP_SUPPORT
+#ifdef CONFIG_DEBUG_BUILD
+    tcbDebugRemove(dest);
+#endif
+    /* The part of migrateTCB() that doesn't involve the slowpathed FPU save */
+    dest->tcbAffinity = sc->scCore;
+#ifdef CONFIG_DEBUG_BUILD
+    tcbDebugAppend(dest);
+#endif
+#endif
+}
+
+static inline void cancelIPC_fp(tcb_t *dest)
+{
+    endpoint_t *ep_ptr;
+    tcb_queue_t queue;
+    ep_ptr = EP_PTR(thread_state_get_blockingObject(dest->tcbState));
+
+    queue = ep_ptr_get_queue(ep_ptr);
+    queue = tcbEPDequeue(dest, queue);
+    ep_ptr_set_queue(ep_ptr, queue);
+
+    if (!queue.head) {
+        endpoint_ptr_set_state(ep_ptr, EPState_Idle);
+    }
+
+    reply_t *reply = REPLY_PTR(thread_state_get_replyObject(dest->tcbState));
+    if (reply != NULL) {
+        reply_unlink(reply, dest);
+    }
+}
+
+/* Dequeue TCB from notification queue */
+static inline void ntfn_queue_dequeue_fp(tcb_t *dest, notification_t *ntfn_ptr)
+{
+    tcb_queue_t ntfn_queue;
+    ntfn_queue.head = (tcb_t *)notification_ptr_get_ntfnQueue_head(ntfn_ptr);
+    ntfn_queue.end = (tcb_t *)notification_ptr_get_ntfnQueue_tail(ntfn_ptr);
+
+    ntfn_queue = tcbEPDequeue(dest, ntfn_queue);
+
+    notification_ptr_set_ntfnQueue_head(ntfn_ptr, (word_t)ntfn_queue.head);
+    notification_ptr_set_ntfnQueue_tail(ntfn_ptr, (word_t)ntfn_queue.end);
+
+    if (!ntfn_queue.head) {
+        notification_ptr_set_state(ntfn_ptr, NtfnState_Idle);
+    }
+}
+#endif
+
 /* Fastpath cap lookup.  Returns a null_cap on failure. */
 static inline cap_t FORCE_INLINE lookup_fp(cap_t cap, cptr_t cptr)
 {

--- a/include/object/endpoint.h
+++ b/include/object/endpoint.h
@@ -19,6 +19,12 @@ static inline tcb_queue_t PURE ep_ptr_get_queue(endpoint_t *epptr)
     return queue;
 }
 
+static inline void ep_ptr_set_queue(endpoint_t *epptr, tcb_queue_t queue)
+{
+    endpoint_ptr_set_epQueue_head(epptr, (word_t)queue.head);
+    endpoint_ptr_set_epQueue_tail(epptr, (word_t)queue.end);
+}
+
 #ifdef CONFIG_KERNEL_MCS
 void sendIPC(bool_t blocking, bool_t do_call, word_t badge,
              bool_t canGrant, bool_t canGrantReply, bool_t canDonate, tcb_t *thread,

--- a/include/object/notification.h
+++ b/include/object/notification.h
@@ -36,4 +36,8 @@ static inline void maybeReturnSchedContext(notification_t *ntfnPtr, tcb_t *tcb)
 }
 #endif
 
-
+static inline void ntfn_set_active(notification_t *ntfnPtr, word_t badge)
+{
+    notification_ptr_set_state(ntfnPtr, NtfnState_Active);
+    notification_ptr_set_ntfnMsgIdentifier(ntfnPtr, badge);
+}

--- a/src/arch/arm/64/traps.S
+++ b/src/arch/arm/64/traps.S
@@ -200,6 +200,10 @@ lel_syscall:
 #ifdef CONFIG_FASTPATH
     cmp     x7, #SYSCALL_CALL
     b.eq    c_handle_fastpath_call
+#ifdef CONFIG_SIGNAL_FASTPATH
+    cmp     x7, #SYSCALL_SEND
+    b.eq    c_handle_fastpath_signal
+#endif /* CONFIG_SIGNAL_FASTPATH */
     cmp     x7, #SYSCALL_REPLY_RECV
 #ifdef CONFIG_KERNEL_MCS
     mov     x2, x6

--- a/src/arch/arm/c_traps.c
+++ b/src/arch/arm/c_traps.c
@@ -154,6 +154,24 @@ void VISIBLE c_handle_fastpath_call(word_t cptr, word_t msgInfo)
     UNREACHABLE();
 }
 
+#ifdef CONFIG_KERNEL_MCS
+#ifdef CONFIG_SIGNAL_FASTPATH
+ALIGN(L1_CACHE_LINE_SIZE)
+void VISIBLE c_handle_fastpath_signal(word_t cptr, word_t msgInfo)
+{
+    NODE_LOCK_SYS;
+
+    c_entry_hook();
+#ifdef TRACK_KERNEL_ENTRIES
+    benchmark_debug_syscall_start(cptr, msgInfo, SysCall);
+    ksKernelEntry.is_fastpath = 1;
+#endif /* DEBUG */
+    fastpath_signal(cptr, msgInfo);
+    UNREACHABLE();
+}
+#endif /* CONFIG_SIGNAL_FASTPATH */
+#endif /* CONFIG_KERNEL_MCS */
+
 ALIGN(L1_CACHE_LINE_SIZE)
 #ifdef CONFIG_KERNEL_MCS
 void VISIBLE c_handle_fastpath_reply_recv(word_t cptr, word_t msgInfo, word_t reply)

--- a/src/object/endpoint.c
+++ b/src/object/endpoint.c
@@ -16,12 +16,6 @@
 #include <object/endpoint.h>
 #include <object/tcb.h>
 
-static inline void ep_ptr_set_queue(endpoint_t *epptr, tcb_queue_t queue)
-{
-    endpoint_ptr_set_epQueue_head(epptr, (word_t)queue.head);
-    endpoint_ptr_set_epQueue_tail(epptr, (word_t)queue.end);
-}
-
 #ifdef CONFIG_KERNEL_MCS
 void sendIPC(bool_t blocking, bool_t do_call, word_t badge,
              bool_t canGrant, bool_t canGrantReply, bool_t canDonate, tcb_t *thread, endpoint_t *epptr)

--- a/src/object/notification.c
+++ b/src/object/notification.c
@@ -32,12 +32,6 @@ static inline void ntfn_ptr_set_queue(notification_t *ntfnPtr, tcb_queue_t ntfn_
     notification_ptr_set_ntfnQueue_tail(ntfnPtr, (word_t)ntfn_queue.end);
 }
 
-static inline void ntfn_set_active(notification_t *ntfnPtr, word_t badge)
-{
-    notification_ptr_set_state(ntfnPtr, NtfnState_Active);
-    notification_ptr_set_ntfnMsgIdentifier(ntfnPtr, badge);
-}
-
 #ifdef CONFIG_KERNEL_MCS
 static inline void maybeDonateSchedContext(tcb_t *tcb, notification_t *ntfnPtr)
 {


### PR DESCRIPTION
This is basically a combination of [Shane's signal fastpath](https://github.com/seL4/seL4/pull/322/commits) from last year and [Anna's signal/IRQ fastpath](https://github.com/pingerino/seL4/blob/phd/src/fastpath/fastpath.c#L421). 

Shane's fastpath was able to handle signalling to both lower and higher prio threads, but there were some issues related to what needs to be done when scheduling contexts are switched in the case of a lower to higher prio signal. I have looked at the `schedule()` code to try and figure out what needs to be done. I have been unable to check my progress much as of yet, so this first pull request is mainly for feedback. 

Shane's code was working on all platforms but I have only tested on AARCH64 so far, where it passes all of seL4test and performs in seL4bench similar but a little worse than Shane's implementation due to the extra logic I add. Before I put more effort into a full benchmarking, I want to confirm that what I have done is on the right track. 

EDIT: I have revised the model to no longer handle any branch that requires a SC switch. This fastpath is for seL4_Signal (an seL4_Send to a notification capability) and is based on the other fastpaths in addition to the [sendSignal() ](https://github.com/seL4/seL4/blob/3978092885e4f3e6524fb3e40b04c02b35804c50/src/object/notification.c) function that is called by the slowpath, but omits the cases that result in a scheduling context switch, redirecting to the slowpath for these. 
