### PR TITLE
python: use type hints

### DIFF
--- a/tools/hardware/device.py
+++ b/tools/hardware/device.py
@@ -162,10 +162,10 @@ class WrappedNode:
         addr = Utils.translate_address(self, addr)
         return self.parent._translate_child_address(addr)
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(self.path)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'WrappedNode(path={})'.format(self.path)
 
 

--- a/tools/hardware/device.py
+++ b/tools/hardware/device.py
@@ -135,12 +135,9 @@ class WrappedNode:
 
     def visit(self, visitor: Any):
         ''' Visit this node and all its children '''
-        ret = [visitor(self)]
-        if ret[0] is None:
-            ret = []
+        visitor(self)
         for child in self.children.values():
-            ret += child.visit(visitor)
-        return ret
+            child.visit(visitor)
 
     def __iter__(self) -> Generator['WrappedNode', None, None]:
         ''' Iterate over all immediate children of this node '''

--- a/tools/hardware/device.py
+++ b/tools/hardware/device.py
@@ -5,8 +5,8 @@
 #
 
 from collections import OrderedDict
-from typing import Any, Dict, Generator, List, Tuple, cast
-
+from typing import Dict, Generator, List, Tuple, cast
+from collections.abc import Callable
 import logging
 import pyfdt.pyfdt
 
@@ -133,7 +133,7 @@ class WrappedNode:
             return []
         return list(self.get_prop('interrupt-affinity').words)
 
-    def visit(self, visitor: Any):
+    def visit(self, visitor: Callable[[WrappedNode], None]):
         ''' Visit this node and all its children '''
         visitor(self)
         for child in self.children.values():

--- a/tools/hardware/fdt.py
+++ b/tools/hardware/fdt.py
@@ -89,7 +89,7 @@ class FdtParser:
         paths = chosen.get_prop(prop).strings
 
         for path in paths:
-            if path[0] != '/':
+            if not path.startswith('/'):
                 path = self.lookup_alias(path)
             node = self.get_path(path)
             if node is None:

--- a/tools/hardware/fdt.py
+++ b/tools/hardware/fdt.py
@@ -109,4 +109,4 @@ class FdtParser:
 
     def visit(self, visitor: Any):
         ''' Walk the tree, calling the given visitor function on each node '''
-        return self.wrapped_root.visit(visitor)
+        self.wrapped_root.visit(visitor)

--- a/tools/hardware/fdt.py
+++ b/tools/hardware/fdt.py
@@ -4,7 +4,8 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-from typing import Any, Dict, IO, List, Union
+from typing import Dict, IO, List, Union
+from collections.abc import Callable
 import pyfdt.pyfdt
 
 from hardware.device import WrappedNode
@@ -107,6 +108,6 @@ class FdtParser:
         prop = chosen.get_prop('seL4,boot-cpu')
         return prop.words[0]
 
-    def visit(self, visitor: Any):
+    def visit(self, visitor: Callable[[WrappedNode], None]):
         ''' Walk the tree, calling the given visitor function on each node '''
         self.wrapped_root.visit(visitor)

--- a/tools/hardware/fdt.py
+++ b/tools/hardware/fdt.py
@@ -82,7 +82,7 @@ class FdtParser:
     def get_devices_list(self, prop) -> List[WrappedNode]:
         ''' Returns a list of devices that are used by the kernel '''
         chosen = self.get_path('/chosen')
-        if not chosen.has_prop(prop):
+        if (chosen is None) or (not chosen.has_prop(prop)):
             return []
 
         ret = []
@@ -100,7 +100,7 @@ class FdtParser:
     def get_boot_cpu(self) -> int:
         ''' Returns phandle of the cpu node specified by the seL4,boot-cpu property '''
         chosen = self.get_path('/chosen')
