### PR TITLE
libsel4: use sel4/config.h instead of autoconf.h

### DIFF
--- a/libsel4/arch_include/arm/sel4/arch/constants_cortex_a15.h
+++ b/libsel4/arch_include/arm/sel4/arch/constants_cortex_a15.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 
 #if !defined(CONFIG_ARM_CORTEX_A15)
 #error CONFIG_ARM_CORTEX_A15 is not defined

--- a/libsel4/arch_include/arm/sel4/arch/constants_cortex_a35.h
+++ b/libsel4/arch_include/arm/sel4/arch/constants_cortex_a35.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 
 #if !defined(CONFIG_ARM_CORTEX_A35)
 #error CONFIG_ARM_CORTEX_A35 is not defined

--- a/libsel4/arch_include/arm/sel4/arch/constants_cortex_a53.h
+++ b/libsel4/arch_include/arm/sel4/arch/constants_cortex_a53.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 
 #if !defined(CONFIG_ARM_CORTEX_A53)
 #error CONFIG_ARM_CORTEX_A53 is not defined

--- a/libsel4/arch_include/arm/sel4/arch/constants_cortex_a55.h
+++ b/libsel4/arch_include/arm/sel4/arch/constants_cortex_a55.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 
 #if !defined(CONFIG_ARM_CORTEX_A55)
 #error CONFIG_ARM_CORTEX_A55 is not defined

--- a/libsel4/arch_include/arm/sel4/arch/constants_cortex_a57.h
+++ b/libsel4/arch_include/arm/sel4/arch/constants_cortex_a57.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 
 #if !defined(CONFIG_ARM_CORTEX_A57)
 #error CONFIG_ARM_CORTEX_A57 is not defined

--- a/libsel4/arch_include/arm/sel4/arch/constants_cortex_a7.h
+++ b/libsel4/arch_include/arm/sel4/arch/constants_cortex_a7.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 
 #if !defined(CONFIG_ARM_CORTEX_A7)
 #error CONFIG_ARM_CORTEX_A7 is not defined

--- a/libsel4/arch_include/arm/sel4/arch/constants_cortex_a72.h
+++ b/libsel4/arch_include/arm/sel4/arch/constants_cortex_a72.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 
 #if !defined(CONFIG_ARM_CORTEX_A72)
 #error CONFIG_ARM_CORTEX_A72 is not defined

--- a/libsel4/arch_include/arm/sel4/arch/constants_cortex_a8.h
+++ b/libsel4/arch_include/arm/sel4/arch/constants_cortex_a8.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 
 #if !defined(CONFIG_ARM_CORTEX_A8)
 #error CONFIG_ARM_CORTEX_A8 is not defined

--- a/libsel4/arch_include/arm/sel4/arch/constants_cortex_a9.h
+++ b/libsel4/arch_include/arm/sel4/arch/constants_cortex_a9.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 
 #if !defined(CONFIG_ARM_CORTEX_A9)
 #error CONFIG_ARM_CORTEX_A9 is not defined

--- a/libsel4/arch_include/arm/sel4/arch/deprecated.h
+++ b/libsel4/arch_include/arm/sel4/arch/deprecated.h
@@ -6,4 +6,6 @@
 
 #pragma once
 
+#include <sel4/config.h>
+
 /* nothing here */

