### PR TITLE
cmake: allow building with coreutils on macOS

### DIFF
--- a/config.cmake
+++ b/config.cmake
@@ -147,8 +147,10 @@ if(DEFINED KernelDTSList AND (NOT "${KernelDTSList}" STREQUAL ""))
         if(error)
             message(FATAL_ERROR "Failed to compile DTS to DTB: ${KernelDTBPath}")
         endif()
-        # CMAKE_HOST_APPLE is a built-in CMake variable
-        if(CMAKE_HOST_APPLE)
+        # The macOS and GNU coreutils `stat` utilities have different interfaces.
+        # Check if we're using the macOS version, otherwise assume GNU coreutils.
+        # CMAKE_HOST_APPLE is a built-in CMake variable.
+        if(CMAKE_HOST_APPLE AND "${STAT_TOOL}" STREQUAL "/usr/bin/stat")
             set(STAT_ARGS "-f%z")
         else()
             set(STAT_ARGS "-c '%s'")


### PR DESCRIPTION
The seL4 CMake build currently uses the `stat` utility to determine the
size of the flattened device tree file. The `stat` utilities in macOS
and GNU coreutils have different interfaces, the CMake build needs to
determine which one it's using.

This change supports building on macOS with GNU coreutils in the PATH,
by only using the macOS `stat` interface with `/usr/bin/stat` on a macOS
host, and otherwise assuming GNU coreutils.

In future, we might be able to avoid the `stat` utility altogether, by
using the built-in `file (SIZE ...)` command that became available in
CMake version 3.14. For now, we avoid updating our build dependencies.