### PR TITLE
python: use '#paragma once' include guard

### DIFF
--- a/libsel4/tools/syscall_stub_gen.py
+++ b/libsel4/tools/syscall_stub_gen.py
@@ -981,8 +981,7 @@ def generate_stub_file(arch, wordsize, input_files, output_file, use_only_ipc_bu
  * Automatically generated system call stubs.
  */
 
-#ifndef __LIBSEL4_SEL4_CLIENT_H
-#define __LIBSEL4_SEL4_CLIENT_H
+#pragma once
 """)
 
     # Emit the includes
@@ -1035,10 +1034,6 @@ def generate_stub_file(arch, wordsize, input_files, output_file, use_only_ipc_bu
                                     method_id, inputs, outputs, structs, use_only_ipc_buffer, comment, mcs))
         if condition != "":
             result.append("#endif")
-
-    # Print footer.
-    result.append("#endif /* __LIBSEL4_SEL4_CLIENT_H */")
-    result.append("")
 
     # Write the output
     output = open(output_file, "w")

--- a/tools/bitfield_gen.py
+++ b/tools/bitfield_gen.py
@@ -3057,13 +3057,10 @@ if __name__ == '__main__':
 
                 print("end", file=out_file)
     else:
-        guard = re.sub(r'[^a-zA-Z0-9_]', '_', out_file.filename.upper())
-        print("#ifndef %(guard)s\n#define %(guard)s\n" %
-              {'guard': guard}, file=out_file)
+        print("#pragma once\n", file=out_file)
         print('\n'.join(map(lambda x: '#include <%s>' % x,
                             INCLUDES[options.environment])), file=out_file)
         for e in det_values(blocks, unions):
             e.generate(options)
-        print("#endif", file=out_file)
 
     finish_output()

--- a/tools/invocation_header_gen.py
+++ b/tools/invocation_header_gen.py
@@ -42,8 +42,7 @@ COMMON_HEADER = """
  */"""
 
 INVOCATION_TEMPLATE = COMMON_HEADER + """
-#ifndef __{{header_title}}_INVOCATION_H
-#define __{{header_title}}_INVOCATION_H
+#pragma once
 
 enum invocation_label {
     InvalidInvocation,
@@ -63,14 +62,10 @@ enum invocation_label {
 #include <sel4/sel4_arch/invocation.h>
 #include <sel4/arch/invocation.h>
 {%- endif %}
-
-#endif /* __{{header_title}}_INVOCATION_H */
-
 """
 
 SEL4_ARCH_INVOCATION_TEMPLATE = COMMON_HEADER + """
-#ifndef __{{header_title}}_SEL4_ARCH_INVOCATION_H
-#define __{{header_title}}_SEL4_ARCH_INVOCATION_H
+#pragma once
 
 {%- if not libsel4 %}
 #include <api/invocation.h>
@@ -99,14 +94,10 @@ enum sel4_arch_invocation_label {
     nSeL4ArchInvocationLabels
     {%- endif %}
 };
-
-#endif /* __{{header_title}}_SEL4_ARCH_INVOCATION_H */
-
 """
 
 ARCH_INVOCATION_TEMPLATE = COMMON_HEADER + """
-#ifndef __{{header_title}}_ARCH_INVOCATION_H
-#define __{{header_title}}_ARCH_INVOCATION_H
+#pragma once
 
 {%- if not libsel4 %}
 #include <arch/api/sel4_invocation.h>
@@ -135,9 +126,6 @@ enum arch_invocation_label {
     nArchInvocationLabels
     {%- endif %}
 };
-
-#endif /* __{{header_title}}_ARCH_INVOCATION_H */
-
 """
 
 


### PR DESCRIPTION
using the '#paragma once' include guard simplifies things a bit and it's the modern way to guard includes.