### PR TITLE
FPU as an object

### DIFF
--- a/include/arch/arm/arch/32/mode/fastpath/fastpath.h
+++ b/include/arch/arm/arch/32/mode/fastpath/fastpath.h
@@ -123,7 +123,7 @@ static inline void NORETURN FORCE_INLINE fastpath_restore(word_t badge, word_t m
 #endif
 
 #ifdef CONFIG_HAVE_FPU
-    lazyFPURestore(NODE_STATE(ksCurThread));
+    eagerFPURestore(NODE_STATE(ksCurThread));
 #endif /* CONFIG_HAVE_FPU */
 
     register word_t badge_reg asm("r0") = badge;

--- a/include/arch/arm/arch/32/mode/machine/registerset.h
+++ b/include/arch/arm/arch/32/mode/machine/registerset.h
@@ -204,14 +204,6 @@ typedef struct user_breakpoint_state {
 } user_breakpoint_state_t;
 #endif
 
-#ifdef CONFIG_HAVE_FPU
-typedef struct user_fpu_state {
-    uint64_t fpregs[32];
-    uint32_t fpexc;
-    uint32_t fpscr;
-} user_fpu_state_t;
-#endif /* CONFIG_HAVE_FPU */
-
 /* ARM user-code context: size = 72 bytes
  * Or with hardware debug support built in:
  *      72 + sizeof(word_t) * (NUM_BPS + NUM_WPS) * 2
@@ -225,9 +217,6 @@ struct user_context {
 #ifdef ARM_BASE_CP14_SAVE_AND_RESTORE
     user_breakpoint_state_t breakpointState;
 #endif /* CONFIG_HARDWARE_DEBUG_API */
-#ifdef CONFIG_HAVE_FPU
-    user_fpu_state_t fpuState;
-#endif /* CONFIG_HAVE_FPU */
 };
 typedef struct user_context user_context_t;
 

--- a/include/arch/arm/arch/32/mode/object/structures.bf
+++ b/include/arch/arm/arch/32/mode/object/structures.bf
@@ -93,6 +93,15 @@ block asid_pool_cap {
     field capType          4
 }
 
+#ifdef CONFIG_HAVE_FPU
+block fpu_cap {
+    padding                         32
+
+    field_high capFpuPtr            28
+    field capType                   4
+}
+#endif
+
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
 block vcpu_cap {
     padding               32
@@ -156,6 +165,9 @@ tagged_union cap capType {
     tag page_table_cap       7
     tag page_directory_cap   9
     tag asid_control_cap    11
+#ifdef CONFIG_HAVE_FPU
+    tag fpu_cap             13
+#endif
     -- Do not extend odd 4-bit caps types beyond 13, as we use
     -- 15 (0xf) to determine which caps are 8-bit.
 

--- a/include/arch/arm/arch/64/mode/fastpath/fastpath.h
+++ b/include/arch/arm/arch/64/mode/fastpath/fastpath.h
@@ -103,7 +103,7 @@ static inline void NORETURN FORCE_INLINE fastpath_restore(word_t badge, word_t m
     c_exit_hook();
 
 #ifdef CONFIG_HAVE_FPU
-    lazyFPURestore(NODE_STATE(ksCurThread));
+    eagerFPURestore(NODE_STATE(ksCurThread));
 #endif /* CONFIG_HAVE_FPU */
 
     register word_t badge_reg asm("x0") = badge;

--- a/include/arch/arm/arch/64/mode/machine/fpu.h
+++ b/include/arch/arm/arch/64/mode/machine/fpu.h
@@ -34,16 +34,17 @@ static inline void saveFpuState(tcb_fpu_t *dest)
         "stp     q28, q29, [%1, #16 * 28]   \n"
 
         /* Use the vregs stored in the tcb_fpu_t object */
-        "stp     q30, q31, [%2, #0]   \n"
+        "str     q30, [%1, #16 * 30]        \n"
+        "str     q31, [%2]                  \n"
 
         /* Status and control registers */
         "mrs     %0, fpsr                   \n"
-        "str     %w0, [%1, #16 * 30]        \n"
+        "str     %w0, [%1, #16 * 31]        \n"
         "mrs     %0, fpcr                   \n"
-        "str     %w0, [%1, #16 * 30 + 4]    \n"
+        "str     %w0, [%1, #16 * 31 + 4]    \n"
 
         : "=&r"(temp)
-        : "r"(dest->tcbBoundFPU), "r"(dest->last_vregs)
+        : "r"(dest->tcbBoundFpu), "r"(dest->q31)
         : "memory"
     );
 }
@@ -71,15 +72,16 @@ static inline void loadFpuState(tcb_fpu_t *src)
         "ldp     q28, q29, [%1, #16 * 28]   \n"
 
         /* Use the vregs stored in the tcb_fpu_t object */
-        "ldp     q30, q31, [%2, #0]  \n"
+        "ldr     q30, [%1, #16 * 30]        \n"
+        "ldr     q31, [%2]                  \n"
 
         /* FP control and status registers */
-        "ldr     %w0, [%1, #16 * 30]        \n"
+        "ldr     %w0, [%1, #16 * 31]        \n"
         "msr     fpsr, %0                   \n"
-        "ldr     %w0, [%1, #16 * 30 + 4]    \n"
+        "ldr     %w0, [%1, #16 * 31 + 4]    \n"
         "msr     fpcr, %0                   \n"
         : "=&r"(temp)
-        : "r"(src->tcbBoundFPU), "r"(src->last_vregs)
+        : "r"(src->tcbBoundFpu), "r"(src->q31)
         : "memory"
     );
 }

--- a/include/arch/arm/arch/64/mode/machine/fpu.h
+++ b/include/arch/arm/arch/64/mode/machine/fpu.h
@@ -12,7 +12,7 @@ extern bool_t isFPUEnabledCached[CONFIG_MAX_NUM_NODES];
 
 #ifdef CONFIG_HAVE_FPU
 /* Store state in the FPU registers into memory. */
