### PR TITLE
avoid multiple definitions of vspace architecture specific function interface

### DIFF
--- a/include/arch/arm/arch/kernel/vspace.h
+++ b/include/arch/arm/arch/kernel/vspace.h
@@ -29,20 +29,12 @@ void write_it_asid_pool(cap_t it_ap_cap, cap_t it_pd_cap);
 /* need a fake array to get the pointer from the linker script */
 extern char arm_vector_table[1];
 
-word_t *PURE lookupIPCBuffer(bool_t isReceiver, tcb_t *thread);
-exception_t handleVMFault(tcb_t *thread, vm_fault_type_t vm_faultType);
 pde_t *pageTableMapped(asid_t asid, vptr_t vaddr, pte_t *pt);
 void setVMRoot(tcb_t *tcb);
 bool_t CONST isValidVTableRoot(cap_t cap);
-exception_t checkValidIPCBuffer(vptr_t vptr, cap_t cap);
 
 vm_rights_t CONST maskVMRights(vm_rights_t vm_rights,
                                seL4_CapRights_t cap_rights_mask);
 
 exception_t decodeARMMMUInvocation(word_t invLabel, word_t length, cptr_t cptr,
                                    cte_t *cte, cap_t cap, word_t *buffer);
-
-#ifdef CONFIG_PRINTING
-void Arch_userStackTrace(tcb_t *tptr);
-#endif
-

--- a/include/arch/riscv/arch/kernel/vspace.h
+++ b/include/arch/riscv/arch/kernel/vspace.h
@@ -38,15 +38,12 @@ struct findVSpaceForASID_ret {
 typedef struct findVSpaceForASID_ret findVSpaceForASID_ret_t;
 
 void copyGlobalMappings(pte_t *newlvl1pt);
-word_t *PURE lookupIPCBuffer(bool_t isReceiver, tcb_t *thread);
 lookupPTSlot_ret_t lookupPTSlot(pte_t *lvl1pt, vptr_t vptr);
-exception_t handleVMFault(tcb_t *thread, vm_fault_type_t vm_faultType);
 void unmapPageTable(asid_t, vptr_t vaddr, pte_t *pt);
 void unmapPage(vm_page_size_t page_size, asid_t asid, vptr_t vptr, pptr_t pptr);
 void deleteASID(asid_t asid, pte_t *vspace);
 void deleteASIDPool(asid_t asid_base, asid_pool_t *pool);
 bool_t CONST isValidVTableRoot(cap_t cap);
-exception_t checkValidIPCBuffer(vptr_t vptr, cap_t cap);
 vm_rights_t CONST maskVMRights(vm_rights_t vm_rights,
                                seL4_CapRights_t cap_rights_mask);
 exception_t decodeRISCVMMUInvocation(word_t label, word_t length, cptr_t cptr,
@@ -58,8 +55,3 @@ exception_t performPageInvocationMapPTE(cap_t cap, cte_t *ctSlot,
                                         pte_t pte, pte_t *base);
 exception_t performPageInvocationUnmap(cap_t cap, cte_t *ctSlot);
 void setVMRoot(tcb_t *tcb);
-
-#ifdef CONFIG_PRINTING
-void Arch_userStackTrace(tcb_t *tptr);
-#endif
-

--- a/include/arch/x86/arch/kernel/vspace.h
+++ b/include/arch/x86/arch/kernel/vspace.h
@@ -132,4 +132,3 @@ static inline bool_t checkVPAlignment(vm_page_size_t sz, word_t w)
 {
     return IS_ALIGNED(w, pageBitsForSize(sz));
 }
-

--- a/include/arch/x86/arch/kernel/vspace.h
+++ b/include/arch/x86/arch/kernel/vspace.h
@@ -74,8 +74,6 @@ asid_map_t findMapForASID(asid_t asid);
 lookupPTSlot_ret_t lookupPTSlot(vspace_root_t *vspace, vptr_t vptr);
 lookupPDSlot_ret_t lookupPDSlot(vspace_root_t *vspace, vptr_t vptr);
 void copyGlobalMappings(vspace_root_t *new_vspace);
-word_t *PURE lookupIPCBuffer(bool_t isReceiver, tcb_t *thread);
-exception_t handleVMFault(tcb_t *thread, vm_fault_type_t vm_faultType);
 void unmapPageDirectory(asid_t asid, vptr_t vaddr, pde_t *pd);
 void unmapPageTable(asid_t, vptr_t vaddr, pte_t *pt);
 
@@ -94,7 +92,6 @@ exception_t decodeX86ModeMapPage(word_t invLabel, vm_page_size_t page_size, cte_
 void setVMRoot(tcb_t *tcb);
 bool_t CONST isValidVTableRoot(cap_t cap);
 bool_t CONST isValidNativeRoot(cap_t cap);
-exception_t checkValidIPCBuffer(vptr_t vptr, cap_t cap);
 vm_rights_t CONST maskVMRights(vm_rights_t vm_rights, seL4_CapRights_t cap_rights_mask);
 void flushTable(vspace_root_t *vspace, word_t vptr, pte_t *pt, asid_t asid);
 
@@ -123,10 +120,6 @@ pde_t CONST makeUserPDELargePage(paddr_t paddr, vm_attributes_t vm_attr, vm_righ
 pde_t CONST makeUserPDEPageTable(paddr_t paddr, vm_attributes_t vm_attr);
 pde_t CONST makeUserPDEInvalid(void);
 
-
-#ifdef CONFIG_PRINTING
-void Arch_userStackTrace(tcb_t *tptr);
-#endif
 
 static inline bool_t checkVPAlignment(vm_page_size_t sz, word_t w)
 {

--- a/include/kernel/vspace.h
+++ b/include/kernel/vspace.h
@@ -8,7 +8,15 @@
 #include <config.h>
 #include <arch/kernel/vspace.h>
 
+exception_t checkValidIPCBuffer(vptr_t vptr, cap_t cap);
+word_t *PURE lookupIPCBuffer(bool_t isReceiver, tcb_t *thread);
+
+exception_t handleVMFault(tcb_t *thread, vm_fault_type_t vm_faultType);
+
 #ifdef CONFIG_KERNEL_LOG_BUFFER
 exception_t benchmark_arch_map_logBuffer(word_t frame_cptr);
 #endif /* CONFIG_KERNEL_LOG_BUFFER */
 
+#ifdef CONFIG_PRINTING
+void Arch_userStackTrace(tcb_t *tptr);
+#endif /* CONFIG_PRINTING */


### PR DESCRIPTION
The generic code uses these functions, thus there should be one common interface definition only.

I have not added these functions
- `bool_t CONST isValidVTableRoot(cap_t cap)`
- `void setVMRoot(tcb_t *tcb)`

because they exists for all architectures, but there is no generic code that uses them. Just the architecture specific code seem to follow a common pattern here.