### PR TITLE
make macro ARRAY_SIZE() handle corner cases

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -41,7 +41,7 @@
 #define IS_ALIGNED(n, b) (!((n) & MASK(b)))
 #define ROUND_DOWN(n, b) (((n) >> (b)) << (b))
 #define ROUND_UP(n, b) (((((n) - UL_CONST(1)) >> (b)) + UL_CONST(1)) << (b))
-#define ARRAY_SIZE(x) (sizeof(x) / sizeof(x[0]))
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
 #define MIN(a,b) (((a)<(b))?(a):(b))
 #define MAX(a,b) (((a)>(b))?(a):(b))
 


### PR DESCRIPTION
Put the parameter in brackets to ensure it is an atom. This makes the macro work as expected in corner cases like `ARRAY_SIZE(foo + 3)` also.

Such a corner case may happen when the argument passed is another macro that lacks brackets. Could happen when experimenting with the code and using sloppy statements...

See also https://github.com/seL4/util_libs/blob/master/libutils/include/utils/arith.h#L121 where it uses proper brackets.