### PR TITLE
CAVEATS-generic: ASID caveat applies all arches

### DIFF
--- a/CAVEATS-generic.md
+++ b/CAVEATS-generic.md
@@ -50,7 +50,7 @@ provides principled access control for execution time, but its formal
 verification is currently still in progress.
 
 
-## Re-using Address Spaces (ARM and x86):
+## Re-using Address Spaces
 
 Before an ASID/page directory/page table can be reused, all frame caps
 installed in it should be revoked. The kernel will not do this automatically


### PR DESCRIPTION
Remove x86 and Arm from heading of the "Re-using address spaces" caveat
because it's also present on RISCV and isn't actually arch specific.

Signed-off-by: Kent McLeod <kent@kry10.com>