### PR TITLE
fix config includes

### DIFF
--- a/include/arch/arm/arch/machine/gic_common.h
+++ b/include/arch/arm/arch/machine/gic_common.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <config.h>
 #include <stdint.h>
 #include <machine/interrupt.h>
 

--- a/include/arch/riscv/arch/32/mode/hardware.h
+++ b/include/arch/riscv/arch/32/mode/hardware.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
+#include <config.h>
 #include <util.h>
-#include <sel4/config.h>
 
 /*
  *         2^32 +-------------------+


### PR DESCRIPTION
The kernel files usually simply include `config.h`, which then handles further details. It's unclear why these two files do things differently, there seems no specific reason and it might be just legacy. The file `config.h` will include `sel4/config.h` anyway, which does include `autoconf.h` then.
Changing this avoids setting a bad example. If there is reason, e.g. why `sel4/config.h` must be hidden from the GIC header file code that might be worth documenting. Due to the way the kernel build works on a single file, this header might have been included already anyway.
