### PR TITLE
cmake: remove unused code

### DIFF
--- a/config.cmake
+++ b/config.cmake
@@ -48,10 +48,9 @@ set_property(
 
 # These options are now set in seL4Config.cmake
 if(DEFINED CALLED_declare_default_headers)
-    # calculate the irq cnode size based on MAX_IRQ
+    # calculate the irq cnode size based on MAX_NUM_IRQ
     if("${KernelArch}" STREQUAL "riscv")
-        set(MAX_IRQ "${CONFIGURE_PLIC_MAX_NUM_INT}")
-        math(EXPR MAX_NUM_IRQ "${MAX_IRQ} + 2")
+        math(EXPR MAX_NUM_IRQ "${CONFIGURE_PLIC_MAX_NUM_INT} + 2")
     else()
         if(
             DEFINED KernelMaxNumNodes
@@ -71,10 +70,6 @@ if(DEFINED CALLED_declare_default_headers)
         math(EXPR BITS "${BITS} + 1")
         math(EXPR MAX_NUM_IRQ "${MAX_NUM_IRQ} >> 1")
     endwhile()
-    math(EXPR SLOTS "1 << ${BITS}")
-    if("${SLOTS}" LESS "${MAX_IRQ}")
-        math(EXPR BITS "${BITS} + 1")
-    endif()
     set(CONFIGURE_IRQ_SLOT_BITS "${BITS}" CACHE INTERNAL "")
     if(NOT DEFINED CONFIGURE_TIMER_PRECISION)
         set(CONFIGURE_TIMER_PRECISION "0")


### PR DESCRIPTION
Clean up the CMake script:
- `SLOTS` cannot be less than `MAX_IRQ` (I'm not sure why this was added initially, seems some safe-guard that was never really needed)
- remove helper variable `MAX_IRQ` and use only `MAX_NUM_IRQ` everywhere  (should have happened at the last refactoring already)