-        if not chosen.has_prop('seL4,boot-cpu'):
+        if (chosen is None) or (not chosen.has_prop('seL4,boot-cpu')):
             raise KeyError('must specify seL4,boot-cpu in /chosen to get boot cpu')
 
         prop = chosen.get_prop('seL4,boot-cpu')

--- a/tools/hardware/fdt.py
+++ b/tools/hardware/fdt.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-from typing import Any, Dict, IO, List
+from typing import Any, Dict, IO, List, Union
 import pyfdt.pyfdt
 
 from hardware.device import WrappedNode
@@ -54,7 +54,7 @@ class FdtParser:
         ''' Look up a node by phandle '''
         return self.by_phandle[phandle]
 
-    def get_path(self, path: str) -> WrappedNode:
+    def get_path(self, path: str) -> Union[WrappedNode, None]:
         ''' Look up a node by path '''
         return self.by_path.get(path, None)
 

--- a/tools/hardware/fdt.py
+++ b/tools/hardware/fdt.py
@@ -91,7 +91,10 @@ class FdtParser:
         for path in paths:
             if path[0] != '/':
                 path = self.lookup_alias(path)
-            ret.append(self.get_path(path))
+            node = self.get_path(path)
+            if node is not None:
+                ret.append(node)
+
         return ret
 
     def get_boot_cpu(self) -> int:

--- a/tools/hardware/fdt.py
+++ b/tools/hardware/fdt.py
@@ -92,8 +92,9 @@ class FdtParser:
             if path[0] != '/':
                 path = self.lookup_alias(path)
             node = self.get_path(path)
-            if node is not None:
-                ret.append(node)
+            if node is None:
+                raise KeyError(f"could not resolve path in chosen node: '{path}'")
+            ret.append(node)
 
         return ret
 

--- a/tools/hardware/memory.py
+++ b/tools/hardware/memory.py
@@ -51,7 +51,7 @@ class Region:
         ''' create a region from a start/end rather than start/size '''
         if start > end:
             raise ValueError(
-                'invalid rage start (0x{:x}) > end (0x{:x})'.format(start > end))
+                'invalid rage start (0x{:x}) > end (0x{:x})'.format(start, end))
         return Region(start, end - start, owner)
 
     def overlaps(self, other):

--- a/tools/hardware/memory.py
+++ b/tools/hardware/memory.py
@@ -17,10 +17,6 @@ class Region:
         self.size = size
         self.owner = owner
 
-    @staticmethod
-    def clone(other):
-        return Region(other.base, other.size)
-
     def __repr__(self):
         ''' Returns a string representation that is a valid Python expression
         that eval() can parse. '''

--- a/tools/hardware/memory.py
+++ b/tools/hardware/memory.py
@@ -30,14 +30,22 @@ class Region:
             self.size)
 
     def __eq__(self, other):
-        return self.base == other.base and self.size == other.size
+        if isinstance(other, type(self)):
+            return self.base == other.base and self.size == other.size
+        else:
+            # duck typing is not supported
+            return NotImplemented
 
     def __ne__(self, other):
         # Needed only for py2.
         return not self.__eq__(other)
 
     def __gt__(self, other):
-        return self.base > other.base
+        if isinstance(other, type(self)):
+            return self.base > other.base
+        else:
+            # duck typing is not supported
+            return NotImplemented
 
     def __hash__(self):
         return hash((self.base, self.size))

--- a/tools/hardware/memory.py
+++ b/tools/hardware/memory.py
@@ -31,18 +31,18 @@ class Region:
             self.base + self.size - (1 if self.size > 0 else 0),
             self.size)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, type(self)):
             return self.base == other.base and self.size == other.size
         else:
             # duck typing is not supported
             return NotImplemented
 
-    def __ne__(self, other):
+    def __ne__(self, other: object) -> bool:
         # Needed only for py2.
         return not self.__eq__(other)
 
-    def __gt__(self, other):
+    def __gt__(self, other: object) -> bool:
         if isinstance(other, type(self)):
             return self.base > other.base
         else:

