### PR TITLE
aarch64: remove redundent CPSR.AIF in HCR_NATIVE

### DIFF
--- a/include/arch/arm/armv/armv8-a/64/armv/vcpu.h
+++ b/include/arch/arm/armv/armv8-a/64/armv/vcpu.h
@@ -24,7 +24,7 @@
 
 /* Allow native tasks to run at EL0, but restrict access */
 #define HCR_NATIVE ( HCR_COMMON | HCR_TGE | HCR_TVM | HCR_TTLB | HCR_DC \
-                   | HCR_TAC | HCR_SWIO |  HCR_TSC | HCR_IMO | HCR_FMO | HCR_AMO)
+                   | HCR_TAC | HCR_SWIO |  HCR_TSC )
 #define HCR_VCPU   ( HCR_COMMON | HCR_TSC)
 
 #define SCTLR_EL1_UCI       BIT(26)     /* Enable EL0 access to DC CVAU, DC CIVAC, DC CVAC,


### PR DESCRIPTION
CPSR.AIF already presented in HCR_COMMON macro,
And HCR_NATIVE includes HCR_COMMON, then no need
To set CPSR.AIF bit again

Signed-off-by: Cao Jianlong <caojianlong@outlook.com>