--- a/libsel4/arch_include/arm/sel4/arch/objecttype.h
+++ b/libsel4/arch_include/arm/sel4/arch/objecttype.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 
 typedef enum _object {
     seL4_ARM_SmallPageObject = seL4_ModeObjectTypeCount,

--- a/libsel4/arch_include/arm/sel4/arch/syscalls.h
+++ b/libsel4/arch_include/arm/sel4/arch/syscalls.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/functions.h>
 #include <sel4/sel4_arch/syscalls.h>
 #include <sel4/types.h>

--- a/libsel4/arch_include/riscv/sel4/arch/objecttype.h
+++ b/libsel4/arch_include/riscv/sel4/arch/objecttype.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 
 typedef enum _object {
     seL4_RISCV_4K_Page = seL4_ModeObjectTypeCount,

--- a/libsel4/arch_include/riscv/sel4/arch/syscalls.h
+++ b/libsel4/arch_include/riscv/sel4/arch/syscalls.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/functions.h>
 #include <sel4/sel4_arch/syscalls.h>
 #include <sel4/types.h>

--- a/libsel4/arch_include/riscv/sel4/arch/types.h
+++ b/libsel4/arch_include/riscv/sel4/arch/types.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/macros.h>
 #include <sel4/simple_types.h>
 #include <sel4/sel4_arch/types.h>

--- a/libsel4/arch_include/x86/sel4/arch/deprecated.h
+++ b/libsel4/arch_include/x86/sel4/arch/deprecated.h
@@ -6,4 +6,6 @@
 
 #pragma once
 
+#include <sel4/config.h>
+
 /* nothing here */

--- a/libsel4/arch_include/x86/sel4/arch/objecttype.h
+++ b/libsel4/arch_include/x86/sel4/arch/objecttype.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 
 typedef enum _object {
     seL4_X86_4K = seL4_ModeObjectTypeCount,

--- a/libsel4/arch_include/x86/sel4/arch/syscalls.h
+++ b/libsel4/arch_include/x86/sel4/arch/syscalls.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/functions.h>
 #include <sel4/sel4_arch/syscalls.h>
 #include <sel4/types.h>

--- a/libsel4/arch_include/x86/sel4/arch/types.h
+++ b/libsel4/arch_include/x86/sel4/arch/types.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/macros.h>
 #include <sel4/simple_types.h>
 #include <sel4/sel4_arch/types.h>

--- a/libsel4/include/sel4/benchmark_tracepoints_types.h
+++ b/libsel4/include/sel4/benchmark_tracepoints_types.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 
 #ifdef CONFIG_BENCHMARK_TRACEPOINTS
 typedef struct benchmark_tracepoint_log_entry {

--- a/libsel4/include/sel4/benchmark_track_types.h
+++ b/libsel4/include/sel4/benchmark_track_types.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <stdint.h>
 
 #if (defined CONFIG_BENCHMARK_TRACK_KERNEL_ENTRIES || defined CONFIG_DEBUG_BUILD)

--- a/libsel4/include/sel4/benchmark_utilisation_types.h
+++ b/libsel4/include/sel4/benchmark_utilisation_types.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 
 #ifdef CONFIG_BENCHMARK_TRACK_UTILISATION
 enum benchmark_track_util_ipc_index {

--- a/libsel4/include/sel4/bootinfo_types.h
+++ b/libsel4/include/sel4/bootinfo_types.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/macros.h>
 
 /* caps with fixed slot positions in the root CNode */

--- a/libsel4/include/sel4/constants.h
+++ b/libsel4/include/sel4/constants.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/macros.h>
 
 #ifndef __ASSEMBLER__

--- a/libsel4/include/sel4/faults.h
+++ b/libsel4/include/sel4/faults.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/types.h>
 #include <sel4/sel4_arch/faults.h>
 

--- a/libsel4/include/sel4/macros.h
+++ b/libsel4/include/sel4/macros.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 
 #ifndef CONST
 #define CONST   __attribute__((__const__))

--- a/libsel4/include/sel4/sel4.h
+++ b/libsel4/include/sel4/sel4.h
@@ -5,6 +5,9 @@
  */
 
 #pragma once
+
+#include <sel4/config.h>
+
 #include <sel4/types.h>
 #include <sel4/macros.h>
 

--- a/libsel4/include/sel4/syscalls.h
+++ b/libsel4/include/sel4/syscalls.h
@@ -5,7 +5,7 @@
  */
 
 #pragma once
-#include <autoconf.h>
+#include <sel4/config.h>
 
 #include <sel4/functions.h>
 

--- a/libsel4/include/sel4/syscalls_master.h
+++ b/libsel4/include/sel4/syscalls_master.h
@@ -5,7 +5,7 @@
  */
 
 #pragma once
-#include <autoconf.h>
+#include <sel4/config.h>
 
 /**
  * @defgroup GeneralSystemCalls System Calls (non-MCS)

--- a/libsel4/include/sel4/syscalls_mcs.h
+++ b/libsel4/include/sel4/syscalls_mcs.h
@@ -5,7 +5,7 @@
  */
 
 #pragma once
-#include <autoconf.h>
+#include <sel4/config.h>
 
 /**
  * @defgroup MCSSystemCalls MCS System Calls

--- a/libsel4/include/sel4/types.h
+++ b/libsel4/include/sel4/types.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/simple_types.h>
 #include <sel4/macros.h>
 #include <sel4/arch/types.h>

--- a/libsel4/include/sel4/virtual_client.h
+++ b/libsel4/include/sel4/virtual_client.h
@@ -5,7 +5,7 @@
  */
 
 #pragma once
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/types.h>
 #include <sel4/macros.h>
 #include <sel4/invocation.h>

--- a/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/constants.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/macros.h>
 
 #ifndef __ASSEMBLER__

--- a/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/deprecated.h
+++ b/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/deprecated.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/macros.h>
 
 typedef seL4_Word seL4_ExceptIPCRegister SEL4_DEPRECATED("use seL4_UnknownSyscall_Msg");

--- a/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/faults.h
+++ b/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/faults.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/faults.h>
 #include <sel4/sel4_arch/constants.h>
 

--- a/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/mapping.h
+++ b/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/mapping.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 
 #define SEL4_MAPPING_LOOKUP_LEVEL 2
 

--- a/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/syscalls.h
+++ b/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/syscalls.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/types.h>
 
 #ifdef CONFIG_KERNEL_MCS

--- a/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/types.bf
+++ b/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/types.bf
@@ -4,7 +4,7 @@
 -- SPDX-License-Identifier: BSD-2-Clause
 --
 
-#include <autoconf.h>
+#include <sel4/config.h>
 
 base 32
 

--- a/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/macros.h>
 
 #ifndef __ASSEMBLER__

--- a/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/faults.h
+++ b/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/faults.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/faults.h>
 #include <sel4/sel4_arch/constants.h>
 

--- a/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/syscalls.h
+++ b/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/syscalls.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/functions.h>
 #include <sel4/types.h>
 

--- a/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/types.bf
+++ b/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/types.bf
@@ -4,7 +4,7 @@
 -- SPDX-License-Identifier: BSD-2-Clause
 --
 
-#include <autoconf.h>
+#include <sel4/config.h>
 
 base 64
 

--- a/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/constants.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/macros.h>
 
 #define TLS_GDT_ENTRY 6

--- a/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/deprecated.h
+++ b/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/deprecated.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/macros.h>
 
 #define EXCEPT_IPC_LENGTH SEL4_DEPRECATE_MACRO(seL4_UnknownSyscall_Length)

--- a/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/faults.h
+++ b/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/faults.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/faults.h>
 #include <sel4/sel4_arch/constants.h>
 

--- a/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/mapping.h
+++ b/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/mapping.h
@@ -5,7 +5,7 @@
  */
 
 #pragma once
-#include <autoconf.h>
+#include <sel4/config.h>
 
 #define SEL4_MAPPING_LOOKUP_LEVEL 2
 #define SEL4_MAPPING_LOOKUP_NO_PT 22

--- a/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/objecttype.h
+++ b/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/objecttype.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 
 typedef enum _mode_object {
     seL4_ModeObjectTypeCount = seL4_NonArchObjectTypeCount,

--- a/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/syscalls.h
+++ b/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/syscalls.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/functions.h>
 #include <sel4/types.h>
 

--- a/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/types.bf
+++ b/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/types.bf
@@ -4,7 +4,7 @@
 -- SPDX-License-Identifier: BSD-2-Clause
 --
 
-#include <autoconf.h>
+#include <sel4/config.h>
 
 base 32
 

--- a/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/types.h
+++ b/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/types.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/simple_types.h>
 
 /* User context as used by seL4_TCB_ReadRegisters / seL4_TCB_WriteRegisters */

--- a/libsel4/sel4_arch_include/riscv32/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/riscv32/sel4/sel4_arch/constants.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/macros.h>
 
 #define seL4_WordBits           32

--- a/libsel4/sel4_arch_include/riscv32/sel4/sel4_arch/faults.h
+++ b/libsel4/sel4_arch_include/riscv32/sel4/sel4_arch/faults.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/faults.h>
 #include <sel4/sel4_arch/constants.h>
 

--- a/libsel4/sel4_arch_include/riscv32/sel4/sel4_arch/mapping.h
+++ b/libsel4/sel4_arch_include/riscv32/sel4/sel4_arch/mapping.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 
 #include <sel4/sel4_arch/mapping.h>
 

--- a/libsel4/sel4_arch_include/riscv32/sel4/sel4_arch/objecttype.h
+++ b/libsel4/sel4_arch_include/riscv32/sel4/sel4_arch/objecttype.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 
 typedef enum _mode_object {
     seL4_ModeObjectTypeCount = seL4_NonArchObjectTypeCount

--- a/libsel4/sel4_arch_include/riscv32/sel4/sel4_arch/types.bf
+++ b/libsel4/sel4_arch_include/riscv32/sel4/sel4_arch/types.bf
@@ -5,7 +5,7 @@
 -- SPDX-License-Identifier: BSD-2-Clause
 --
 
-#include <autoconf.h>
+#include <sel4/config.h>
 
 base 32
 

--- a/libsel4/sel4_arch_include/riscv32/sel4/sel4_arch/types.h
+++ b/libsel4/sel4_arch_include/riscv32/sel4/sel4_arch/types.h
@@ -7,5 +7,5 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/simple_types.h>

--- a/libsel4/sel4_arch_include/riscv64/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/riscv64/sel4/sel4_arch/constants.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/macros.h>
 
 #define seL4_WordBits           64

--- a/libsel4/sel4_arch_include/riscv64/sel4/sel4_arch/faults.h
+++ b/libsel4/sel4_arch_include/riscv64/sel4/sel4_arch/faults.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/faults.h>
 #include <sel4/sel4_arch/constants.h>
 

--- a/libsel4/sel4_arch_include/riscv64/sel4/sel4_arch/mapping.h
+++ b/libsel4/sel4_arch_include/riscv64/sel4/sel4_arch/mapping.h
@@ -6,7 +6,7 @@
  */
 
 #pragma once
-#include <autoconf.h>
+#include <sel4/config.h>
 
 #include <sel4/sel4_arch/mapping.h>
 

--- a/libsel4/sel4_arch_include/riscv64/sel4/sel4_arch/objecttype.h
+++ b/libsel4/sel4_arch_include/riscv64/sel4/sel4_arch/objecttype.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 
 typedef enum _mode_object {
     seL4_RISCV_Giga_Page = seL4_NonArchObjectTypeCount,

--- a/libsel4/sel4_arch_include/riscv64/sel4/sel4_arch/types.bf
+++ b/libsel4/sel4_arch_include/riscv64/sel4/sel4_arch/types.bf
@@ -5,7 +5,7 @@
 -- SPDX-License-Identifier: BSD-2-Clause
 --
 
-#include <autoconf.h>
+#include <sel4/config.h>
 
 base 64
 

--- a/libsel4/sel4_arch_include/riscv64/sel4/sel4_arch/types.h
+++ b/libsel4/sel4_arch_include/riscv64/sel4/sel4_arch/types.h
@@ -6,5 +6,5 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/simple_types.h>

--- a/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/constants.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/macros.h>
 
 #define TLS_GDT_ENTRY   7

--- a/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/deprecated.h
+++ b/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/deprecated.h
@@ -6,4 +6,6 @@
 
 #pragma once
 
+#include <sel4/config.h>
+
 /* nothing here */

--- a/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/faults.h
+++ b/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/faults.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/faults.h>
 #include <sel4/sel4_arch/constants.h>
 

--- a/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/objecttype.h
+++ b/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/objecttype.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 
 typedef enum _mode_object {
     seL4_X86_PDPTObject = seL4_NonArchObjectTypeCount,

--- a/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/syscalls.h
+++ b/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/syscalls.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #ifdef CONFIG_KERNEL_MCS
 #define LIBSEL4_MCS_REPLY reply
 #else

--- a/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/syscalls_syscall.h
+++ b/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/syscalls_syscall.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/functions.h>
 #include <sel4/types.h>
 

--- a/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/syscalls_sysenter.h
+++ b/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/syscalls_sysenter.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/functions.h>
 #include <sel4/types.h>
 

--- a/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/types.bf
+++ b/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/types.bf
@@ -4,7 +4,7 @@
 -- SPDX-License-Identifier: BSD-2-Clause
 --
 
-#include <autoconf.h>
+#include <sel4/config.h>
 
 base 64
 

--- a/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/types.h
+++ b/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/types.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/simple_types.h>
 
 typedef seL4_CPtr seL4_X64_PML4;

--- a/libsel4/sel4_plat_include/allwinnerA20/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/allwinnerA20/sel4/plat/api/constants.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/arch/constants_cortex_a7.h>
 
 /* First address in the virtual address space that is not accessible to user level */

--- a/libsel4/sel4_plat_include/am335x/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/am335x/sel4/plat/api/constants.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/arch/constants_cortex_a8.h>
 
 /* First address in the virtual address space that is not accessible to user level */

--- a/libsel4/sel4_plat_include/apq8064/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/apq8064/sel4/plat/api/constants.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/arch/constants_cortex_a15.h>
 
 /* First address in the virtual address space that is not accessible to user level */

--- a/libsel4/sel4_plat_include/ariane/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/ariane/sel4/plat/api/constants.h
@@ -6,4 +6,4 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>

--- a/libsel4/sel4_plat_include/bcm2711/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/bcm2711/sel4/plat/api/constants.h
@@ -6,7 +6,7 @@
  */
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 /* RasPi4 uses a BCM2711 SoC with 4x Cortex-A72. */
 #include <sel4/arch/constants_cortex_a72.h>
 

--- a/libsel4/sel4_plat_include/bcm2837/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/bcm2837/sel4/plat/api/constants.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 /* RasPi3 uses a BCM2837 SoC with 4x Cortex-A53. */
 #include <sel4/arch/constants_cortex_a53.h>
 

--- a/libsel4/sel4_plat_include/exynos4/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/exynos4/sel4/plat/api/constants.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/arch/constants_cortex_a9.h>
 
 /* First address in the virtual address space that is not accessible to user level */

--- a/libsel4/sel4_plat_include/exynos5/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/exynos5/sel4/plat/api/constants.h
@@ -5,7 +5,7 @@
  */
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 
 /* This is used for multiple SOCs:
  * - Exynos5250 (A15)

--- a/libsel4/sel4_plat_include/fvp/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/fvp/sel4/plat/api/constants.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 
 /* The FVP can emulate various cores */
 #if defined(CONFIG_ARM_CORTEX_A57)

--- a/libsel4/sel4_plat_include/hifive/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/hifive/sel4/plat/api/constants.h
@@ -6,4 +6,4 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>

--- a/libsel4/sel4_plat_include/hikey/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/hikey/sel4/plat/api/constants.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 /* HiKey uses a HiSilicon Kirin620 SoC with 2 clusters of 4 Cortex-A53 each. */
 #include <sel4/arch/constants_cortex_a53.h>
 

--- a/libsel4/sel4_plat_include/imx6/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/imx6/sel4/plat/api/constants.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/arch/constants_cortex_a9.h>
 
 /* First address in the virtual address space that is not accessible to user level */

--- a/libsel4/sel4_plat_include/imx7/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/imx7/sel4/plat/api/constants.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/arch/constants_cortex_a7.h>
 
 /* First address in the virtual address space that is not accessible to user level */

--- a/libsel4/sel4_plat_include/imx8mm-evk/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/imx8mm-evk/sel4/plat/api/constants.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/arch/constants_cortex_a53.h>
 
 #if CONFIG_WORD_SIZE == 32

--- a/libsel4/sel4_plat_include/imx8mq-evk/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/imx8mq-evk/sel4/plat/api/constants.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/arch/constants_cortex_a53.h>
 
 #if CONFIG_WORD_SIZE == 32

--- a/libsel4/sel4_plat_include/maaxboard/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/maaxboard/sel4/plat/api/constants.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/arch/constants_cortex_a53.h>
 
 #if CONFIG_WORD_SIZE == 32

--- a/libsel4/sel4_plat_include/odroidc2/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/odroidc2/sel4/plat/api/constants.h
@@ -6,5 +6,5 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/arch/constants_cortex_a53.h>

--- a/libsel4/sel4_plat_include/odroidc4/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/odroidc4/sel4/plat/api/constants.h
@@ -6,5 +6,5 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/arch/constants_cortex_a55.h>

--- a/libsel4/sel4_plat_include/omap3/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/omap3/sel4/plat/api/constants.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/arch/constants_cortex_a8.h>
 
 /* First address in the virtual address space that is not accessible to user level */

--- a/libsel4/sel4_plat_include/pc99/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/pc99/sel4/plat/api/constants.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 
 /* Defined for each architecture: the number of hardware breakpoints
  * available.

--- a/libsel4/sel4_plat_include/polarfire/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/polarfire/sel4/plat/api/constants.h
@@ -6,4 +6,4 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>

--- a/libsel4/sel4_plat_include/qemu-arm-virt/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/qemu-arm-virt/sel4/plat/api/constants.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 
 /* The QEMU virt platform can emulate various cores */
 #if defined(CONFIG_ARM_CORTEX_A15)

--- a/libsel4/sel4_plat_include/qemu-riscv-virt/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/qemu-riscv-virt/sel4/plat/api/constants.h
@@ -6,6 +6,6 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 
 /* nothing here */

--- a/libsel4/sel4_plat_include/quartz64/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/quartz64/sel4/plat/api/constants.h
@@ -6,5 +6,5 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/arch/constants_cortex_a55.h>

--- a/libsel4/sel4_plat_include/rocketchip/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/rocketchip/sel4/plat/api/constants.h
@@ -6,4 +6,4 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>

--- a/libsel4/sel4_plat_include/rockpro64/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/rockpro64/sel4/plat/api/constants.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 
 /* The ROCKPro64 uses a RK3399 SOC with a A53/A72 big.LITTLE design. Both cores
  * are designed to be identical

--- a/libsel4/sel4_plat_include/spike/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/spike/sel4/plat/api/constants.h
@@ -6,4 +6,4 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>

--- a/libsel4/sel4_plat_include/tk1/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/tk1/sel4/plat/api/constants.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/arch/constants_cortex_a15.h>
 
 /* First address in the virtual address space that is not accessible to user level */

--- a/libsel4/sel4_plat_include/tqma8xqp1gb/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/tqma8xqp1gb/sel4/plat/api/constants.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/arch/constants_cortex_a35.h>
 
 #ifdef CONFIG_ARCH_AARCH32

--- a/libsel4/sel4_plat_include/tx1/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/tx1/sel4/plat/api/constants.h
@@ -6,5 +6,5 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/arch/constants_cortex_a57.h>

--- a/libsel4/sel4_plat_include/tx2/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/tx2/sel4/plat/api/constants.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 
 /* Actually, it's a NVIDIA-Denver2/A57 HMP big.LITTLE system */
 #if defined(CONFIG_ARM_CORTEX_A57)

--- a/libsel4/sel4_plat_include/zynq7000/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/zynq7000/sel4/plat/api/constants.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 #include <sel4/arch/constants_cortex_a9.h>
 
 /* First address in the virtual address space that is not accessible to user level */

--- a/libsel4/sel4_plat_include/zynqmp/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/zynqmp/sel4/plat/api/constants.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 
 #if !defined(CONFIG_PLAT_ZYNQMP) && !defined(PLAT_ZYNQMP_ZCU102)
 #error "unknown platform"

--- a/libsel4/tools/syscall_stub_gen.py
+++ b/libsel4/tools/syscall_stub_gen.py
@@ -78,7 +78,7 @@ MAX_MESSAGE_LENGTH = 64
 
 # Headers to include
 INCLUDES = [
-    'autoconf.h', 'sel4/types.h'
+    'sel4/config.h', 'sel4/types.h'
 ]
 
 TYPES = {

--- a/tools/bitfield_gen.py
+++ b/tools/bitfield_gen.py
@@ -55,7 +55,7 @@ def var_name(name, base):
 
 # Headers to include depending on which environment we are generating code for.
 INCLUDES = {
-    'sel4': ['assert.h', 'config.h', 'stdint.h', 'util.h'],
+    'sel4': ['config.h', 'assert.h', 'stdint.h', 'util.h'],
     'libsel4': ['sel4/config.h', 'sel4/simple_types.h', 'sel4/debug_assert.h'],
 }
 

--- a/tools/bitfield_gen.py
+++ b/tools/bitfield_gen.py
@@ -56,7 +56,7 @@ def var_name(name, base):
 # Headers to include depending on which environment we are generating code for.
 INCLUDES = {
     'sel4': ['assert.h', 'config.h', 'stdint.h', 'util.h'],
-    'libsel4': ['autoconf.h', 'sel4/simple_types.h', 'sel4/debug_assert.h'],
+    'libsel4': ['sel4/config.h', 'sel4/simple_types.h', 'sel4/debug_assert.h'],
 }
 
 ASSERTS = {

--- a/tools/syscall_header_gen.py
+++ b/tools/syscall_header_gen.py
@@ -96,7 +96,7 @@ LIBSEL4_HEADER_TEMPLATE = """/*
 """ + COMMON_HEADER + """
 #pragma once
 
-#include <autoconf.h>
+#include <sel4/config.h>
 
 typedef enum {
 {%- for condition, list in enum %}


### PR DESCRIPTION
Clarify libsel4 include structure and use `sel4/config.h` everywhere. Just `sel4/config.h` will eventually include the generated `autoconf.h` then. This reduces the dependency on the usage of the `autoconf.h` file and provide a central config file for libsel4 that is under git control.