--- a/tools/hardware/memory.py
+++ b/tools/hardware/memory.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
+from typing import Union
 import functools
 import hardware
 
@@ -12,7 +13,8 @@ import hardware
 class Region:
     ''' Represents a region of memory. '''
 
-    def __init__(self, base: int, size: int, owner: 'WrappedNode' = None):
+    def __init__(self, base: int, size: int,
+                 owner: Union['WrappedNode', None] = None):
         self.base = base
         self.size = size
         self.owner = owner
@@ -51,7 +53,7 @@ class Region:
         return hash((self.base, self.size))
 
     @staticmethod
-    def from_range(start, end, owner=None):
+    def from_range(start, end, owner: Union['WrappedNode', None] = None):
         ''' create a region from a start/end rather than start/size '''
         if start > end:
             raise ValueError(

--- a/tools/hardware/memory.py
+++ b/tools/hardware/memory.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-from typing import Union
+from typing import List, Union
 import functools
 import hardware
 
@@ -19,12 +19,12 @@ class Region:
         self.size = size
         self.owner = owner
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         ''' Returns a string representation that is a valid Python expression
         that eval() can parse. '''
         return 'Region(base=0x{:x},size=0x{:x})'.format(self.base, self.size)
 
-    def __str__(self):
+    def __str__(self) -> str:
         ''' Returns a string representation. '''
         return 'Region [0x{:x}..0x{:x}] ({:d} bytes)'.format(
             self.base,
@@ -49,25 +49,25 @@ class Region:
             # duck typing is not supported
             return NotImplemented
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash((self.base, self.size))
 
     @staticmethod
-    def from_range(start, end, owner: Union['WrappedNode', None] = None):
+    def from_range(start: int, end: int, owner: Union['WrappedNode', None] = None) -> Region:
         ''' create a region from a start/end rather than start/size '''
         if start > end:
             raise ValueError(
                 'invalid rage start (0x{:x}) > end (0x{:x})'.format(start, end))
         return Region(start, end - start, owner)
 
-    def overlaps(self, other):
+    def overlaps(self, other: Region) -> bool:
         ''' returns True if this region overlaps the given region '''
         # Either our base is first, and to overlap our end must be > other.base
         # or other.base is first, and to overlap other's end must be > self.base
         return (self.base <= other.base and (self.base + self.size) > other.base) \
             or (other.base <= self.base and (other.base + other.size) > self.base)
 
-    def reserve(self, excluded):
+    def reserve(self, excluded: Region) -> List[Region]:
         ''' returns an array of regions that represent this region
         minus the excluded range '''
         if not self.overlaps(excluded):
@@ -90,7 +90,7 @@ class Region:
                                              self.base + self.size, self.owner))
         return ret
 
-    def align_base(self, align_bits):
+    def align_base(self, align_bits: int) -> Region:
         ''' align this region up to a given number of bits '''
         new_base = hardware.utils.align_up(self.base, align_bits)
         diff = new_base - self.base
@@ -102,7 +102,7 @@ class Region:
         # to check if this region still fits its needs.
         return Region(new_base, self.size - diff, self.owner)
 
-    def align_size(self, align_bits):
+    def align_size(self, align_bits: int) -> Region:
         ''' align this region's size to a given number of bits.
          will move the base address down and the region's size
          up '''
@@ -110,7 +110,7 @@ class Region:
         new_size = hardware.utils.align_up(self.size, align_bits)
         return Region(new_base, new_size, self.owner)
 
-    def make_chunks(self, chunksz):
+    def make_chunks(self, chunksz: int) -> List[Region]:
         base = self.base
         size = self.size
         ret = []

--- a/tools/hardware/outputs/c_header.py
+++ b/tools/hardware/outputs/c_header.py
@@ -189,7 +189,7 @@ def create_c_header_file(config, kernel_irqs: List, kernel_macros: Dict,
                          kernel_regions: List, physBase: int, physical_memory,
                          outputStream):
 
