### PR TITLE
print value for unknown entry reason

### DIFF
--- a/include/api/debug.h
+++ b/include/api/debug.h
@@ -59,7 +59,7 @@ static inline void debug_printKernelEntryReason(void)
         break;
 #endif
     default:
-        printf("Unknown\n");
+        printf("Unknown (%u)\n", ksKernelEntry.path);
         break;
 
     }


### PR DESCRIPTION
This is not supposed to happen, thus printing the value gives a bit more insight what might have happened here.