-static inline void saveFpuState(user_fpu_state_t *dest)
+static inline void saveFpuState(tcb_fpu_t *dest)
 {
     word_t temp;
 
@@ -47,7 +47,7 @@ static inline void saveFpuState(user_fpu_state_t *dest)
 }
 
 /* Load FPU state from memory into the FPU registers. */
-static inline void loadFpuState(user_fpu_state_t *src)
+static inline void loadFpuState(tcb_fpu_t *src)
 {
     word_t temp;
 

--- a/include/arch/arm/arch/64/mode/machine/registerset.h
+++ b/include/arch/arm/arch/64/mode/machine/registerset.h
@@ -232,14 +232,6 @@ extern const register_t msgRegisters[];
 extern const register_t frameRegisters[];
 extern const register_t gpRegisters[];
 
-#ifdef CONFIG_HAVE_FPU
-typedef struct user_fpu_state {
-    uint64_t vregs[64];
-    uint32_t fpsr;
-    uint32_t fpcr;
-} user_fpu_state_t;
-#endif /* CONFIG_HAVE_FPU */
-
 /* ARM user-code context: size = 72 bytes
  * Or with hardware debug support built in:
  *      72 + sizeof(word_t) * (NUM_BPS + NUM_WPS) * 2
@@ -250,9 +242,6 @@ typedef struct user_fpu_state {
  */
 struct user_context {
     word_t registers[n_contextRegisters];
-#ifdef CONFIG_HAVE_FPU
-    user_fpu_state_t fpuState;
-#endif /* CONFIG_HAVE_FPU */
 };
 typedef struct user_context user_context_t;
 

--- a/include/arch/arm/arch/64/mode/object/structures.bf
+++ b/include/arch/arm/arch/64/mode/object/structures.bf
@@ -105,6 +105,14 @@ block asid_pool_cap {
     field_high capASIDPool          37
 }
 
+block fpu_cap {
+    padding                         16
+    field_high capFpuPtr            48
+
+    field capType                   5
+    padding                         59
+}
+
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
 block vcpu_cap {
     padding                         64
@@ -181,14 +189,15 @@ tagged_union cap capType {
     tag page_global_directory_cap   9
     tag asid_control_cap            11
     tag asid_pool_cap               13
+    tag fpu_cap                     15
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
-    tag vcpu_cap                    15
+    tag vcpu_cap                    17
 #endif
 #ifdef CONFIG_ARM_SMMU
-    tag sid_control_cap             17
-    tag sid_cap                     19
-    tag cb_control_cap              21
-    tag cb_cap                      23
+    tag sid_control_cap             19
+    tag sid_cap                     21
+    tag cb_control_cap              23
+    tag cb_cap                      25
 #endif
 }
 

--- a/include/arch/arm/arch/64/mode/object/structures.bf
+++ b/include/arch/arm/arch/64/mode/object/structures.bf
@@ -105,6 +105,7 @@ block asid_pool_cap {
     field_high capASIDPool          37
 }
 
+#ifdef CONFIG_HAVE_FPU
 block fpu_cap {
     padding                         16
     field_high capFpuPtr            48
@@ -112,6 +113,7 @@ block fpu_cap {
     field capType                   5
     padding                         59
 }
+#endif
 
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
 block vcpu_cap {
@@ -189,7 +191,9 @@ tagged_union cap capType {
     tag page_global_directory_cap   9
     tag asid_control_cap            11
     tag asid_pool_cap               13
+#ifdef CONFIG_HAVE_FPU
     tag fpu_cap                     15
+#endif
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
     tag vcpu_cap                    17
 #endif

--- a/include/arch/arm/arch/64/mode/object/structures.h
+++ b/include/arch/arm/arch/64/mode/object/structures.h
@@ -16,6 +16,7 @@
 #include <arch/machine/hardware.h>
 #include <arch/machine/registerset.h>
 
+#ifdef CONFIG_HAVE_FPU
 typedef struct fpu {
     uint64_t vregs[62];
     uint32_t fpsr;
@@ -34,12 +35,14 @@ typedef struct tcb_fpu {
     /* Last quad-word register in the fpu */
     uint64_t q31[2];
 } tcb_fpu_t;
+#endif
 
 typedef struct arch_tcb {
     user_context_t tcbContext;
 
+#ifdef CONFIG_HAVE_FPU
     tcb_fpu_t tcbFpu;
-
+#endif
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
     struct vcpu *tcbVCPU;
 #endif

--- a/include/arch/arm/arch/64/mode/object/structures.h
+++ b/include/arch/arm/arch/64/mode/object/structures.h
@@ -31,7 +31,7 @@ typedef struct tcb_fpu {
     /* Object created from retyping an untyped */
     fpu_t *tcbBoundFpu;
 
-    uint64_t vregs[2];
+    uint64_t last_vregs[2];
 } tcb_fpu_t;
 
 typedef struct arch_tcb {

--- a/include/arch/arm/arch/64/mode/object/structures.h
+++ b/include/arch/arm/arch/64/mode/object/structures.h
@@ -31,7 +31,8 @@ typedef struct tcb_fpu {
     /* Object created from retyping an untyped */
     fpu_t *tcbBoundFpu;
 
-    uint64_t last_vregs[2];
+    /* Last quad-word register in the fpu */
+    uint64_t q31[2];
 } tcb_fpu_t;
 
 typedef struct arch_tcb {
@@ -118,6 +119,9 @@ typedef pgde_t vspace_root_t;
 
 #define PT_PTR(r)           ((pte_t *)(r))
 #define PT_REF(p)           ((word_t)(p))
+
+#define FPU_PTR(r)          ((fpu_t *)(r))
+#define FPU_REF(p)          ((word_t)(p))
 
 /* Generate a vcpu_t pointer from a vcpu block reference */
 #define VCPU_PTR(r)       ((struct vcpu *)(r))

--- a/include/arch/arm/arch/64/mode/object/structures.h
+++ b/include/arch/arm/arch/64/mode/object/structures.h
@@ -16,8 +16,29 @@
 #include <arch/machine/hardware.h>
 #include <arch/machine/registerset.h>
 
+typedef struct fpu {
+    uint64_t vregs[62];
+    uint32_t fpsr;
+    uint32_t fpcr;
+
+    /* Backlink from fpu to TCB */
+    struct tcb *fpuBoundTCB;
+} fpu_t;
+
+compile_assert(fpu_object_size_correct, sizeof(fpu_t) == BIT(seL4_FPUBits));
+
+typedef struct tcb_fpu {
+    /* Object created from retyping an untyped */
+    fpu_t *tcbBoundFpu;
+
+    uint64_t vregs[2];
+} tcb_fpu_t;
+
 typedef struct arch_tcb {
     user_context_t tcbContext;
+
+    tcb_fpu_t tcbFpu;
+
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
     struct vcpu *tcbVCPU;
 #endif

--- a/include/arch/arm/arch/smp/ipi_inline.h
+++ b/include/arch/arm/arch/smp/ipi_inline.h
@@ -16,7 +16,7 @@ static inline void doRemoteStall(word_t cpu)
 }
 
 #ifdef CONFIG_HAVE_FPU
-static inline void doRemoteswitchFpuOwner(user_fpu_state_t *new_owner, word_t cpu)
+static inline void doRemoteswitchFpuOwner(tcb_fpu_t *new_owner, word_t cpu)
 {
     doRemoteOp1Arg(IpiRemoteCall_switchFpuOwner, (word_t)new_owner, cpu);
 }

--- a/include/arch/riscv/arch/32/mode/object/structures.bf
+++ b/include/arch/riscv/arch/32/mode/object/structures.bf
@@ -58,6 +58,15 @@ block asid_pool_cap {
     field       capType         4
 }
 
+#ifdef CONFIG_HAVE_FPU
+block fpu_cap {
+    field_high capFpuPtr        32
+
+    padding                     28
+    field capType               4
+}
+#endif
+
 -- NB: odd numbers are arch caps (see isArchCap())
 tagged_union cap capType {
     mask 4 0xe
@@ -75,6 +84,9 @@ tagged_union cap capType {
     -- 4-bit tag arch caps
     tag frame_cap           1
     tag page_table_cap      3
+#ifdef CONFIG_HAVE_FPU
+    tag fpu_cap             5
+#endif
     tag asid_control_cap    11
     tag asid_pool_cap       13
 

--- a/include/arch/riscv/arch/64/mode/object/structures.bf
+++ b/include/arch/riscv/arch/64/mode/object/structures.bf
@@ -64,6 +64,16 @@ block asid_pool_cap {
     field_high  capASIDPool     37
 }
 
+#ifdef CONFIG_HAVE_FPU
+block fpu_cap {
+    padding                     25
+    field_high capFpuPtr        39
+
+    field capType               5
+    padding                     59
+}
+#endif
+
 -- NB: odd numbers are arch caps (see isArchCap())
 tagged_union cap capType {
     -- 5-bit tag caps
@@ -88,6 +98,9 @@ tagged_union cap capType {
     tag page_table_cap      3
     tag asid_control_cap    11
     tag asid_pool_cap       13
+#ifdef CONFIG_HAVE_FPU
+    tag fpu_cap             15
+#endif
 }
 
 ---- Arch-independent object types

--- a/include/arch/riscv/arch/fastpath/fastpath.h
+++ b/include/arch/riscv/arch/fastpath/fastpath.h
@@ -108,7 +108,7 @@ static inline void NORETURN FORCE_INLINE fastpath_restore(word_t badge, word_t m
     c_exit_hook();
 
 #ifdef CONFIG_HAVE_FPU
-    lazyFPURestore(NODE_STATE(ksCurThread));
+    eagerFPURestore(NODE_STATE(ksCurThread));
     set_tcb_fs_state(NODE_STATE(ksCurThread), isFpuEnable());
 #endif
 

--- a/include/arch/riscv/arch/machine/registerset.h
+++ b/include/arch/riscv/arch/machine/registerset.h
@@ -89,30 +89,8 @@ extern const register_t msgRegisters[] VISIBLE;
 extern const register_t frameRegisters[] VISIBLE;
 extern const register_t gpRegisters[] VISIBLE;
 
-#ifdef CONFIG_HAVE_FPU
-
-#define RISCV_NUM_FP_REGS   32
-
-#if defined(CONFIG_RISCV_EXT_D)
-typedef uint64_t fp_reg_t;
-#elif defined(CONFIG_RISCV_EXT_F)
-typedef uint32_t fp_reg_t;
-#else
-#error Unknown RISCV FPU extension
-#endif
-
-typedef struct user_fpu_state {
-    fp_reg_t regs[RISCV_NUM_FP_REGS];
-    uint32_t fcsr;
-} user_fpu_state_t;
-
-#endif
-
 struct user_context {
     word_t registers[n_contextRegisters];
-#ifdef CONFIG_HAVE_FPU
-    user_fpu_state_t fpuState;
-#endif
 };
 typedef struct user_context user_context_t;
 

--- a/include/arch/riscv/arch/smp/ipi_inline.h
+++ b/include/arch/riscv/arch/smp/ipi_inline.h
@@ -14,7 +14,7 @@ static inline void doRemoteStall(word_t cpu)
 }
 
 #ifdef CONFIG_HAVE_FPU
-static inline void doRemoteswitchFpuOwner(user_fpu_state_t *new_owner, word_t cpu)
+static inline void doRemoteswitchFpuOwner(tcb_fpu_t *new_owner, word_t cpu)
 {
     doRemoteOp1Arg(IpiRemoteCall_switchFpuOwner, (word_t)new_owner, cpu);
 }

--- a/include/arch/x86/arch/machine/fpu.h
+++ b/include/arch/x86/arch/machine/fpu.h
@@ -114,7 +114,7 @@ static inline void disableFpu(void)
 #ifdef CONFIG_VTX
 static inline bool_t vcpuThreadUsingFPU(tcb_t *thread)
 {
-    return thread->tcbArch.tcbVCPU && &thread->tcbArch.tcbVCPU->fpuState == NODE_STATE(ksActiveFPUState);
+    return thread->tcbArch.tcbVCPU && &thread->tcbArch.tcbVCPU->fpuState == NODE_STATE(ksActiveFPU);
 }
 #endif /* CONFIG_VTX */
 

--- a/include/machine/fpu.h
+++ b/include/machine/fpu.h
@@ -47,5 +47,33 @@ static inline void FORCE_INLINE eagerFPURestore(tcb_t *thread)
     }
 }
 
+static inline void doUnbindFpu(fpu_t *fpuPtr, tcb_t *tcb)
+{
+    fpuPtr->fpuBoundTCB = NULL;
+    tcb->tcbArch.tcbFpu.tcbBoundFpu = NULL;
+}
+
+static void UNUSED unbindMaybeFpu(fpu_t *fpuPtr)
+{
+    tcb_t *tcb = fpuPtr->fpuBoundTCB;
+    if (tcb) {
+        doUnbindFpu(fpuPtr, tcb);
+    }
+}
+
+static void unbindFpu(tcb_t *tcb)
+{
+    fpu_t *fpuPtr = tcb->tcbArch.tcbFpu.tcbBoundFpu;
+    if (fpuPtr) {
+        doUnbindFpu(fpuPtr, tcb);
+    }
+}
+
+static void bindFpu(tcb_t *tcb, fpu_t *fpuPtr)
+{
+    fpuPtr->fpuBoundTCB = tcb;
+    tcb->tcbArch.tcbFpu.tcbBoundFpu = fpuPtr;
+}
+
 #endif /* CONFIG_HAVE_FPU */
 

--- a/include/machine/fpu.h
+++ b/include/machine/fpu.h
@@ -49,8 +49,8 @@ static inline void FORCE_INLINE eagerFPURestore(tcb_t *thread)
 
 static inline void doUnbindFpu(fpu_t *fpuPtr, tcb_t *tcb)
 {
-    fpuPtr->fpuBoundTCB = NULL;
-    tcb->tcbArch.tcbFpu.tcbBoundFpu = NULL;
+    memzero(fpuPtr, sizeof(fpu_t));
+    memzero(&tcb->tcbArch.tcbFpu, sizeof(tcb_fpu_t));
 }
 
 static void UNUSED unbindMaybeFpu(fpu_t *fpuPtr)

--- a/include/machine/fpu.h
+++ b/include/machine/fpu.h
@@ -19,40 +19,31 @@ void fpuThreadDelete(tcb_t *thread);
 /* Handle an FPU exception. */
 exception_t handleFPUFault(void);
 
-void switchLocalFpuOwner(user_fpu_state_t *new_owner);
+void switchLocalFpuOwner(tcb_fpu_t *new_owner);
 
 /* Switch the current owner of the FPU state on the core specified by 'cpu'. */
-void switchFpuOwner(user_fpu_state_t *new_owner, word_t cpu);
+void switchFpuOwner(tcb_fpu_t *new_owner, word_t cpu);
 
 /* Returns whether or not the passed thread is using the current active fpu state */
 static inline bool_t nativeThreadUsingFPU(tcb_t *thread)
 {
-    return &thread->tcbArch.tcbContext.fpuState ==
-           NODE_STATE_ON_CORE(ksActiveFPUState, thread->tcbAffinity);
+    return &thread->tcbArch.tcbFpu ==
+           NODE_STATE_ON_CORE(ksActiveFPU, thread->tcbAffinity);
 }
 
-static inline void FORCE_INLINE lazyFPURestore(tcb_t *thread)
+static inline void FORCE_INLINE eagerFPURestore(tcb_t *thread)
 {
-    if (unlikely(NODE_STATE(ksActiveFPUState))) {
-        /* If we have enabled/disabled the FPU too many times without
-         * someone else trying to use it, we assume it is no longer
-         * in use and switch out its state. */
-        if (unlikely(NODE_STATE(ksFPURestoresSinceSwitch) > CONFIG_FPU_MAX_RESTORES_SINCE_SWITCH)) {
-            switchLocalFpuOwner(NULL);
-            NODE_STATE(ksFPURestoresSinceSwitch) = 0;
-        } else {
-            if (likely(nativeThreadUsingFPU(thread))) {
-                /* We are using the FPU, make sure it is enabled */
-                enableFpu();
-            } else {
-                /* Someone is using the FPU and it might be enabled */
-                disableFpu();
-            }
-            NODE_STATE(ksFPURestoresSinceSwitch)++;
-        }
+    /* If next thread doesn't have an fpu object and fpu is currently
+     * enabled, we can disable fpu */
+    if (!thread->tcbArch.tcbFpu.tcbBoundFpu
+        && isFPUEnabledCached[CURRENT_CPU_INDEX()]) {
+        disableFpu();
     } else {
-        /* No-one (including us) is using the FPU, so we assume it
-         * is currently disabled */
+        if (nativeThreadUsingFPU(thread)) {
+            enableFpu();
+        } else {
+            switchLocalFpuOwner(&thread->tcbArch.tcbFpu);
+        }
     }
 }
 

--- a/include/model/statedata.h
+++ b/include/model/statedata.h
@@ -74,7 +74,7 @@ NODE_STATE_DECLARE(sched_context_t, *ksIdleSC);
 
 #ifdef CONFIG_HAVE_FPU
 /* Current state installed in the FPU, or NULL if the FPU is currently invalid */
-NODE_STATE_DECLARE(user_fpu_state_t *, ksActiveFPUState);
+NODE_STATE_DECLARE(tcb_fpu_t *, ksActiveFPU);
 /* Number of times we have restored a user context with an active FPU without switching it */
 NODE_STATE_DECLARE(word_t, ksFPURestoresSinceSwitch);
 #endif /* CONFIG_HAVE_FPU */

--- a/include/model/statedata.h
+++ b/include/model/statedata.h
@@ -75,8 +75,6 @@ NODE_STATE_DECLARE(sched_context_t, *ksIdleSC);
 #ifdef CONFIG_HAVE_FPU
 /* Current state installed in the FPU, or NULL if the FPU is currently invalid */
 NODE_STATE_DECLARE(tcb_fpu_t *, ksActiveFPU);
-/* Number of times we have restored a user context with an active FPU without switching it */
-NODE_STATE_DECLARE(word_t, ksFPURestoresSinceSwitch);
 #endif /* CONFIG_HAVE_FPU */
 #ifdef CONFIG_DEBUG_BUILD
 NODE_STATE_DECLARE(tcb_t *, ksDebugTCBs);

--- a/include/object/tcb.h
+++ b/include/object/tcb.h
@@ -148,6 +148,10 @@ exception_t decodeUnbindNotification(cap_t cap);
 #ifdef CONFIG_KERNEL_MCS
 exception_t decodeSetTimeoutEndpoint(cap_t cap, cte_t *slot);
 #endif
+#ifdef CONFIG_HAVE_FPU
+exception_t decodeBindFpu(cap_t cap);
+exception_t decodeUnbindFpu(cap_t cap);
+#endif
 
 
 #ifdef CONFIG_KERNEL_MCS

--- a/libsel4/arch_include/arm/sel4/arch/objecttype.h
+++ b/libsel4/arch_include/arm/sel4/arch/objecttype.h
@@ -23,6 +23,7 @@ typedef enum _object {
 #ifdef CONFIG_TK1_SMMU
     seL4_ARM_IOPageTableObject,
 #endif
+    seL4_ARM_FPUObject,
     seL4_ObjectTypeCount
 } seL4_ArchObjectType;
 

--- a/libsel4/arch_include/riscv/sel4/arch/objecttype.h
+++ b/libsel4/arch_include/riscv/sel4/arch/objecttype.h
@@ -13,6 +13,9 @@ typedef enum _object {
     seL4_RISCV_4K_Page = seL4_ModeObjectTypeCount,
     seL4_RISCV_Mega_Page,
     seL4_RISCV_PageTableObject,
+#ifdef CONFIG_HAVE_FPU
+    seL4_RISCV_FPUObject,
+#endif
     seL4_ObjectTypeCount
 } seL4_ArchObjectType;
 

--- a/libsel4/include/interfaces/sel4.xml
+++ b/libsel4/include/interfaces/sel4.xml
@@ -605,6 +605,19 @@
             </error>
         </method>
 
+        <method id="TCBBindFPU" name="BindFPU" manual_name="Bind FPU" manual_label="tcb_bindfpu">
+            <brief>
+                Binds an FPU object to a <obj name="TCB"/>
+            </brief>
+            <param dir="in" name="fpu" type="seL4_CPtr" description="FPU to bind."/>
+        </method>
+
+        <method id="TCBUnbindFPU" name="UnbindFPU" manual_name="Unbind FPU" manual_label="tcb_unbindfpu">
+            <brief>
+                Unbinds an fpu object from a <obj name="TCB"/>
+            </brief>
+        </method>
+
         <method id="TCBSetAffinity" name="SetAffinity" manual_name="Set CPU Affinity" manual_label="tcb_setaffinity">
             <condition>
                 <and>

--- a/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/constants.h
@@ -168,15 +168,19 @@ typedef enum {
         defined(CONFIG_HARDWARE_DEBUG_API) \
     ) \
 )
-#define seL4_TCBBits 11
+#define seL4_TCBBits 10
 #elif ( \
     defined(CONFIG_HAVE_FPU) || \
     (defined(CONFIG_ARM_HYPERVISOR_SUPPORT) && defined(CONFIG_ARM_HYP_ENABLE_VCPU_CP14_SAVE_AND_RESTORE)) || \
     defined(CONFIG_HARDWARE_DEBUG_API) \
 )
-#define seL4_TCBBits 10
+#define seL4_TCBBits 9
 #else
 #define seL4_TCBBits 9
+#endif
+
+#ifdef CONFIG_HAVE_FPU
+#define seL4_FPUBits 8
 #endif
 
 #define seL4_EndpointBits 4

--- a/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
@@ -174,8 +174,9 @@ typedef enum {
 #define seL4_LargePageBits 21
 #define seL4_HugePageBits 30
 #define seL4_SlotBits 5
-#define seL4_TCBBits 11
+#define seL4_TCBBits 10
 #define seL4_EndpointBits 4
+#define seL4_FPUBits 9
 #ifdef CONFIG_KERNEL_MCS
 #define seL4_NotificationBits 6
 #define seL4_ReplyBits           5

--- a/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
@@ -176,7 +176,9 @@ typedef enum {
 #define seL4_SlotBits 5
 #define seL4_TCBBits 10
 #define seL4_EndpointBits 4
+#ifdef CONFIG_HAVE_FPU
 #define seL4_FPUBits 9
+#endif
 #ifdef CONFIG_KERNEL_MCS
 #define seL4_NotificationBits 6
 #define seL4_ReplyBits           5

--- a/libsel4/sel4_arch_include/riscv32/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/riscv32/sel4/sel4_arch/constants.h
@@ -24,6 +24,13 @@
 #define seL4_EndpointBits       4
 #define seL4_IPCBufferSizeBits  9
 #define seL4_TCBBits            9
+#ifdef CONFIG_HAVE_FPU
+#ifdef CONFIG_RISCV_EXT_D
+#define seL4_FPUBits            8
+#elif CONFIG_RISCV_EXT_F
+#define seL4_FPUBits            7
+#endif
+#endif
 
 /* Untyped size limits */
 #define seL4_MinUntypedBits     4

--- a/libsel4/sel4_arch_include/riscv64/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/riscv64/sel4/sel4_arch/constants.h
@@ -23,10 +23,14 @@
 #endif
 #define seL4_EndpointBits       4
 #define seL4_IPCBufferSizeBits  10
-#ifdef CONFIG_HAVE_FPU
-#define seL4_TCBBits            11
-#else
 #define seL4_TCBBits            10
+
+#ifdef CONFIG_HAVE_FPU
+#ifdef CONFIG_RISCV_EXT_D
+#define seL4_FPUBits            8
+#elif CONFIG_RISCV_EXT_F
+#define seL4_FPUBits            7
+#endif
 #endif
 
 /* Sv39/Sv48 pages/ptes sizes */

--- a/src/arch/arm/32/c_traps.c
+++ b/src/arch/arm/32/c_traps.c
@@ -31,7 +31,7 @@ void VISIBLE NORETURN restore_user_context(void)
 #endif
 
 #ifdef CONFIG_HAVE_FPU
-    lazyFPURestore(NODE_STATE(ksCurThread));
+    eagerFPURestore(NODE_STATE(ksCurThread));
 #endif /* CONFIG_HAVE_FPU */
 
     if (config_set(CONFIG_ARM_HYPERVISOR_SUPPORT)) {

--- a/src/arch/arm/64/c_traps.c
+++ b/src/arch/arm/64/c_traps.c
@@ -23,7 +23,7 @@ void VISIBLE NORETURN restore_user_context(void)
     c_exit_hook();
 
 #ifdef CONFIG_HAVE_FPU
-    lazyFPURestore(NODE_STATE(ksCurThread));
+    eagerFPURestore(NODE_STATE(ksCurThread));
 #endif /* CONFIG_HAVE_FPU */
 
     asm volatile(

--- a/src/arch/arm/64/object/objecttype.c
+++ b/src/arch/arm/64/object/objecttype.c
@@ -369,6 +369,8 @@ word_t Arch_getObjectSize(word_t t)
         return seL4_PageDirBits;
     case seL4_ARM_PageUpperDirectoryObject:
         return seL4_PUDBits;
+    case seL4_ARM_FPUObject:
+        return seL4_FPUBits;
 #ifndef AARCH64_VSPACE_S2_START_L1
     case seL4_ARM_PageGlobalDirectoryObject:
         return seL4_PGDBits;

--- a/src/arch/arm/64/object/objecttype.c
+++ b/src/arch/arm/64/object/objecttype.c
@@ -91,6 +91,12 @@ deriveCap_ret_t Arch_deriveCap(cte_t *slot, cap_t cap)
         ret.status = EXCEPTION_NONE;
         return ret;
 
+#ifdef CONFIG_HAVE_FPU
+    case cap_fpu_cap:
+        ret.status = EXCEPTION_NONE;
+        ret.cap = cap_null_cap_new();
+        break;
+#endif
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
     case cap_vcpu_cap:
         ret.cap = cap;
@@ -228,6 +234,15 @@ finaliseCap_ret_t Arch_finaliseCap(cap_t cap, bool_t final)
         }
         break;
 #endif
+#ifdef CONFIG_HAVE_FPU
+    case cap_fpu_cap:
+        if (final) {
+            fpu_t *fpu = FPU_PTR(cap_fpu_cap_get_capFPUPtr(cap));
+            unbindMaybeFPU(fpu);
+        }
+        break;
+    }
+#endif
     }
 
     fc_ret.remainder = cap_null_cap_new();
@@ -322,6 +337,14 @@ bool_t CONST Arch_sameRegionAs(cap_t cap_a, cap_t cap_b)
         if (cap_get_capType(cap_b) == cap_cb_cap) {
             return cap_cb_cap_get_capCB(cap_a) ==
                    cap_cb_cap_get_capCB(cap_b);
+        }
+        break;
+#endif
+#ifdef CONFIG_HAVE_FPU 
+    case cap_fpu_cap:
+        if (cap_get_capType(cap_b) == cap_fpu_cap) {
+            return cap_fpu_cap_get_capFPUPtr(cap_a) ==
+                   cap_fpu_cap_get_capFPUPtr(cap_b);
         }
         break;
 #endif

--- a/src/arch/arm/64/object/objecttype.c
+++ b/src/arch/arm/64/object/objecttype.c
@@ -391,8 +391,10 @@ word_t Arch_getObjectSize(word_t t)
         return seL4_PageDirBits;
     case seL4_ARM_PageUpperDirectoryObject:
         return seL4_PUDBits;
+#ifdef CONFIG_HAVE_FPU
     case seL4_ARM_FPUObject:
         return seL4_FPUBits;
+#endif
 #ifndef AARCH64_VSPACE_S2_START_L1
     case seL4_ARM_PageGlobalDirectoryObject:
         return seL4_PGDBits;
@@ -481,9 +483,12 @@ cap_t Arch_createObject(object_t t, void *regionBase, word_t userSize, bool_t de
                    0,                     /* capPTIsMapped      */
                    0                      /* capPTMappedAddress */
                );
-    
+
+#ifdef CONFIG_HAVE_FPU    
     case seL4_ARM_FPUObject:
+        memzero(regionBase, BIT(seL4_FPUBits));
         return cap_fpu_cap_new((word_t) regionBase);
+#endif
 
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
     case seL4_ARM_VCPUObject:

--- a/src/arch/arm/64/object/objecttype.c
+++ b/src/arch/arm/64/object/objecttype.c
@@ -457,6 +457,9 @@ cap_t Arch_createObject(object_t t, void *regionBase, word_t userSize, bool_t de
                    0,                     /* capPTIsMapped      */
                    0                      /* capPTMappedAddress */
                );
+    
+    case seL4_ARM_FPUObject:
+        return cap_fpu_cap_new((word_t) regionBase);
 
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
     case seL4_ARM_VCPUObject:

--- a/src/arch/arm/64/object/objecttype.c
+++ b/src/arch/arm/64/object/objecttype.c
@@ -95,7 +95,7 @@ deriveCap_ret_t Arch_deriveCap(cte_t *slot, cap_t cap)
     case cap_fpu_cap:
         ret.status = EXCEPTION_NONE;
         ret.cap = cap_null_cap_new();
-        break;
+        return ret;
 #endif
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
     case cap_vcpu_cap:
@@ -237,11 +237,10 @@ finaliseCap_ret_t Arch_finaliseCap(cap_t cap, bool_t final)
 #ifdef CONFIG_HAVE_FPU
     case cap_fpu_cap:
         if (final) {
-            fpu_t *fpu = FPU_PTR(cap_fpu_cap_get_capFPUPtr(cap));
-            unbindMaybeFPU(fpu);
+            fpu_t *fpu = FPU_PTR(cap_fpu_cap_get_capFpuPtr(cap));
+            unbindMaybeFpu(fpu);
         }
         break;
-    }
 #endif
     }
 
@@ -343,8 +342,8 @@ bool_t CONST Arch_sameRegionAs(cap_t cap_a, cap_t cap_b)
 #ifdef CONFIG_HAVE_FPU 
     case cap_fpu_cap:
         if (cap_get_capType(cap_b) == cap_fpu_cap) {
-            return cap_fpu_cap_get_capFPUPtr(cap_a) ==
-                   cap_fpu_cap_get_capFPUPtr(cap_b);
+            return cap_fpu_cap_get_capFpuPtr(cap_a) ==
+                   cap_fpu_cap_get_capFpuPtr(cap_b);
         }
         break;
 #endif

--- a/src/arch/arm/smp/ipi.c
+++ b/src/arch/arm/smp/ipi.c
@@ -39,7 +39,7 @@ static void handleRemoteCall(IpiModeRemoteCall_t call, word_t arg0,
 
 #ifdef CONFIG_HAVE_FPU
         case IpiRemoteCall_switchFpuOwner:
-            switchLocalFpuOwner((user_fpu_state_t *)arg0);
+            switchLocalFpuOwner((tcb_fpu_t *)arg0);
             break;
 #endif /* CONFIG_HAVE_FPU */
 

--- a/src/arch/riscv/c_traps.c
+++ b/src/arch/riscv/c_traps.c
@@ -34,7 +34,7 @@ void VISIBLE NORETURN restore_user_context(void)
 
 
 #ifdef CONFIG_HAVE_FPU
-    lazyFPURestore(NODE_STATE(ksCurThread));
+    eagerFPURestore(NODE_STATE(ksCurThread));
     set_tcb_fs_state(NODE_STATE(ksCurThread), isFpuEnable());
 #endif
 

--- a/src/arch/riscv/smp/ipi.c
+++ b/src/arch/riscv/smp/ipi.c
@@ -41,7 +41,7 @@ static void handleRemoteCall(IpiRemoteCall_t call, word_t arg0,
 
 #ifdef CONFIG_HAVE_FPU
         case IpiRemoteCall_switchFpuOwner:
-            switchLocalFpuOwner((user_fpu_state_t *)arg0);
+            switchLocalFpuOwner((tcb_fpu_t *)arg0);
             break;
 #endif /* CONFIG_HAVE_FPU */
 

--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -556,7 +556,7 @@ BOOT_CODE tcb_t *create_initial_thread(cap_t root_cnode_cap, cap_t it_pd_cap, vp
 BOOT_CODE void init_core_state(tcb_t *scheduler_action)
 {
 #ifdef CONFIG_HAVE_FPU
-    NODE_STATE(ksActiveFPUState) = NULL;
+    NODE_STATE(ksActiveFPU) = NULL;
 #endif
 #ifdef CONFIG_DEBUG_BUILD
     /* add initial threads to the debug queue */

--- a/src/machine/fpu.c
+++ b/src/machine/fpu.c
@@ -15,7 +15,7 @@
 void switchLocalFpuOwner(tcb_fpu_t *new_owner)
 {
     enableFpu();
-    if (NODE_STATE(ksActiveFPU)) {
+    if (NODE_STATE(ksActiveFPU) && NODE_STATE(ksActiveFPU)->tcbBoundFpu) {
         saveFpuState(NODE_STATE(ksActiveFPU));
     }
     if (new_owner && new_owner->tcbBoundFpu) {

--- a/src/machine/fpu.c
+++ b/src/machine/fpu.c
@@ -12,22 +12,21 @@
 
 #ifdef CONFIG_HAVE_FPU
 /* Switch the owner of the FPU to the given thread on local core. */
-void switchLocalFpuOwner(user_fpu_state_t *new_owner)
+void switchLocalFpuOwner(tcb_fpu_t *new_owner)
 {
     enableFpu();
-    if (NODE_STATE(ksActiveFPUState)) {
-        saveFpuState(NODE_STATE(ksActiveFPUState));
+    if (NODE_STATE(ksActiveFPU)) {
+        saveFpuState(NODE_STATE(ksActiveFPU));
     }
-    if (new_owner) {
-        NODE_STATE(ksFPURestoresSinceSwitch) = 0;
+    if (new_owner && new_owner->tcbBoundFpu) {
         loadFpuState(new_owner);
     } else {
         disableFpu();
     }
-    NODE_STATE(ksActiveFPUState) = new_owner;
+    NODE_STATE(ksActiveFPU) = new_owner;
 }
 
-void switchFpuOwner(user_fpu_state_t *new_owner, word_t cpu)
+void switchFpuOwner(tcb_fpu_t *new_owner, word_t cpu)
 {
 #ifdef ENABLE_SMP_SUPPORT
     if (cpu != getCurrentCPUIndex()) {
@@ -46,14 +45,8 @@ void switchFpuOwner(user_fpu_state_t *new_owner, word_t cpu)
  * it over. */
 exception_t handleFPUFault(void)
 {
-    /* If we have already given the FPU to the user, we should not reach here.
-     * This should only be able to occur on CPUs without an FPU at all, which
-     * we presumably are happy to assume will not be running seL4. */
-    assert(!nativeThreadUsingFPU(NODE_STATE(ksCurThread)));
-
-    /* Otherwise, lazily switch over the FPU. */
-    switchLocalFpuOwner(&NODE_STATE(ksCurThread)->tcbArch.tcbContext.fpuState);
-
+    fail("Unimplemented!\n");
+    UNREACHABLE();
     return EXCEPTION_NONE;
 }
 

--- a/src/model/statedata.c
+++ b/src/model/statedata.c
@@ -44,8 +44,6 @@ UP_STATE_DEFINE(tcb_t *, ksSchedulerAction);
 #ifdef CONFIG_HAVE_FPU
 /* Currently active FPU state, or NULL if there is no active FPU state */
 UP_STATE_DEFINE(tcb_fpu_t *, ksActiveFPU);
-
-UP_STATE_DEFINE(word_t, ksFPURestoresSinceSwitch);
 #endif /* CONFIG_HAVE_FPU */
 #ifdef CONFIG_KERNEL_MCS
 /* the amount of time passed since the kernel time was last updated */

--- a/src/model/statedata.c
+++ b/src/model/statedata.c
@@ -43,7 +43,7 @@ UP_STATE_DEFINE(tcb_t *, ksSchedulerAction);
 
 #ifdef CONFIG_HAVE_FPU
 /* Currently active FPU state, or NULL if there is no active FPU state */
-UP_STATE_DEFINE(user_fpu_state_t *, ksActiveFPUState);
+UP_STATE_DEFINE(tcb_fpu_t *, ksActiveFPU);
 
 UP_STATE_DEFINE(word_t, ksFPURestoresSinceSwitch);
 #endif /* CONFIG_HAVE_FPU */

--- a/src/object/objecttype.c
+++ b/src/object/objecttype.c
@@ -197,6 +197,9 @@ finaliseCap_ret_t finaliseCap(cap_t cap, bool_t final, bool_t exposed)
                 }
             }
 #endif
+#ifdef CONFIG_HAVE_FPU
+            unbindFpu(tcb);
+#endif
             suspend(tcb);
 #ifdef CONFIG_DEBUG_BUILD
             tcbDebugRemove(tcb);

--- a/src/object/objecttype.c
+++ b/src/object/objecttype.c
@@ -197,6 +197,7 @@ finaliseCap_ret_t finaliseCap(cap_t cap, bool_t final, bool_t exposed)
                 }
             }
 #endif
+            Arch_prepareThreadDelete(tcb);
 #ifdef CONFIG_HAVE_FPU
             unbindFpu(tcb);
 #endif
@@ -204,7 +205,6 @@ finaliseCap_ret_t finaliseCap(cap_t cap, bool_t final, bool_t exposed)
 #ifdef CONFIG_DEBUG_BUILD
             tcbDebugRemove(tcb);
 #endif
-            Arch_prepareThreadDelete(tcb);
             fc_ret.remainder =
                 Zombie_new(
                     tcbArchCNodeEntries,

--- a/src/object/tcb.c
+++ b/src/object/tcb.c
@@ -1662,6 +1662,7 @@ exception_t decodeUnbindNotification(cap_t cap)
     return invokeTCB_NotificationControl(tcb, NULL);
 }
 
+#ifdef CONFIG_HAVE_FPU
 exception_t decodeBindFpu(cap_t cap)
 {
     fpu_t *fpuPtr;
@@ -1713,6 +1714,7 @@ exception_t decodeUnbindFpu(cap_t cap)
     unbindFpu(tcb);
     return EXCEPTION_NONE;
 }
+#endif
 
 /* The following functions sit in the preemption monad and implement the
  * preemptible, non-faulting bottom end of a TCB invocation. */


### PR DESCRIPTION
### Brief summary
Currently, seL4 treats the FPU as part of the thread context, saved in the TCB on preemption. As FPU state is large, the kernel uses lazy switching for the FPU, meaning on a context switch FPU access is disabled, resulting in an exception when a thread attempts to use it; the kernel will then save and restore the FPU state. This introduces a timing channel (e.g. [cve-2018-3665](https://access.redhat.com/security/cve/cve-2018-3665)). The eager FPU design is chosen to remedy this, however, eager loading the FPU on every context switch in seL4 is impractical as it introduces high overheads to the context switch. The FPU is thus represented as an object so that the eager load only occurs if a thread has an FPU capability bound to it.

### API
The current API for the FPU object takes inspiration from the notification binding process:
`seL4_TCB_BindFPU(seL4_TCB tcb, seL4_CPtr fpu)`
`seL4_TCB_UnbindFPU(seL4_TCB tcb)`

### odroidc2 benchmarks
_(MCS off, inter-vspace, length 0, same prio)_
Call performance:
| Benchmark              | Mean | Min | Max | Std Dev | Iterations |
|------------------------|------|-----|-----|---------|------------|
| Old IPC call           | 234  | 234 | 234 | 0       | 16         |
| Eager FPU - No FPU     | 236  | 236 | 236 | 0       | 16         |
| Eager FPU - Both FPU   | 381  | 381 | 381 | 0       | 16         |
| Eager FPU - Client FPU | 250  | 250 | 250 | 0       | 16         |
| Eager FPU - Server FPU | 252  | 249 | 255 | 3       | 16         |

ReplyRecv performance:
| Benchmark              | Mean | Min | Max | Std Dev | Iterations |
|------------------------|------|-----|-----|---------|------------|
| Old IPC                | 244  | 244 | 244 | 0       | 16         |
| Eager FPU - No FPU     | 258  | 258 | 258 | 0       | 16         |
| Eager FPU - Both FPU   | 405  | 403 | 412 | 4       | 16         |
| Eager FPU - Client FPU | 270  | 270 | 270 | 0       | 16         |
| Eager FPU - Server FPU | 278  | 271 | 280 | 4       | 16         |

### Implementation status
| Arch    | Status        |
|---------|---------------|
| aarch64 | semi-complete |
| aarch32 | semi-complete/requires debugging |
| riscv   | semi-complete |
| x86     | WIP           |

- Semi-complete implementations currently suffer a problem in testing that cannot be explained. seL4test has plenty of uts to work with, however, after some uts have been split in testing by the utspace split allocator, they can't be untype_retype'd again, and the kernel complains that there is no memory left to allocate in the untyped when there should be. This is being investigated. Apart from this issue the semi-complete implementations are functional on ALL tests (the problem doesn't arise when running each test individually).

- The exact fault which is triggered when a thread does not have an FPU and attempts to perform an FPU op is left unimplemented and is left as a question to the developer community on what they prefer.

- The x86 WIP implementation can be viewed here: https://github.com/andybui01/seL4/tree/andy/wip-fpu-x86port.

- The aarch32 implementation is buggy when running with both SMP and MCS enabled in _debugging_ mode. My guess here is there's some memory overflow into the debugging structures that's causing this or vice versa.

### Using it
The following changes are necessary to run a build with the FPU object: https://github.com/andybui01/seL4_libs/commit/c45675827401f3943c5dee6cbd6354a784d10835.

If you are compiling for ARM, the flag `-mgeneral-regs-only` must be added to the muslcsys cmakelist. Furthermore, an FPU object must be allocated for the rootserver early on, to prevent any FPU faults from occurring where the compiler uses a FPU register. Again, this is only for ARM.