-    jinja_env = jinja2.Environment(loader=jinja2.BaseLoader, trim_blocks=True,
+    jinja_env = jinja2.Environment(loader=jinja2.BaseLoader(), trim_blocks=True,
                                    lstrip_blocks=True)
 
     template = jinja_env.from_string(HEADER_TEMPLATE)

--- a/tools/hardware/outputs/c_header.py
+++ b/tools/hardware/outputs/c_header.py
@@ -12,7 +12,8 @@ from typing import Dict, List, Tuple
 import hardware
 from hardware.config import Config
 from hardware.fdt import FdtParser
-from hardware.utils.rule import HardwareYaml
+from hardware.memory import Region
+from hardware.utils.rule import HardwareYaml, KernelInterrupt, KernelRegionGroup
 
 
 HEADER_TEMPLATE = '''/*
@@ -131,7 +132,7 @@ static const p_region_t BOOT_RODATA avail_p_regs[] = {
 '''
 
 
-def get_kernel_devices(tree: FdtParser, hw_yaml: HardwareYaml) -> Tuple[List, Dict]:
+def get_kernel_devices(tree: FdtParser, hw_yaml: HardwareYaml) -> Tuple[List[KernelRegionGroup], Dict[int, str]]:
     '''
     Given a device tree and a set of rules, returns a tuple (groups, offsets).
 
@@ -144,7 +145,7 @@ def get_kernel_devices(tree: FdtParser, hw_yaml: HardwareYaml) -> Tuple[List, Di
     kernel_devices = tree.get_kernel_devices()
 
     kernel_offset = 0
-    groups = []
+    groups: List[KernelRegionGroup] = []
     for dev in kernel_devices:
         dev_rule = hw_yaml.get_rule(dev)
         new_regions = dev_rule.get_regions(dev)
@@ -155,14 +156,14 @@ def get_kernel_devices(tree: FdtParser, hw_yaml: HardwareYaml) -> Tuple[List, Di
             else:
                 groups.append(reg)
 
-    offsets = {}
+    offsets: Dict[int, str] = {}
     for group in groups:
         kernel_offset = group.set_kernel_offset(kernel_offset)
         offsets.update(group.get_labelled_addresses())
     return (groups, offsets)
 
 
-def get_interrupts(tree: FdtParser, hw_yaml: HardwareYaml) -> List:
+def get_interrupts(tree: FdtParser, hw_yaml: HardwareYaml) -> List[KernelInterrupt]:
     ''' Get dict of interrupts, {label: KernelInterrupt} from the DT and hardware rules. '''
     kernel_devices = tree.get_kernel_devices()
 
@@ -225,6 +226,6 @@ def run(tree: FdtParser, hw_yaml: HardwareYaml, config: Config, args: argparse.N
         args.header_out)
 
 
-def add_args(parser):
+def add_args(parser: argparse.ArgumentParser):
     parser.add_argument('--header-out', help='output file for c header',
                         type=argparse.FileType('w'))

--- a/tools/hardware/outputs/c_header.py
+++ b/tools/hardware/outputs/c_header.py
@@ -8,7 +8,7 @@
 import argparse
 import builtins
 import jinja2
-from typing import Dict, List
+from typing import Dict, List, Tuple
 import hardware
 from hardware.config import Config
 from hardware.fdt import FdtParser
@@ -131,7 +131,7 @@ static const p_region_t BOOT_RODATA avail_p_regs[] = {
 '''
 
 
-def get_kernel_devices(tree: FdtParser, hw_yaml: HardwareYaml) -> (List, Dict):
+def get_kernel_devices(tree: FdtParser, hw_yaml: HardwareYaml) -> Tuple[List, Dict]:
     '''
     Given a device tree and a set of rules, returns a tuple (groups, offsets).
 

--- a/tools/hardware/outputs/compat_strings.py
+++ b/tools/hardware/outputs/compat_strings.py
@@ -25,6 +25,6 @@ def run(tree: FdtParser, hw_yaml: HardwareYaml, config: Config,
     args.compat_strings_out.close()
 
 
-def add_args(parser):
+def add_args(parser: argparse.ArgumentParser):
     parser.add_argument('--compat-strings-out',
                         help='output file for compat strings list', type=argparse.FileType('w'))

--- a/tools/hardware/outputs/elfloader.py
+++ b/tools/hardware/outputs/elfloader.py
@@ -12,7 +12,7 @@ import logging
 import pyfdt.pyfdt
 
 from jinja2 import Environment, BaseLoader
-from typing import List
+from typing import Dict, List, Union
 
 from hardware import config, device, fdt
 from hardware.utils import cpu, memory, rule
@@ -120,7 +120,7 @@ def get_elfloader_cpus(tree: fdt.FdtParser, devices: List[device.WrappedNode]) -
         if cpu_node.has_prop('reg'):
             cpuid = cpu_node.parse_address(list(cpu_node.get_prop('reg').words))
 
-        extra_data = 0
+        extra_data: Union[str, int] = 0
         if enable_method == 'psci' and psci_node:
             extra_data = 'PSCI_METHOD_' + psci_node.get_prop('method').strings[0].upper()
         elif enable_method == 'spin-table':
@@ -173,6 +173,6 @@ def run(tree: fdt.FdtParser, hardware: rule.HardwareYaml, config: config.Config,
     args.elfloader_out.close()
 
 
-def add_args(parser):
+def add_args(parser: argparse.ArgumentParser):
     parser.add_argument('--elfloader-out', help='output file for elfloader header',
                         type=argparse.FileType('w'))

--- a/tools/hardware/outputs/elfloader.py
+++ b/tools/hardware/outputs/elfloader.py
@@ -158,7 +158,7 @@ def run(tree: fdt.FdtParser, hardware: rule.HardwareYaml, config: config.Config,
 
     device_info.sort(key=lambda a: a['compat'])
 
-    template = Environment(loader=BaseLoader, trim_blocks=True,
+    template = Environment(loader=BaseLoader(), trim_blocks=True,
                            lstrip_blocks=True).from_string(HEADER_TEMPLATE)
 
     template_args = dict(builtins.__dict__, **{

--- a/tools/hardware/outputs/yaml.py
+++ b/tools/hardware/outputs/yaml.py
@@ -8,14 +8,15 @@
 
 import argparse
 import yaml
-from typing import List
+from typing import Dict, List
 import hardware
 from hardware.config import Config
 from hardware.fdt import FdtParser
-from hardware.utils.rule import HardwareYaml
+from hardware.memory import Region
+from hardware.utils.rule import HardwareYaml, KernelRegionGroup
 
 
-def make_yaml_list_of_regions(regions) -> List:
+def make_yaml_list_of_regions(regions: List[Region]) -> List[Dict[str, int]]:
     return [
         {
             'start': r.base,
@@ -25,7 +26,7 @@ def make_yaml_list_of_regions(regions) -> List:
     ]
 
 
-def create_yaml_file(dev_mem, phys_mem, outputStream):
+def create_yaml_file(dev_mem: List[Region], phys_mem: List[Region], outputStream):
 
     yaml.add_representer(
         int,
@@ -40,7 +41,7 @@ def create_yaml_file(dev_mem, phys_mem, outputStream):
         yaml.dump(yaml_obj, outputStream)
 
 
-def get_kernel_devices(tree: FdtParser, hw_yaml: HardwareYaml):
+def get_kernel_devices(tree: FdtParser, hw_yaml: HardwareYaml) -> List[KernelRegionGroup]:
     kernel_devices = tree.get_kernel_devices()
 
     groups = []
@@ -64,6 +65,6 @@ def run(tree: FdtParser, hw_yaml: HardwareYaml, config: Config,
     create_yaml_file(dev_mem, phys_mem, args.yaml_out)
 
 
-def add_args(parser):
+def add_args(parser: argparse.ArgumentParser):
     parser.add_argument('--yaml-out', help='output file for memory yaml',
                         type=argparse.FileType('w'))

--- a/tools/hardware/utils/cpu.py
+++ b/tools/hardware/utils/cpu.py
@@ -16,6 +16,8 @@ from hardware.fdt import FdtParser
 def get_cpus(tree: FdtParser) -> List[WrappedNode]:
     ' Return a list of all the CPUs described in this device tree. '
     cpus_node = tree.get_path('/cpus')
+    if cpus_node is None:
+        return []
 
     found_cpus = []
     for node in cpus_node:

--- a/tools/hardware/utils/memory.py
+++ b/tools/hardware/utils/memory.py
@@ -27,12 +27,12 @@ def get_memory_regions(tree: FdtParser):
 
 def merge_memory_regions(regions: Set[Region]) -> Set[Region]:
     ''' Check all region and merge adjacent ones '''
-    all_regions = [dict(idx=idx, region=region, right_adj=None, left_adj=None)
-                   for (idx, region) in enumerate(regions)]
+    all_regions = [dict(region=region, right_adj=None, left_adj=None)
+                   for region in regions]
 
     # Find all right contiguous regions
-    for dreg in all_regions:
-        for dnreg in all_regions[dreg['idx']+1:]:
+    for idx, dreg in enumerate(all_regions):
+        for dnreg in all_regions[idx+1:]:
             if dreg['region'].owner == dnreg['region'].owner:
                 if dnreg['region'].base == dreg['region'].base + dreg['region'].size:
                     dreg['right_adj'] = dnreg

--- a/tools/hardware/utils/memory.py
+++ b/tools/hardware/utils/memory.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-from typing import List, Set
+from typing import List, Set, Tuple
 
 import hardware
 from hardware.config import Config
@@ -83,7 +83,7 @@ def reserve_regions(regions: Set[Region], reserved: Set[Region]) -> Set[Region]:
     return ret
 
 
-def get_physical_memory(tree: FdtParser, config: Config) -> List[Region]:
+def get_physical_memory(tree: FdtParser, config: Config) -> Tuple[List[Region], Set[Region], int]:
     ''' returns a list of regions representing physical memory as used by the kernel '''
     regions = merge_memory_regions(get_memory_regions(tree))
     reserved = parse_reserved_regions(tree.get_path('/reserved-memory'))

--- a/tools/hardware/utils/memory.py
+++ b/tools/hardware/utils/memory.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-from typing import List, Set, Tuple, Union
+from typing import List, Set, Tuple, TypedDict, Union
 
 import hardware
 from hardware.config import Config
@@ -14,9 +14,9 @@ from hardware.memory import Region
 from hardware.utils.rule import KernelRegionGroup
 
 
-def get_memory_regions(tree: FdtParser):
+def get_memory_regions(tree: FdtParser) -> Set[Region]:
     ''' Get all regions with device_type = memory in the tree '''
-    regions = set()
+    regions: Set[Region] = set()
 
     def visitor(node: WrappedNode):
         if node.has_prop('device_type') and node.get_prop('device_type').strings[0] == 'memory':
@@ -95,7 +95,7 @@ def get_physical_memory(tree: FdtParser, config: Config) -> Tuple[List[Region], 
 
 def get_addrspace_exclude(regions: List[Region], config: Config):
     ''' Returns a list of regions that represents the inverse of the given region list. '''
-    ret = set()
+    ret: Set[Region] = set()
     # We can't create untypeds that exceed the addrspace_max, so we round down to the smallest
     # untyped size alignment so that the kernel will be able to turn the entire range into untypeds.
     as_max = hardware.utils.align_down(config.addrspace_max,

--- a/tools/hardware/utils/memory.py
+++ b/tools/hardware/utils/memory.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-from typing import List, Set, Tuple
+from typing import List, Set, Tuple, Union
 
 import hardware
 from hardware.config import Config
@@ -55,7 +55,7 @@ def merge_memory_regions(regions: Set[Region]) -> Set[Region]:
     return contiguous_regions
 
 
-def parse_reserved_regions(node: WrappedNode) -> Set[Region]:
+def parse_reserved_regions(node: Union[WrappedNode, None]) -> Set[Region]:
     ''' Parse a reserved-memory node, looking for regions that are
         unusable by OS (e.g. reserved for firmware/bootloader) '''
     if node is None:

--- a/tools/hardware/utils/rule.py
+++ b/tools/hardware/utils/rule.py
@@ -6,7 +6,7 @@
 
 from collections import defaultdict
 from functools import lru_cache
-from typing import Dict, List
+from typing import Dict, List, Union
 
 import logging
 
@@ -16,7 +16,7 @@ from hardware.fdt import FdtParser
 from hardware.memory import Region
 
 
-def get_macro_str(macro: str) -> str:
+def get_macro_str(macro: Union[str, None]) -> str:
     ''' Helper function that returns the appropriate C preprocessor line for a given macro '''
     if macro is None:
         return ''
@@ -26,7 +26,7 @@ def get_macro_str(macro: str) -> str:
     return '#ifdef ' + macro
 
 
-def get_endif(macro: str) -> str:
+def get_endif(macro: Union[str, None]) -> str:
     ''' Helper function that returns the appropriate endif line for a given macro '''
     if macro is None:
         return ''
@@ -37,7 +37,9 @@ def get_endif(macro: str) -> str:
 class KernelRegionGroup:
     ''' wraps a contiguous region of memory that is mapped into the kernel. '''
 
-    def __init__(self, region: Region, kernel_name: str, page_bits: int, max_size: int, condition_macro: str = None, user_ok: bool = False):
+    def __init__(self, region: Region, kernel_name: str, page_bits: int,
+                 max_size: int, condition_macro: Union[str, None] = None,
+                 user_ok: bool = False):
         self.macro = condition_macro
         self.desc = region.owner.path if region.owner else 'dynamically generated region'
         self.kernel_offset = -1
@@ -108,7 +110,10 @@ class KernelRegionGroup:
 class KernelInterrupt:
     ''' Represents an interrupt that is used by the kernel. '''
 
-    def __init__(self, label: str, irq: int, prio: int = 0, sel_macro: str = None, false_irq: int = -1, enable_macro: str = None, desc: str = None):
+    def __init__(self, label: str, irq: int, prio: int = 0,
+                 sel_macro: Union[str, None] = None, false_irq: int = -1,
+                 enable_macro: Union[str, None] = None,
+                 desc: Union[str, None] = None):
         self.label = label
         self.irq = irq
         self.prio = prio
@@ -239,7 +244,7 @@ class HardwareYaml:
         raise ValueError('Failed to match compatibles "{}" for node {}!'.format(
             ', '.join(device.get_prop('compatible').strings), device.path))
 
-    def get_matched_compatible(self, device: WrappedNode) -> str:
+    def get_matched_compatible(self, device: WrappedNode) -> Union[str, None]:
         ''' Returns the best matching compatible string for this device '''
         if not device.has_prop('compatible'):
             raise ValueError(

--- a/tools/hardware/utils/rule.py
+++ b/tools/hardware/utils/rule.py
@@ -99,7 +99,7 @@ class KernelRegionGroup:
     def __repr__(self) -> str:
         return 'KernelRegion(reg={},labels={})'.format(self.regions, self.labels)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, type(self)):
             return other.base == self.base and other.size == self.size
         else:

--- a/tools/hardware/utils/rule.py
+++ b/tools/hardware/utils/rule.py
@@ -66,37 +66,37 @@ class KernelRegionGroup:
             self.labels[k] = v
         self.desc += ', ' + other_group.desc
 
-    def get_macro(self):
+    def get_macro(self) -> str:
         ''' Get the #ifdef line for this region group '''
         return get_macro_str(self.macro)
 
-    def get_endif(self):
+    def get_endif(self) -> str:
         ''' Get the #endif line for this region group '''
         return get_endif(self.macro)
 
-    def set_kernel_offset(self, offset):
+    def set_kernel_offset(self, offset: int) -> int:
         ''' Set the base offset that this region is mapped at in the kernel.
             Returns the next free address in the kernel (i.e. base offset + region size) '''
         self.kernel_offset = offset
         return offset + self.size
 
-    def get_labelled_addresses(self) -> Dict:
+    def get_labelled_addresses(self) -> Dict[int, str]:
         ''' Get a dict of address -> label for the kernel '''
-        ret = {}
+        ret: Dict[int, str] = {}
         for (k, v) in self.labels.items():
             ret[v + self.kernel_offset] = k
         return ret
 
-    def get_map_offset(self, reg):
+    def get_map_offset(self, reg) -> int:
         ''' Get the offset that the given region is mapped at. '''
         index = self.regions.index(reg)
         return self.kernel_offset + (index * (1 << self.page_bits))
 
-    def get_desc(self):
+    def get_desc(self) -> str:
         ''' Get this region group's description '''
         return self.desc
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'KernelRegion(reg={},labels={})'.format(self.regions, self.labels)
 
     def __eq__(self, other):
@@ -122,31 +122,31 @@ class KernelInterrupt:
         self.enable_macro = enable_macro
         self.desc = desc
 
-    def get_enable_macro_str(self):
+    def get_enable_macro_str(self) -> str:
         ''' Get the enable macro #ifdef line '''
         return get_macro_str(self.enable_macro)
 
-    def has_enable(self):
+    def has_enable(self) -> bool:
         ''' True if this interrupt has an enable macro '''
         return self.enable_macro is not None
 
-    def get_enable_endif(self):
+    def get_enable_endif(self) -> str:
         ''' Get the enable macro #endif line '''
         return get_endif(self.enable_macro)
 
-    def get_sel_macro_str(self):
+    def get_sel_macro_str(self) -> str:
         ''' Get the select macro #ifdef line '''
         return get_macro_str(self.sel_macro)
 
-    def has_sel(self):
+    def has_sel(self) -> bool:
         ''' True if this interrupt has a select macro '''
         return self.sel_macro is not None
 
-    def get_sel_endif(self):
+    def get_sel_endif(self) -> str:
         ''' Get the select macro #endif line '''
         return get_endif(self.sel_macro)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'KernelInterrupt(label={},irq={},sel_macro={},false_irq={})'.format(self.label, self.irq, self.sel_macro, self.false_irq)
 
 
@@ -191,7 +191,7 @@ class DeviceRule:
     @lru_cache()
     def get_interrupts(self, tree: FdtParser, node: WrappedNode) -> List[KernelInterrupt]:
         ''' Returns a list of KernelInterrupts that this rule says are used by the kernel for this device. '''
-        ret = []
+        ret: List[KernelInterrupt] = []
         interrupts = node.get_interrupts(tree)
 
         for name, rule in self.interrupts.items():

--- a/tools/hardware/utils/rule.py
+++ b/tools/hardware/utils/rule.py
@@ -98,7 +98,11 @@ class KernelRegionGroup:
         return 'KernelRegion(reg={},labels={})'.format(self.regions, self.labels)
 
     def __eq__(self, other):
-        return other.base == self.base and other.size == self.size
+        if isinstance(other, type(self)):
+            return other.base == self.base and other.size == self.size
+        else:
+            # duck typing is not supported
+            return NotImplemented
 
 
 class KernelInterrupt:


### PR DESCRIPTION
This change will require at least Python 3.7, but we have that in the official docker containers now.