### PR TITLE
Add support for the Avnet MaaXBoard

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -28,6 +28,7 @@ Upcoming release: BINARY COMPATIBLE
 
  * Added support for the ARM Cortex A55
  * Added support for the ODroid C4
+ * Added support for the Avnet MaaXBoard
  * Rename libsel4 config option ENABLE_SMP_SUPPORT to CONFIG_ENABLE_SMP_SUPPORT to be namespace compliant.
  * Rename libsel4 config option AARCH64_VSPACE_S2_START_L1 to CONFIG_AARCH64_VSPACE_S2_START_L1 to be namespace
    compliant.

--- a/libsel4/sel4_plat_include/maaxboard/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/maaxboard/sel4/plat/api/constants.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ * Copyright 2022, Capgemini Engineering
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <autoconf.h>
+#include <sel4/arch/constants_cortex_a53.h>
+
+#if CONFIG_WORD_SIZE == 32
+/* First address in the virtual address space that is not accessible to user level */
+#define seL4_UserTop 0xe0000000
+#else
+/* otherwise this is defined at the arch level */
+#endif

--- a/src/plat/maaxboard/config.cmake
+++ b/src/plat/maaxboard/config.cmake
@@ -7,10 +7,9 @@
 
 cmake_minimum_required(VERSION 3.7.2)
 
-declare_platform(imx8mq-evk KernelPlatformImx8mq-evk PLAT_IMX8MQ_EVK KernelArchARM)
-declare_platform(imx8mm-evk KernelPlatformImx8mm-evk PLAT_IMX8MM_EVK KernelArchARM)
+declare_platform(maaxboard KernelPlatformMaaxboard PLAT_MAAXBOARD KernelArchARM)
 
-if(KernelPlatformImx8mq-evk OR KernelPlatformImx8mm-evk)
+if(KernelPlatformMaaxboard)
     if("${KernelSel4Arch}" STREQUAL aarch32)
         declare_seL4_arch(aarch32)
     elseif("${KernelSel4Arch}" STREQUAL aarch64)
@@ -18,18 +17,18 @@ if(KernelPlatformImx8mq-evk OR KernelPlatformImx8mm-evk)
     else()
         fallback_declare_seL4_arch_default(aarch64)
     endif()
-    if(KernelPlatformImx8mq-evk)
-        config_set(KernelPlatImx8mq PLAT_IMX8MQ ON)
-    endif()
+
+    config_set(KernelPlatImx8mq PLAT_IMX8MQ ON)
+
     set(KernelArmCortexA53 ON)
     set(KernelArchArmV8a ON)
     set(KernelArmGicV3 ON)
     config_set(KernelARMPlatform ARM_PLAT ${KernelPlatform})
     set(KernelArmMach "imx" CACHE INTERNAL "")
     list(APPEND KernelDTSList "tools/dts/${KernelPlatform}.dts")
-    list(APPEND KernelDTSList "src/plat/imx8m-evk/overlay-${KernelPlatform}.dts")
+    list(APPEND KernelDTSList "src/plat/maaxboard/overlay-${KernelPlatform}.dts")
     if(KernelSel4ArchAarch32)
-        list(APPEND KernelDTSList "src/plat/imx8m-evk/overlay-imx8m-32bit.dts")
+        list(APPEND KernelDTSList "src/plat/maaxboard/overlay-${KernelPlatform}-32bit.dts")
     endif()
     declare_default_headers(
         TIMER_FREQUENCY 8000000
@@ -44,6 +43,6 @@ if(KernelPlatformImx8mq-evk OR KernelPlatformImx8mm-evk)
 endif()
 
 add_sources(
-    DEP "KernelPlatformImx8mq-evk OR KernelPlatformImx8mm-evk"
+    DEP "KernelPlatformMaaxboard"
     CFILES src/arch/arm/machine/gic_v3.c src/arch/arm/machine/l2c_nop.c
 )

--- a/src/plat/maaxboard/overlay-maaxboard-32bit.dts
+++ b/src/plat/maaxboard/overlay-maaxboard-32bit.dts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ * Copyright 2022, Capgemini Engineering
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+/ {
+
+    /* 32-bit kernel platforms require memory to be clamped to the top of
+     * the kernel window.
+     */
+	memory@40000000 {
+		device_type = "memory";
+		reg = < 0x00 0x40000000 0x00 0x1f000000 >;
+	};
+
+	/* These devices extend out of the 32-bit memory range.*/
+	/delete-node/gpu@38000000;
+	/delete-node/gpu3d@38000000;
+};

--- a/src/plat/maaxboard/overlay-maaxboard.dts
+++ b/src/plat/maaxboard/overlay-maaxboard.dts
@@ -23,9 +23,18 @@
 	 * Instead of adding and removing individual USB properties via the overlay, start from scratch:
 	 * 1. Delete existing USB nodes in maaxboard.dts
 	 * 2. Then build the USB nodes in overlay-maxboard.dts
+	 *
+	 * Also the extent of the memory map of the SYS_CTR timer needs increasing from the incorrect
+	 * value provided (0x20000) in the Avnet DTS.
 	 */
 
 	soc@0 {
+
+		bus@30400000 {
+			timer@306a0000 {
+				reg = <0x306a0000 0x30000>;
+			};
+		};
 
 		/delete-node/ usb@38100000;
 		/delete-node/ usb@38200000;

--- a/src/plat/maaxboard/overlay-maaxboard.dts
+++ b/src/plat/maaxboard/overlay-maaxboard.dts
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ * Copyright 2022, Capgemini Engineering
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+/ {
+	chosen {
+		seL4,elfloader-devices =
+			"serial0",
+			&{/psci};
+
+		seL4,kernel-devices =
+			"serial0",
+			&{/soc@0/interrupt-controller@38800000},
+			&{/timer};
+	};
+
+	/* Redefine USB to use dwc3 driver.
+	 * This structure is compatible with the dwc3-generic driver used by both U-Boot and Linux.
+	 * Modify usb@38x00000 entries from maaxboard.dts.
+	 * Instead of adding and removing individual USB properties via the overlay, start from scratch:
+	 * 1. Delete existing USB nodes in maaxboard.dts
+	 * 2. Then build the USB nodes in overlay-maxboard.dts
+	 */
+
+	soc@0 {
+
+		/delete-node/ usb@38100000;
+		/delete-node/ usb@38200000;
+
+		usb@38100000 {
+			compatible = "fsl,imx8mq-dwc3\0snps,dwc3";
+			#address-cells = <0x01>;
+			#size-cells = <0x01>;
+			reg = <0x38100000 0x10000>;
+			clocks = <0x02 0xce 0x02 0x98 0x02 0x01>;
+			clock-names = "bus_early\0ref\0suspend";
+			assigned-clocks = <0x02 0x6e 0x02 0x98>;
+			assigned-clock-parents = <0x02 0x56 0x02 0x48>;
+			assigned-clock-rates = <0x1dcd6500 0x5f5e100>;
+			interrupts = <0x00 0x28 0x04>;
+			status = "okay";
+			dr_mode = "host";
+			dwc3 {
+				compatible = "fsl,imx8mq-dwc3\0snps,dwc3";
+				reg = <0x38100000 0x10000>;
+				interrupts = <0x00 0x28 0x04>;
+				phys = <0x3f 0x3f>;
+				phy-names = "usb2-phy\0usb3-phy";
+				usb3-resume-missing-cas;
+				snps,power-down-scale = <0x02>;
+				status = "okay";
+				dr_mode = "host";
+				maximum-speed = "super-speed";
+			};
+		};
+
+		usb@38200000 {
+			compatible = "fsl,imx8mq-dwc3\0snps,dwc3";
+			#address-cells = <0x01>;
+			#size-cells = <0x01>;
+			reg = <0x38200000 0x10000>;
+			clocks = <0x02 0xcf 0x02 0x98 0x02 0x01>;
+			clock-names = "bus_early\0ref\0suspend";
+			assigned-clocks = <0x02 0x6e 0x02 0x98>;
+			assigned-clock-parents = <0x02 0x56 0x02 0x48>;
+			assigned-clock-rates = <0x1dcd6500 0x5f5e100>;
+			interrupts = <0x00 0x29 0x04>;
+			status = "okay";
+			dr_mode = "host";
+			dwc3 {
+				compatible = "fsl,imx8mq-dwc3\0snps,dwc3";
+				reg = <0x38200000 0x10000>;
+				interrupts = <0x00 0x29 0x04>;
+				phys = <0x40 0x40>;
+				phy-names = "usb2-phy\0usb3-phy";
+				usb3-resume-missing-cas;
+				snps,power-down-scale = <0x02>;
+				status = "okay";
+				dr_mode = "host";
+				maximum-speed = "super-speed";
+			};
+		};
+	};
+
+	/* These general purpose timers exist in the SoC documentation, but not in the DTS from Avnet */
+
+	gpt@302d0000 {
+		compatible = "fsl,imx8mq-gpt\0fsl,imx7d-gpt";
+		reg = < 0x00 0x302d0000 0x00 0x10000 >;
+		interrupts = < 0x00 0x37 0x04 >;
+		clocks = < 0x04 0xc5 0x04 0xc5 0x04 0xf9 >;
+		clock-names = "ipg\0per\0osc_per";
+		status = "disabled";
+	};
+
+	gpt@302e0000 {
+		compatible = "fsl,imx8mq-gpt\0fsl,imx7d-gpt";
+		reg = < 0x00 0x302e0000 0x00 0x10000 >;
+		interrupts = < 0x00 0x36 0x04 >;
+		clocks = < 0x04 0xc5 0x04 0xc5 0x04 0xf9 >;
+		clock-names = "ipg\0per\0osc_per";
+		status = "disabled";
+	};
+
+	gpt@302f0000 {
+		compatible = "fsl,imx8mq-gpt\0fsl,imx7d-gpt";
+		reg = < 0x00 0x302f0000 0x00 0x10000 >;
+		interrupts = < 0x00 0x35 0x04 >;
+		clocks = < 0x04 0xc5 0x04 0xc5 0x04 0xf9 >;
+		clock-names = "ipg\0per\0osc_per";
+		status = "disabled";
+	};
+
+	gpt@30700000 {
+		compatible = "fsl,imx8mq-gpt\0fsl,imx7d-gpt";
+		reg = < 0x00 0x30700000 0x00 0x10000 >;
+		interrupts = < 0x00 0x34 0x04 >;
+		clocks = < 0x04 0xc5 0x04 0xc5 0x04 0xf9 >;
+		clock-names = "ipg\0per\0osc_per";
+		status = "disabled";
+	};
+
+	gpt@306f0000 {
+		compatible = "fsl,imx8mq-gpt\0fsl,imx7d-gpt";
+		reg = < 0x00 0x306f0000 0x00 0x10000 >;
+		interrupts = < 0x00 0x33 0x04 >;
+		clocks = < 0x04 0xc5 0x04 0xc5 0x04 0xf9 >;
+		clock-names = "ipg\0per\0osc_per";
+		status = "disabled";
+	};
+
+	gpt@306e0000 {
+		compatible = "fsl,imx8mq-gpt\0fsl,imx7d-gpt";
+		reg = < 0x00 0x306e0000 0x00 0x10000 >;
+		interrupts = < 0x00 0x2e 0x04 >;
+		clocks = < 0x04 0xc5 0x04 0xc5 0x04 0xf9 >;
+		clock-names = "ipg\0per\0osc_per";
+		status = "disabled";
+	};
+
+};

--- a/tools/dts/maaxboard.dts
+++ b/tools/dts/maaxboard.dts
@@ -1,0 +1,1849 @@
+/*
+ * Copyright 2016 Freescale Semiconductor, Inc.
+ * Copyright 2017 NXP
+ * Copyright (C) 2017-2018 Pengutronix, Lucas Stach <kernel@pengutronix.de>
+ * Copyright 2019 EMBEST
+ * Copyright 2022 Capgemini Engineering
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+/*
+ * This file is derived from a DTS file supplied by Avnet.
+ *
+ * The licenses of all input files to this process are compatible
+ * with GPL-2.0.
+ *
+ * The following commands were used to derive this file:
+ * > git clone https://github.com/Avnet/linux-imx.git
+ * > cd linux-imx
+ * > cpp -nostdinc -I include -I arch -undef -x assembler-with-cpp \
+ * >    arch/arm64/boot/dts/freescale/maaxboard-base.dts temp.dts
+ * > dtc -o temp.dtb temp.dts
+ * > dtc -o maaxboard.dts temp.dtb
+ * > rm temp.dts temp.dtb
+ */
+
+/dts-v1/;
+
+/ {
+	interrupt-parent = <0x01>;
+	#address-cells = <0x02>;
+	#size-cells = <0x02>;
+	model = "Avnet Maaxboard";
+	compatible = "avnet/embest,maaxboard\0fsl,imx8mq";
+
+	aliases {
+		csi0 = "/soc@0/bus@30800000/mipi_csi1@30a70000";
+		csi1 = "/soc@0/bus@30800000/mipi_csi2@30b60000";
+		ethernet0 = "/soc@0/bus@30800000/ethernet@30be0000";
+		gpio0 = "/soc@0/bus@30000000/gpio@30200000";
+		gpio1 = "/soc@0/bus@30000000/gpio@30210000";
+		gpio2 = "/soc@0/bus@30000000/gpio@30220000";
+		gpio3 = "/soc@0/bus@30000000/gpio@30230000";
+		gpio4 = "/soc@0/bus@30000000/gpio@30240000";
+		i2c0 = "/soc@0/bus@30800000/i2c@30a20000";
+		i2c1 = "/soc@0/bus@30800000/i2c@30a30000";
+		i2c2 = "/soc@0/bus@30800000/i2c@30a40000";
+		i2c3 = "/soc@0/bus@30800000/i2c@30a50000";
+		mmc0 = "/soc@0/bus@30800000/mmc@30b40000";
+		mmc1 = "/soc@0/bus@30800000/mmc@30b50000";
+		serial0 = "/soc@0/bus@30800000/serial@30860000";
+		serial1 = "/soc@0/bus@30800000/serial@30890000";
+		serial2 = "/soc@0/bus@30800000/serial@30880000";
+		serial3 = "/soc@0/bus@30800000/serial@30a60000";
+		spi0 = "/soc@0/bus@30800000/spi@30820000";
+		spi1 = "/soc@0/bus@30800000/spi@30830000";
+		spi2 = "/soc@0/bus@30800000/spi@30840000";
+	};
+
+	clock-ckil {
+		compatible = "fixed-clock";
+		#clock-cells = <0x00>;
+		clock-frequency = <0x8000>;
+		clock-output-names = "ckil";
+		phandle = <0x14>;
+	};
+
+	clock-osc-25m {
+		compatible = "fixed-clock";
+		#clock-cells = <0x00>;
+		clock-frequency = <0x17d7840>;
+		clock-output-names = "osc_25m";
+		phandle = <0x15>;
+	};
+
+	clock-osc-27m {
+		compatible = "fixed-clock";
+		#clock-cells = <0x00>;
+		clock-frequency = <0x19bfcc0>;
+		clock-output-names = "osc_27m";
+		phandle = <0x16>;
+	};
+
+	clock-ext1 {
+		compatible = "fixed-clock";
+		#clock-cells = <0x00>;
+		clock-frequency = <0x7ed6b40>;
+		clock-output-names = "clk_ext1";
+		phandle = <0x17>;
+	};
+
+	clock-ext2 {
+		compatible = "fixed-clock";
+		#clock-cells = <0x00>;
+		clock-frequency = <0x7ed6b40>;
+		clock-output-names = "clk_ext2";
+		phandle = <0x18>;
+	};
+
+	clock-ext3 {
+		compatible = "fixed-clock";
+		#clock-cells = <0x00>;
+		clock-frequency = <0x7ed6b40>;
+		clock-output-names = "clk_ext3";
+		phandle = <0x19>;
+	};
+
+	clock-ext4 {
+		compatible = "fixed-clock";
+		#clock-cells = <0x00>;
+		clock-frequency = <0x7ed6b40>;
+		clock-output-names = "clk_ext4";
+		phandle = <0x1a>;
+	};
+
+	cpus {
+		#address-cells = <0x01>;
+		#size-cells = <0x00>;
+
+		cpu@0 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a53";
+			reg = <0x00>;
+			clock-latency = <0xee6c>;
+			clocks = <0x02 0x102>;
+			enable-method = "psci";
+			next-level-cache = <0x03>;
+			operating-points-v2 = <0x04>;
+			#cooling-cells = <0x02>;
+			nvmem-cells = <0x05>;
+			nvmem-cell-names = "speed_grade";
+			cpu-idle-states = <0x06>;
+			phandle = <0x08>;
+		};
+
+		cpu@1 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a53";
+			reg = <0x01>;
+			clock-latency = <0xee6c>;
+			clocks = <0x02 0x102>;
+			enable-method = "psci";
+			next-level-cache = <0x03>;
+			operating-points-v2 = <0x04>;
+			#cooling-cells = <0x02>;
+			cpu-idle-states = <0x06>;
+			phandle = <0x09>;
+		};
+
+		cpu@2 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a53";
+			reg = <0x02>;
+			clock-latency = <0xee6c>;
+			clocks = <0x02 0x102>;
+			enable-method = "psci";
+			next-level-cache = <0x03>;
+			operating-points-v2 = <0x04>;
+			#cooling-cells = <0x02>;
+			cpu-idle-states = <0x06>;
+			phandle = <0x0a>;
+		};
+
+		cpu@3 {
+			device_type = "cpu";
+			compatible = "arm,cortex-a53";
+			reg = <0x03>;
+			clock-latency = <0xee6c>;
+			clocks = <0x02 0x102>;
+			enable-method = "psci";
+			next-level-cache = <0x03>;
+			operating-points-v2 = <0x04>;
+			#cooling-cells = <0x02>;
+			cpu-idle-states = <0x06>;
+			phandle = <0x0b>;
+		};
+
+		l2-cache0 {
+			compatible = "cache";
+			phandle = <0x03>;
+		};
+
+		idle-states {
+			entry-method = "psci";
+
+			cpu-sleep {
+				compatible = "arm,idle-state";
+				arm,psci-suspend-param = <0x10033>;
+				local-timer-stop;
+				entry-latency-us = <0x3e8>;
+				exit-latency-us = <0x2bc>;
+				min-residency-us = <0xa8c>;
+				wakeup-latency-us = <0x5dc>;
+				phandle = <0x06>;
+			};
+		};
+	};
+
+	opp-table {
+		compatible = "operating-points-v2";
+		opp-shared;
+		phandle = <0x04>;
+
+		opp-800000000 {
+			opp-hz = <0x00 0x2faf0800>;
+			opp-microvolt = <0xdbba0>;
+			opp-supported-hw = <0x0f 0x04>;
+			clock-latency-ns = <0x249f0>;
+			opp-suspend;
+		};
+
+		opp-1000000000 {
+			opp-hz = <0x00 0x3b9aca00>;
+			opp-microvolt = <0xdbba0>;
+			opp-supported-hw = <0x0e 0x03>;
+			clock-latency-ns = <0x249f0>;
+			opp-suspend;
+		};
+
+		opp-1300000000 {
+			opp-hz = <0x00 0x4d7c6d00>;
+			opp-microvolt = <0xf4240>;
+			opp-supported-hw = <0x0c 0x04>;
+			clock-latency-ns = <0x249f0>;
+			opp-suspend;
+		};
+
+		opp-1500000000 {
+			opp-hz = <0x00 0x59682f00>;
+			opp-microvolt = <0xf4240>;
+			opp-supported-hw = <0x08 0x03>;
+			clock-latency-ns = <0x249f0>;
+			opp-suspend;
+		};
+	};
+
+	pmu {
+		compatible = "arm,cortex-a53-pmu";
+		interrupts = <0x01 0x07 0x04>;
+		interrupt-parent = <0x07>;
+		interrupt-affinity = <0x08 0x09 0x0a 0x0b>;
+	};
+
+	psci {
+		compatible = "arm,psci-1.0";
+		method = "smc";
+	};
+
+	thermal-zones {
+
+		cpu-thermal {
+			polling-delay-passive = <0xfa>;
+			polling-delay = <0x7d0>;
+			thermal-sensors = <0x0c 0x00>;
+
+			trips {
+
+				cpu-alert {
+					temperature = <0x13880>;
+					hysteresis = <0x7d0>;
+					type = "passive";
+				};
+
+				cpu-crit {
+					temperature = <0x17318>;
+					hysteresis = <0x7d0>;
+					type = "critical";
+				};
+
+				trip0 {
+					temperature = <0x13880>;
+					hysteresis = <0x7d0>;
+					type = "passive";
+					phandle = <0x0d>;
+				};
+
+				trip1 {
+					temperature = <0x14c08>;
+					hysteresis = <0x7d0>;
+					type = "passive";
+					phandle = <0x0f>;
+				};
+			};
+
+			cooling-maps {
+
+				map0 {
+					trip = <0x0d>;
+					cooling-device = <0x0e 0x00 0x01 0x08 0xffffffff 0xffffffff 0x09 0xffffffff 0xffffffff 0x0a 0xffffffff 0xffffffff 0x0b 0xffffffff 0xffffffff>;
+				};
+
+				map1 {
+					trip = <0x0f>;
+					cooling-device = <0x0e 0x00 0x02>;
+				};
+			};
+		};
+	};
+
+	timer {
+		compatible = "arm,armv8-timer";
+		interrupts = <0x01 0x0d 0x08 0x01 0x0e 0x08 0x01 0x0b 0x08 0x01 0x0a 0x08>;
+		interrupt-parent = <0x07>;
+		arm,no-tick-in-suspend;
+	};
+
+	busfreq {
+		compatible = "fsl,imx_busfreq";
+		clocks = <0x02 0xea 0x02 0x76 0x02 0x77 0x02 0x77 0x02 0xfc 0x02 0xfb 0x02 0x46 0x02 0x4d 0x02 0x48 0x02 0x4e 0x02 0x71 0x02 0x67 0x02 0x74 0x02 0x02 0x02 0x55 0x02 0x49>;
+		clock-names = "dram_pll\0dram_alt_src\0dram_apb_src\0dram_apb_pre_div\0dram_core\0dram_alt_root\0sys1_pll_40m\0sys1_pll_400m\0sys1_pll_100m\0sys1_pll_800m\0noc_div\0main_axi_src\0ahb_div\0osc_25m\0sys2_pll_333m\0sys1_pll_133m";
+		interrupts = <0x00 0x66 0x04 0x00 0x6d 0x04 0x00 0x6e 0x04 0x00 0x6f 0x04>;
+		interrupt-name = "irq_busfreq_0\0irq_busfreq_1\0irq_busfreq_2\0irq_busfreq_3";
+	};
+
+	soc@0 {
+		compatible = "simple-bus";
+		#address-cells = <0x01>;
+		#size-cells = <0x01>;
+		ranges = <0x00 0x00 0x00 0x3e000000>;
+		dma-ranges = <0x40000000 0x00 0x40000000 0xc0000000>;
+
+		caam-sm@100000 {
+			compatible = "fsl,imx6q-caam-sm";
+			reg = <0x100000 0x8000>;
+		};
+
+		bus@30000000 {
+			compatible = "fsl,imx8mq-aips-bus\0simple-bus";
+			#address-cells = <0x01>;
+			#size-cells = <0x01>;
+			ranges = <0x30000000 0x30000000 0x400000>;
+
+			sai@30010000 {
+				compatible = "fsl,imx8mq-sai\0fsl,imx6sx-sai";
+				reg = <0x30010000 0x10000>;
+				interrupts = <0x00 0x5f 0x04>;
+				clocks = <0x02 0xee 0x02 0x00 0x02 0xc4 0x02 0x00 0x02 0x00>;
+				clock-names = "bus\0mclk0\0mclk1\0mclk2\0mclk3";
+				dmas = <0x10 0x08 0x01 0x00 0x10 0x09 0x01 0x00>;
+				dma-names = "rx\0tx";
+				fsl,dataline = <0x00 0xff 0xff>;
+				status = "disabled";
+			};
+
+			sai@30030000 {
+				compatible = "fsl,imx8mq-sai\0fsl,imx6sx-sai";
+				reg = <0x30030000 0x10000>;
+				interrupts = <0x00 0x5a 0x04>;
+				clocks = <0x02 0xf3 0x02 0x00 0x02 0xc9 0x02 0x00 0x02 0x00>;
+				clock-names = "bus\0mclk0\0mclk1\0mclk2\0mclk3";
+				dmas = <0x10 0x04 0x18 0x00 0x10 0x05 0x18 0x00>;
+				dma-names = "rx\0tx";
+				fsl,shared-interrupt;
+				status = "disabled";
+			};
+
+			sai@30040000 {
+				compatible = "fsl,imx8mq-sai\0fsl,imx6sx-sai";
+				reg = <0x30040000 0x10000>;
+				interrupts = <0x00 0x5a 0x04>;
+				clocks = <0x02 0xf2 0x02 0x00 0x02 0xc8 0x02 0x00 0x02 0x00>;
+				clock-names = "bus\0mclk0\0mclk1\0mclk2\0mclk3";
+				dmas = <0x10 0x02 0x18 0x00 0x10 0x03 0x18 0x00>;
+				dma-names = "rx\0tx";
+				fsl,shared-interrupt;
+				fsl,dataline = <0x00 0x0f 0x0f>;
+				status = "disabled";
+			};
+
+			sai@30050000 {
+				compatible = "fsl,imx8mq-sai\0fsl,imx6sx-sai";
+				reg = <0x30050000 0x10000>;
+				interrupts = <0x00 0x64 0x04>;
+				clocks = <0x02 0xf1 0x02 0x00 0x02 0xc7 0x02 0x00 0x02 0x00 0x02 0x1b 0x02 0x20>;
+				clock-names = "bus\0mclk0\0mclk1\0mclk2\0mclk3\0pll8k\0pll11k";
+				dmas = <0x10 0x00 0x18 0x00 0x10 0x01 0x18 0x00>;
+				dma-names = "rx\0tx";
+				fsl,dataline = <0x00 0x00 0x0f>;
+				status = "disabled";
+				assigned-clocks = <0x02 0x84>;
+				assigned-clock-parents = <0x02 0x1b>;
+				assigned-clock-rates = <0x1770000>;
+				phandle = <0x48>;
+			};
+
+			gpio@30200000 {
+				compatible = "fsl,imx8mq-gpio\0fsl,imx35-gpio";
+				reg = <0x30200000 0x10000>;
+				interrupts = <0x00 0x40 0x04 0x00 0x41 0x04>;
+				clocks = <0x02 0x103>;
+				gpio-controller;
+				#gpio-cells = <0x02>;
+				interrupt-controller;
+				#interrupt-cells = <0x02>;
+				gpio-ranges = <0x11 0x00 0x0a 0x1e>;
+				phandle = <0x28>;
+			};
+
+			gpio@30210000 {
+				compatible = "fsl,imx8mq-gpio\0fsl,imx35-gpio";
+				reg = <0x30210000 0x10000>;
+				interrupts = <0x00 0x42 0x04 0x00 0x43 0x04>;
+				clocks = <0x02 0x104>;
+				gpio-controller;
+				#gpio-cells = <0x02>;
+				interrupt-controller;
+				#interrupt-cells = <0x02>;
+				gpio-ranges = <0x11 0x00 0x28 0x15>;
+				phandle = <0x38>;
+			};
+
+			gpio@30220000 {
+				compatible = "fsl,imx8mq-gpio\0fsl,imx35-gpio";
+				reg = <0x30220000 0x10000>;
+				interrupts = <0x00 0x44 0x04 0x00 0x45 0x04>;
+				clocks = <0x02 0x105>;
+				gpio-controller;
+				#gpio-cells = <0x02>;
+				interrupt-controller;
+				#interrupt-cells = <0x02>;
+				gpio-ranges = <0x11 0x00 0x3d 0x1a>;
+				phandle = <0x2b>;
+			};
+
+			gpio@30230000 {
+				compatible = "fsl,imx8mq-gpio\0fsl,imx35-gpio";
+				reg = <0x30230000 0x10000>;
+				interrupts = <0x00 0x46 0x04 0x00 0x47 0x04>;
+				clocks = <0x02 0x106>;
+				gpio-controller;
+				#gpio-cells = <0x02>;
+				interrupt-controller;
+				#interrupt-cells = <0x02>;
+				gpio-ranges = <0x11 0x00 0x57 0x20>;
+			};
+
+			gpio@30240000 {
+				compatible = "fsl,imx8mq-gpio\0fsl,imx35-gpio";
+				reg = <0x30240000 0x10000>;
+				interrupts = <0x00 0x48 0x04 0x00 0x49 0x04>;
+				clocks = <0x02 0x107>;
+				gpio-controller;
+				#gpio-cells = <0x02>;
+				interrupt-controller;
+				#interrupt-cells = <0x02>;
+				gpio-ranges = <0x11 0x00 0x77 0x1e>;
+				phandle = <0x4d>;
+			};
+
+			tmu@30260000 {
+				compatible = "fsl,imx8mq-tmu";
+				reg = <0x30260000 0x10000>;
+				interrupt = <0x00 0x31 0x04>;
+				clocks = <0x02 0xf6>;
+				little-endian;
+				fsl,tmu-range = <0xb0000 0xa0026 0x80048 0x70061>;
+				fsl,tmu-calibration = <0x00 0x23 0x01 0x29 0x02 0x2f 0x03 0x35 0x04 0x3d 0x05 0x43 0x06 0x4b 0x07 0x51 0x08 0x57 0x09 0x5f 0x0a 0x67 0x0b 0x6f 0x10000 0x1b 0x10001 0x23 0x10002 0x2b 0x10003 0x33 0x10004 0x3b 0x10005 0x43 0x10006 0x4b 0x10007 0x55 0x10008 0x5d 0x10009 0x67 0x1000a 0x70 0x20000 0x17 0x20001 0x23 0x20002 0x2d 0x20003 0x37 0x20004 0x41 0x20005 0x4b 0x20006 0x57 0x20007 0x63 0x20008 0x6f 0x30000 0x15 0x30001 0x21 0x30002 0x2d 0x30003 0x39 0x30004 0x45 0x30005 0x53 0x30006 0x5f 0x30007 0x71>;
+				#thermal-sensor-cells = <0x00>;
+				phandle = <0x0c>;
+
+				throttle-cfgs {
+
+					devfreq {
+						throttle,max_state = <0x02>;
+						#cooling-cells = <0x02>;
+						phandle = <0x0e>;
+					};
+				};
+			};
+
+			watchdog@30280000 {
+				compatible = "fsl,imx8mq-wdt\0fsl,imx21-wdt";
+				reg = <0x30280000 0x10000>;
+				interrupts = <0x00 0x4e 0x04>;
+				clocks = <0x02 0xd4>;
+				status = "okay";
+				pinctrl-names = "default";
+				pinctrl-0 = <0x12>;
+				fsl,ext-reset-output;
+			};
+
+			watchdog@30290000 {
+				compatible = "fsl,imx8mq-wdt\0fsl,imx21-wdt";
+				reg = <0x30290000 0x10000>;
+				interrupts = <0x00 0x4f 0x04>;
+				clocks = <0x02 0xd5>;
+				status = "disabled";
+			};
+
+			watchdog@302a0000 {
+				compatible = "fsl,imx8mq-wdt\0fsl,imx21-wdt";
+				reg = <0x302a0000 0x10000>;
+				interrupts = <0x00 0x0a 0x04>;
+				clocks = <0x02 0xd6>;
+				status = "disabled";
+			};
+
+			sdma@302c0000 {
+				compatible = "fsl,imx8mq-sdma\0fsl,imx7d-sdma";
+				reg = <0x302c0000 0x10000>;
+				interrupts = <0x00 0x67 0x04>;
+				clocks = <0x02 0xe4 0x02 0xe4>;
+				clock-names = "ipg\0ahb";
+				#dma-cells = <0x03>;
+				fsl,sdma-ram-script-name = "imx/sdma/sdma-imx7d.bin";
+				phandle = <0x10>;
+			};
+
+			lcdif@30320000 {
+				compatible = "fsl,imx8mq-lcdif\0fsl,imx28-lcdif";
+				reg = <0x30320000 0x10000>;
+				clocks = <0x02 0x80>;
+				clock-names = "pix";
+				assigned-clocks = <0x02 0x80 0x02 0x24 0x02 0x21 0x02 0x23>;
+				assigned-clock-parents = <0x02 0x25 0x02 0x23 0x02 0x03>;
+				interrupts = <0x00 0x05 0x04>;
+				status = "disabled";
+				max-memory-bandwidth = "\r0 ";
+				assigned-clock-rate = <0x7829b80 0x00 0x00 0x43977780>;
+			};
+
+			iomuxc@30330000 {
+				compatible = "fsl,imx8mq-iomuxc";
+				reg = <0x30330000 0x10000>;
+				phandle = <0x11>;
+
+				imx8mq-evk {
+
+					gpio_ledsgrp {
+						fsl,pins = <0x3c 0x2a4 0x00 0x00 0x00 0x19 0x48 0x2b0 0x00 0x00 0x00 0x19>;
+						phandle = <0x46>;
+					};
+
+					gpio_keysgrp {
+						fsl,pins = <0x110 0x378 0x00 0x05 0x00 0x56 0x10c 0x374 0x00 0x05 0x00 0x56>;
+						phandle = <0x47>;
+					};
+
+					uart1grp {
+						fsl,pins = <0x234 0x49c 0x4f4 0x00 0x00 0x49 0x238 0x4a0 0x00 0x00 0x00 0x49>;
+						phandle = <0x20>;
+					};
+
+					uart4grp {
+						fsl,pins = <0x24c 0x4b4 0x50c 0x00 0x02 0x49 0x250 0x4b8 0x00 0x00 0x00 0x49 0x210 0x478 0x508 0x01 0x01 0x49 0x20c 0x474 0x00 0x01 0x00 0x49 0x208 0x470 0x00 0x05 0x00 0x19>;
+						phandle = <0x2c>;
+					};
+
+					wlangrp {
+						fsl,pins = <0xec 0x354 0x00 0x05 0x00 0x19 0xd0 0x338 0x00 0x05 0x00 0x19 0x28 0x290 0x00 0x05 0x00 0x05>;
+						phandle = <0x4c>;
+					};
+
+					reg3V3wfgrp {
+						fsl,pins = <0xf0 0x358 0x00 0x05 0x00 0x19>;
+						phandle = <0x4a>;
+					};
+
+					usdhc1grp {
+						fsl,pins = <0xa0 0x308 0x00 0x00 0x00 0x83 0xa4 0x30c 0x00 0x00 0x00 0xc3 0xa8 0x310 0x00 0x00 0x00 0xc3 0xac 0x314 0x00 0x00 0x00 0xc3 0xb0 0x318 0x00 0x00 0x00 0xc3 0xb4 0x31c 0x00 0x00 0x00 0xc3 0x40 0x2a8 0x00 0x00 0x00 0x19>;
+						phandle = <0x32>;
+					};
+
+					usdhc1grp100mhz {
+						fsl,pins = <0xa0 0x308 0x00 0x00 0x00 0x85 0xa4 0x30c 0x00 0x00 0x00 0xc5 0xa8 0x310 0x00 0x00 0x00 0xc5 0xac 0x314 0x00 0x00 0x00 0xc5 0xb0 0x318 0x00 0x00 0x00 0xc5 0xb4 0x31c 0x00 0x00 0x00 0xc5 0x40 0x2a8 0x00 0x00 0x00 0x19>;
+						phandle = <0x33>;
+					};
+
+					usdhc1grp200mhz {
+						fsl,pins = <0xa0 0x308 0x00 0x00 0x00 0x87 0xa4 0x30c 0x00 0x00 0x00 0xc7 0xa8 0x310 0x00 0x00 0x00 0xc7 0xac 0x314 0x00 0x00 0x00 0xc7 0xb0 0x318 0x00 0x00 0x00 0xc7 0xb4 0x31c 0x00 0x00 0x00 0xc7 0x40 0x2a8 0x00 0x00 0x00 0x19>;
+						phandle = <0x34>;
+					};
+
+					usdhc2grp {
+						fsl,pins = <0xd4 0x33c 0x00 0x00 0x00 0x83 0xd8 0x340 0x00 0x00 0x00 0xc3 0xdc 0x344 0x00 0x00 0x00 0xc3 0xe0 0x348 0x00 0x00 0x00 0xc3 0xe4 0x34c 0x00 0x00 0x00 0xc3 0xe8 0x350 0x00 0x00 0x00 0xc3>;
+						phandle = <0x35>;
+					};
+
+					i2c1grp {
+						fsl,pins = <0x214 0x47c 0x00 0x00 0x00 0x4000007f 0x218 0x480 0x00 0x00 0x00 0x4000007f>;
+						phandle = <0x25>;
+					};
+
+					i2c4grp {
+						fsl,pins = <0x22c 0x494 0x00 0x00 0x00 0x4000007f 0x230 0x498 0x00 0x00 0x00 0x4000007f>;
+						phandle = <0x29>;
+					};
+
+					csi1grp {
+						fsl,pins = <0x13c 0x3a4 0x00 0x05 0x00 0x19 0x12c 0x394 0x00 0x05 0x00 0x19>;
+					};
+
+					pmicirq {
+						fsl,pins = <0x44 0x2ac 0x00 0x00 0x00 0x19>;
+						phandle = <0x26>;
+					};
+
+					wdoggrp {
+						fsl,pins = <0x30 0x298 0x00 0x01 0x00 0xc6>;
+						phandle = <0x12>;
+					};
+
+					fec1grp {
+						fsl,pins = <0x68 0x2d0 0x00 0x00 0x00 0x03 0x6c 0x2d4 0x4c0 0x00 0x01 0x23 0x70 0x2d8 0x00 0x00 0x00 0x1f 0x74 0x2dc 0x00 0x00 0x00 0x1f 0x78 0x2e0 0x00 0x00 0x00 0x1f 0x7c 0x2e4 0x00 0x00 0x00 0x1f 0x9c 0x304 0x00 0x00 0x00 0x91 0x98 0x300 0x00 0x00 0x00 0x91 0x94 0x2fc 0x00 0x00 0x00 0x91 0x90 0x2f8 0x00 0x00 0x00 0x91 0x84 0x2ec 0x00 0x00 0x00 0x1f 0x8c 0x2f4 0x00 0x00 0x00 0x91 0x88 0x2f0 0x00 0x00 0x00 0x91 0x80 0x2e8 0x00 0x00 0x00 0x1f 0x4c 0x2b4 0x00 0x00 0x00 0x19>;
+						phandle = <0x3b>;
+					};
+
+					mipi_dsi_en {
+						fsl,pins = <0x124 0x38c 0x00 0x05 0x00 0x16>;
+						phandle = <0x4b>;
+					};
+
+					ft5426_pinsgrp {
+						fsl,pins = <0x128 0x390 0x00 0x05 0x00 0x19 0x38 0x2a0 0x00 0x00 0x00 0x19>;
+						phandle = <0x2a>;
+					};
+
+					pwm1_grp {
+						fsl,pins = <0x2c 0x294 0x00 0x01 0x00 0x06>;
+						phandle = <0x1e>;
+					};
+				};
+			};
+
+			syscon@30340000 {
+				compatible = "fsl,imx8mq-iomuxc-gpr\0fsl,imx6q-iomuxc-gpr\0syscon\0simple-mfd";
+				reg = <0x30340000 0x10000>;
+				phandle = <0x2f>;
+
+				mux-controller {
+					compatible = "mmio-mux";
+					#mux-control-cells = <0x01>;
+					mux-reg-masks = <0x34 0x04>;
+					phandle = <0x23>;
+				};
+			};
+
+			ocotp-ctrl@30350000 {
+				compatible = "fsl,imx8mq-ocotp\0syscon";
+				reg = <0x30350000 0x10000>;
+				clocks = <0x02 0xfa>;
+				#address-cells = <0x01>;
+				#size-cells = <0x01>;
+
+				speed-grade@10 {
+					reg = <0x10 0x04>;
+					phandle = <0x05>;
+				};
+
+				mac-address@640 {
+					reg = <0x90 0x06>;
+					phandle = <0x3a>;
+				};
+			};
+
+			syscon@30360000 {
+				compatible = "fsl,imx8mq-anatop\0syscon";
+				reg = <0x30360000 0x10000>;
+				interrupts = <0x00 0x31 0x04>;
+			};
+
+			caam_secvio {
+				compatible = "fsl,imx6q-caam-secvio";
+				interrupts = <0x00 0x14 0x04>;
+				jtag-tamper = "disabled";
+				watchdog-tamper = "enabled";
+				internal-boot-tamper = "enabled";
+				external-pin-tamper = "disabled";
+			};
+
+			caam-snvs@30370000 {
+				compatible = "fsl,imx6q-caam-snvs";
+				reg = <0x30370000 0x10000>;
+			};
+
+			snvs@30370000 {
+				compatible = "fsl,sec-v4.0-mon\0syscon\0simple-mfd";
+				reg = <0x30370000 0x10000>;
+				phandle = <0x13>;
+
+				snvs-rtc-lp {
+					compatible = "fsl,sec-v4.0-mon-rtc-lp";
+					regmap = <0x13>;
+					offset = <0x34>;
+					interrupts = <0x00 0x13 0x04 0x00 0x14 0x04>;
+					clocks = <0x02 0x108>;
+					clock-names = "snvs-rtc";
+				};
+
+				snvs-powerkey {
+					compatible = "fsl,sec-v4.0-pwrkey";
+					regmap = <0x13>;
+					interrupts = <0x00 0x04 0x04>;
+					clocks = <0x02 0x108>;
+					clock-names = "snvs";
+					linux,keycode = <0x74>;
+					wakeup-source;
+					status = "okay";
+				};
+			};
+
+			clock-controller@30380000 {
+				compatible = "fsl,imx8mq-ccm";
+				reg = <0x30380000 0x10000>;
+				interrupts = <0x00 0x55 0x04 0x00 0x56 0x04>;
+				#clock-cells = <0x01>;
+				clocks = <0x14 0x15 0x16 0x17 0x18 0x19 0x1a>;
+				clock-names = "ckil\0osc_25m\0osc_27m\0clk_ext1\0clk_ext2\0clk_ext3\0clk_ext4";
+				assigned-clocks = <0x02 0x69 0x02 0x75 0x02 0x19 0x02 0x1e>;
+				assigned-clock-parents = <0x02 0x4c 0x02 0x56>;
+				assigned-clock-rates = <0x00 0x00 0x2ee00000 0x2b110000>;
+				phandle = <0x02>;
+			};
+
+			reset-controller@30390000 {
+				compatible = "fsl,imx8mq-src\0syscon";
+				reg = <0x30390000 0x10000>;
+				#reset-cells = <0x01>;
+				phandle = <0x22>;
+			};
+
+			gpc@303a0000 {
+				compatible = "fsl,imx8mq-gpc";
+				reg = <0x303a0000 0x10000>;
+				interrupt-parent = <0x07>;
+				interrupt-controller;
+				broken-wake-request-signals;
+				#interrupt-cells = <0x03>;
+				phandle = <0x01>;
+
+				pgc {
+					#address-cells = <0x01>;
+					#size-cells = <0x00>;
+
+					power-domain@0 {
+						#power-domain-cells = <0x00>;
+						reg = <0x00>;
+						phandle = <0x21>;
+					};
+
+					power-domain@1 {
+						#power-domain-cells = <0x00>;
+						reg = <0x01>;
+						power-domains = <0x1b>;
+						phandle = <0x43>;
+					};
+
+					power-domain@2 {
+						#power-domain-cells = <0x00>;
+						reg = <0x02>;
+					};
+
+					power-domain@3 {
+						#power-domain-cells = <0x00>;
+						reg = <0x03>;
+						phandle = <0x41>;
+					};
+
+					power-domain@4 {
+						#power-domain-cells = <0x00>;
+						reg = <0x04>;
+					};
+
+					power-domain@5 {
+						#power-domain-cells = <0x00>;
+						reg = <0x05>;
+						clocks = <0x02 0xd7 0x02 0x66 0x02 0x6f 0x02 0x70>;
+						power-supply = <0x1c>;
+						phandle = <0x3e>;
+					};
+
+					power-domain@6 {
+						#power-domain-cells = <0x00>;
+						reg = <0x06>;
+						power-supply = <0x1d>;
+						phandle = <0x44>;
+					};
+
+					power-domain@7 {
+						#power-domain-cells = <0x00>;
+						reg = <0x07>;
+					};
+
+					power-domain@8 {
+						#power-domain-cells = <0x00>;
+						reg = <0x08>;
+						phandle = <0x2e>;
+					};
+
+					power-domain@9 {
+						#power-domain-cells = <0x00>;
+						reg = <0x09>;
+						phandle = <0x39>;
+					};
+
+					power-domain@a {
+						#power-domain-cells = <0x00>;
+						reg = <0x0a>;
+						phandle = <0x1b>;
+					};
+				};
+			};
+		};
+
+		bus@30400000 {
+			compatible = "fsl,imx8mq-aips-bus\0simple-bus";
+			#address-cells = <0x01>;
+			#size-cells = <0x01>;
+			ranges = <0x30400000 0x30400000 0x400000>;
+
+			pwm@30660000 {
+				compatible = "fsl,imx8mq-pwm\0fsl,imx27-pwm";
+				reg = <0x30660000 0x10000>;
+				interrupts = <0x00 0x51 0x04>;
+				clocks = <0x02 0xbf 0x02 0xbf>;
+				clock-names = "ipg\0per";
+				#pwm-cells = <0x02>;
+				status = "disabled";
+				pinctrl-names = "default";
+				pinctrl-0 = <0x1e>;
+				phandle = <0x49>;
+			};
+
+			pwm@30670000 {
+				compatible = "fsl,imx8mq-pwm\0fsl,imx27-pwm";
+				reg = <0x30670000 0x10000>;
+				interrupts = <0x00 0x52 0x04>;
+				clocks = <0x02 0xc0 0x02 0xc0>;
+				clock-names = "ipg\0per";
+				#pwm-cells = <0x02>;
+				status = "disabled";
+			};
+
+			pwm@30680000 {
+				compatible = "fsl,imx8mq-pwm\0fsl,imx27-pwm";
+				reg = <0x30680000 0x10000>;
+				interrupts = <0x00 0x53 0x04>;
+				clocks = <0x02 0xc1 0x02 0xc1>;
+				clock-names = "ipg\0per";
+				#pwm-cells = <0x02>;
+				status = "disabled";
+			};
+
+			pwm@30690000 {
+				compatible = "fsl,imx8mq-pwm\0fsl,imx27-pwm";
+				reg = <0x30690000 0x10000>;
+				interrupts = <0x00 0x54 0x04>;
+				clocks = <0x02 0xc2 0x02 0xc2>;
+				clock-names = "ipg\0per";
+				#pwm-cells = <0x02>;
+				status = "disabled";
+			};
+
+			timer@306a0000 {
+				compatible = "nxp,sysctr-timer";
+				reg = <0x306a0000 0x20000>;
+				interrupts = <0x00 0x2f 0x04>;
+				clocks = <0x15>;
+				clock-names = "per";
+			};
+		};
+
+		bus@30800000 {
+			compatible = "fsl,imx8mq-aips-bus\0simple-bus";
+			#address-cells = <0x01>;
+			#size-cells = <0x01>;
+			ranges = <0x30800000 0x30800000 0x400000 0x8000000 0x8000000 0x10000000>;
+
+			spdif@30810000 {
+				compatible = "fsl,imx8mm-spdif\0fsl,imx35-spdif";
+				reg = <0x30810000 0x10000>;
+				interrupts = <0x00 0x06 0x04>;
+				clocks = <0x02 0xec 0x02 0x02 0x02 0x87 0x02 0x00 0x02 0x00 0x02 0x00 0x02 0xec 0x02 0x00 0x02 0x00 0x02 0x00>;
+				clock-names = "core\0rxtx0\0rxtx1\0rxtx2\0rxtx3\0rxtx4\0rxtx5\0rxtx6\0rxtx7\0spba";
+				dmas = <0x1f 0x08 0x12 0x00 0x1f 0x09 0x12 0x00>;
+				dma-names = "rx\0tx";
+				status = "disabled";
+			};
+
+			spi@30820000 {
+				#address-cells = <0x01>;
+				#size-cells = <0x00>;
+				compatible = "fsl,imx8mq-ecspi\0fsl,imx51-ecspi";
+				reg = <0x30820000 0x10000>;
+				interrupts = <0x00 0x1f 0x04>;
+				clocks = <0x02 0xb3 0x02 0xb3>;
+				clock-names = "ipg\0per";
+				status = "disabled";
+			};
+
+			spi@30830000 {
+				#address-cells = <0x01>;
+				#size-cells = <0x00>;
+				compatible = "fsl,imx8mq-ecspi\0fsl,imx51-ecspi";
+				reg = <0x30830000 0x10000>;
+				interrupts = <0x00 0x20 0x04>;
+				clocks = <0x02 0xb4 0x02 0xb4>;
+				clock-names = "ipg\0per";
+				status = "disabled";
+			};
+
+			spi@30840000 {
+				#address-cells = <0x01>;
+				#size-cells = <0x00>;
+				compatible = "fsl,imx8mq-ecspi\0fsl,imx51-ecspi";
+				reg = <0x30840000 0x10000>;
+				interrupts = <0x00 0x21 0x04>;
+				clocks = <0x02 0xb5 0x02 0xb5>;
+				clock-names = "ipg\0per";
+				status = "disabled";
+			};
+
+			serial@30860000 {
+				compatible = "fsl,imx8mq-uart\0fsl,imx6q-uart";
+				reg = <0x30860000 0x10000>;
+				interrupts = <0x00 0x1a 0x04>;
+				clocks = <0x02 0xca 0x02 0xca>;
+				clock-names = "ipg\0per";
+				status = "okay";
+				pinctrl-names = "default";
+				pinctrl-0 = <0x20>;
+				assigned-clocks = <0x02 0x94>;
+				assigned-clock-parents = <0x02 0x02>;
+			};
+
+			serial@30880000 {
+				compatible = "fsl,imx8mq-uart\0fsl,imx6q-uart";
+				reg = <0x30880000 0x10000>;
+				interrupts = <0x00 0x1c 0x04>;
+				clocks = <0x02 0xcc 0x02 0xcc>;
+				clock-names = "ipg\0per";
+				status = "disabled";
+			};
+
+			serial@30890000 {
+				compatible = "fsl,imx8mq-uart\0fsl,imx6q-uart";
+				reg = <0x30890000 0x10000>;
+				interrupts = <0x00 0x1b 0x04>;
+				clocks = <0x02 0xcb 0x02 0xcb>;
+				clock-names = "ipg\0per";
+				status = "disabled";
+			};
+
+			spdif@308a0000 {
+				compatible = "fsl,imx8mm-spdif\0fsl,imx35-spdif";
+				reg = <0x308a0000 0x10000>;
+				interrupts = <0x00 0x0d 0x04>;
+				clocks = <0x02 0xec 0x02 0x02 0x02 0x88 0x02 0x00 0x02 0x00 0x02 0x00 0x02 0xec 0x02 0x00 0x02 0x00 0x02 0x00>;
+				clock-names = "core\0rxtx0\0rxtx1\0rxtx2\0rxtx3\0rxtx4\0rxtx5\0rxtx6\0rxtx7\0spba";
+				dmas = <0x1f 0x10 0x12 0x00 0x1f 0x11 0x12 0x00>;
+				dma-names = "rx\0tx";
+				status = "disabled";
+			};
+
+			sai@308b0000 {
+				#sound-dai-cells = <0x00>;
+				compatible = "fsl,imx8mq-sai";
+				reg = <0x308b0000 0x10000>;
+				interrupts = <0x00 0x60 0x04>;
+				clocks = <0x02 0xef 0x02 0x00 0x02 0xc5 0x02 0x00 0x02 0x00>;
+				clock-names = "bus\0mclk0\0mclk1\0mclk2\0mclk3";
+				dmas = <0x1f 0x0a 0x18 0x00 0x1f 0x0b 0x18 0x00>;
+				dma-names = "rx\0tx";
+				status = "disabled";
+			};
+
+			sai@308c0000 {
+				compatible = "fsl,imx8mq-sai\0fsl,imx6sx-sai";
+				reg = <0x308c0000 0x10000>;
+				interrupts = <0x00 0x32 0x04>;
+				clocks = <0x02 0xf0 0x02 0x00 0x02 0xc6 0x02 0x00 0x02 0x00>;
+				clock-names = "bus\0mclk0\0mclk1\0mclk2\0mclk3";
+				dmas = <0x1f 0x0c 0x18 0x00 0x1f 0x0d 0x18 0x00>;
+				dma-names = "rx\0tx";
+				status = "disabled";
+			};
+
+			crypto@30900000 {
+				compatible = "fsl,sec-v4.0";
+				#address-cells = <0x01>;
+				#size-cells = <0x01>;
+				reg = <0x30900000 0x40000>;
+				ranges = <0x00 0x30900000 0x40000>;
+				interrupts = <0x00 0x5b 0x04>;
+				clocks = <0x02 0x74 0x02 0xec>;
+				clock-names = "aclk\0ipg";
+
+				jr@1000 {
+					compatible = "fsl,sec-v4.0-job-ring";
+					reg = <0x1000 0x1000>;
+					interrupts = <0x00 0x69 0x04>;
+				};
+
+				jr@2000 {
+					compatible = "fsl,sec-v4.0-job-ring";
+					reg = <0x2000 0x1000>;
+					interrupts = <0x00 0x6a 0x04>;
+				};
+
+				jr@3000 {
+					compatible = "fsl,sec-v4.0-job-ring";
+					reg = <0x3000 0x1000>;
+					interrupts = <0x00 0x72 0x04>;
+				};
+			};
+
+			dphy@30a00300 {
+				compatible = "fsl,imx8mq-mipi-dphy";
+				reg = <0x30a00300 0x100>;
+				clocks = <0x02 0xa4>;
+				clock-names = "phy_ref";
+				assigned-clocks = <0x02 0xa4>;
+				assigned-clock-parents = <0x02 0x25>;
+				assigned-clock-rates = <0x16e3600>;
+				#phy-cells = <0x00>;
+				power-domains = <0x21>;
+				status = "okay";
+				phandle = <0x24>;
+			};
+
+			mipi_dsi@30a00000 {
+				#address-cells = <0x01>;
+				#size-cells = <0x00>;
+				compatible = "fsl,imx8mq-nwl-dsi";
+				reg = <0x30a00000 0x300>;
+				clocks = <0x02 0xa3 0x02 0xf4 0x02 0xf5 0x02 0xa4 0x02 0x23 0x02 0x80>;
+				clock-names = "core\0rx_esc\0tx_esc\0phy_ref\0video_pll\0lcdif";
+				assigned-clocks = <0x02 0xa4 0x02 0xa3 0x02 0xf4 0x02 0xf5>;
+				assigned-clock-parents = <0x02 0x25 0x02 0x4c 0x02 0x47>;
+				assigned-clock-rates = <0x19bfcc0 0xfdad680 0x4c4b400 0x1312d00>;
+				interrupts = <0x00 0x22 0x04>;
+				power-domains = <0x21>;
+				resets = <0x22 0x15 0x22 0x17 0x22 0x18 0x22 0x19>;
+				reset-names = "byte\0dpi\0esc\0pclk";
+				mux-controls = <0x23 0x00>;
+				phys = <0x24>;
+				phy-names = "dphy";
+				status = "disabled";
+			};
+
+			i2c@30a20000 {
+				compatible = "fsl,imx8mq-i2c\0fsl,imx21-i2c";
+				reg = <0x30a20000 0x10000>;
+				interrupts = <0x00 0x23 0x04>;
+				clocks = <0x02 0xb8>;
+				#address-cells = <0x01>;
+				#size-cells = <0x00>;
+				status = "okay";
+				clock-frequency = <0x186a0>;
+				pinctrl-names = "default";
+				pinctrl-0 = <0x25>;
+
+				pmic@4b {
+					compatible = "rohm,bd71837";
+					reg = <0x4b>;
+					pinctrl-names = "default";
+					pinctrl-0 = <0x26>;
+					clocks = <0x27>;
+					clock-names = "osc";
+					clock-output-names = "pmic_clk";
+					interrupt-parent = <0x28>;
+					interrupts = <0x07 0x01>;
+					interrupt-names = "irq";
+					rohm,reset-snvs-powered;
+
+					regulators {
+
+						BUCK1 {
+							regulator-name = "buck1";
+							regulator-min-microvolt = <0xaae60>;
+							regulator-max-microvolt = <0x13d620>;
+							regulator-boot-on;
+							regulator-always-on;
+							regulator-ramp-delay = <0x4e2>;
+							rohm,dvs-run-voltage = <0xdbba0>;
+							rohm,dvs-idle-voltage = <0xcf850>;
+							rohm,dvs-suspend-voltage = <0xc3500>;
+						};
+
+						BUCK2 {
+							regulator-name = "buck2";
+							regulator-min-microvolt = <0xaae60>;
+							regulator-max-microvolt = <0x13d620>;
+							regulator-boot-on;
+							regulator-always-on;
+							regulator-ramp-delay = <0x4e2>;
+							rohm,dvs-run-voltage = <0xf4240>;
+							rohm,dvs-idle-voltage = <0xdbba0>;
+						};
+
+						BUCK3 {
+							regulator-name = "buck3";
+							regulator-min-microvolt = <0xaae60>;
+							regulator-max-microvolt = <0x13d620>;
+							regulator-boot-on;
+							rohm,dvs-run-voltage = <0xf4240>;
+							regulator-enable-ramp-delay = <0xb4>;
+							phandle = <0x1c>;
+						};
+
+						BUCK4 {
+							regulator-name = "buck4";
+							regulator-min-microvolt = <0xaae60>;
+							regulator-max-microvolt = <0x13d620>;
+							rohm,dvs-run-voltage = <0xf4240>;
+							regulator-boot-on;
+							regulator-enable-ramp-delay = <0xb4>;
+							phandle = <0x1d>;
+						};
+
+						BUCK5 {
+							regulator-name = "buck5";
+							regulator-min-microvolt = <0xdbba0>;
+							regulator-max-microvolt = <0xf4240>;
+							regulator-boot-on;
+							regulator-always-on;
+						};
+
+						BUCK6 {
+							regulator-name = "buck6";
+							regulator-min-microvolt = <0x2dc6c0>;
+							regulator-max-microvolt = <0x325aa0>;
+							regulator-boot-on;
+							regulator-always-on;
+						};
+
+						BUCK7 {
+							regulator-name = "buck7";
+							regulator-min-microvolt = <0x1b7740>;
+							regulator-max-microvolt = <0x1cfde0>;
+							regulator-boot-on;
+							regulator-always-on;
+						};
+
+						BUCK8 {
+							regulator-name = "buck8";
+							regulator-min-microvolt = <0x124f80>;
+							regulator-max-microvolt = <0x13d620>;
+							regulator-boot-on;
+							regulator-always-on;
+						};
+
+						LDO1 {
+							regulator-name = "ldo1";
+							regulator-min-microvolt = <0x2dc6c0>;
+							regulator-max-microvolt = <0x325aa0>;
+							regulator-boot-on;
+							regulator-always-on;
+						};
+
+						LDO2 {
+							regulator-name = "ldo2";
+							regulator-min-microvolt = <0xdbba0>;
+							regulator-max-microvolt = <0xdbba0>;
+							regulator-boot-on;
+							regulator-always-on;
+						};
+
+						LDO3 {
+							regulator-name = "ldo3";
+							regulator-min-microvolt = <0x1b7740>;
+							regulator-max-microvolt = <0x1cfde0>;
+							regulator-boot-on;
+							regulator-always-on;
+						};
+
+						LDO4 {
+							regulator-name = "ldo4";
+							regulator-min-microvolt = <0xdbba0>;
+							regulator-max-microvolt = <0xf4240>;
+							regulator-boot-on;
+							regulator-always-on;
+						};
+
+						LDO5 {
+							regulator-name = "ldo5";
+							regulator-min-microvolt = <0x2625a0>;
+							regulator-max-microvolt = <0x27ac40>;
+							regulator-boot-on;
+							regulator-always-on;
+						};
+
+						LDO6 {
+							regulator-name = "ldo6";
+							regulator-min-microvolt = <0xdbba0>;
+							regulator-max-microvolt = <0xf4240>;
+							regulator-boot-on;
+							regulator-always-on;
+						};
+
+						LDO7 {
+							regulator-name = "ldo7";
+							regulator-min-microvolt = <0x2dc6c0>;
+							regulator-max-microvolt = <0x325aa0>;
+							regulator-boot-on;
+							regulator-always-on;
+						};
+					};
+				};
+			};
+
+			i2c@30a30000 {
+				compatible = "fsl,imx8mq-i2c\0fsl,imx21-i2c";
+				reg = <0x30a30000 0x10000>;
+				interrupts = <0x00 0x24 0x04>;
+				clocks = <0x02 0xb9>;
+				#address-cells = <0x01>;
+				#size-cells = <0x00>;
+				status = "disabled";
+			};
+
+			i2c@30a40000 {
+				compatible = "fsl,imx8mq-i2c\0fsl,imx21-i2c";
+				reg = <0x30a40000 0x10000>;
+				interrupts = <0x00 0x25 0x04>;
+				clocks = <0x02 0xba>;
+				#address-cells = <0x01>;
+				#size-cells = <0x00>;
+				status = "disabled";
+			};
+
+			i2c@30a50000 {
+				compatible = "fsl,imx8mq-i2c\0fsl,imx21-i2c";
+				reg = <0x30a50000 0x10000>;
+				interrupts = <0x00 0x26 0x04>;
+				clocks = <0x02 0xbb>;
+				#address-cells = <0x01>;
+				#size-cells = <0x00>;
+				status = "disabled";
+				clock-frequency = <0x61a80>;
+				pinctrl-names = "default";
+				pinctrl-0 = <0x29>;
+
+				ft5426_ts@38 {
+					compatible = "focaltech,fts";
+					reg = <0x38>;
+					pinctrl-0 = <0x2a>;
+					interrupt-parent = <0x2b>;
+					interrupts = <0x0d 0x02>;
+					focaltech,reset-gpio = <0x28 0x04 0x01>;
+					focaltech,irq-gpio = <0x2b 0x0d 0x02>;
+					focaltech,max-touch-number = <0x0a>;
+					focaltech,panel-type = <0x54260002>;
+					focaltech,display-coords = <0x00 0x00 0x2d0 0x500>;
+					focaltech,have-key;
+					focaltech,key-number = <0x03>;
+					focaltech,keys = <0x8b 0x66 0x9e>;
+					focaltech,key-y-coord = <0x7d0>;
+					focaltech,key-x-coords = <0xc8 0x258 0x320>;
+					status = "disabled";
+				};
+			};
+
+			serial@30a60000 {
+				compatible = "fsl,imx8mq-uart\0fsl,imx6q-uart";
+				reg = <0x30a60000 0x10000>;
+				interrupts = <0x00 0x1d 0x04>;
+				clocks = <0x02 0xcd 0x02 0xcd>;
+				clock-names = "ipg\0per";
+				status = "okay";
+				pinctrl-names = "default";
+				pinctrl-0 = <0x2c>;
+				assigned-clocks = <0x02 0x97>;
+				assigned-clock-parents = <0x02 0x47>;
+				fsl,uart-has-rtscts;
+				resets = <0x2d>;
+			};
+
+			mipi_csi1@30a70000 {
+				compatible = "fsl,mxc-mipi-csi2_yav";
+				reg = <0x30a70000 0x1000>;
+				interrupts = <0x00 0x2c 0x04>;
+				clocks = <0x02 0xa7 0x02 0xa9 0x02 0xa8>;
+				clock-names = "clk_core\0clk_esc\0clk_pxl";
+				assigned-clocks = <0x02 0xa7 0x02 0xa8 0x02 0xa9>;
+				assigned-clock-rates = <0x7ed6b40 0x5f5e100 0x3ef1480>;
+				power-domains = <0x2e>;
+				csis-phy-reset = <0x22 0x4c 0x07>;
+				phy-gpr = <0x2f 0x88>;
+				status = "disabled";
+				#address-cells = <0x01>;
+				#size-cells = <0x00>;
+
+				port {
+
+					endpoint@1 {
+						remote-endpoint = <0x30>;
+						phandle = <0x31>;
+					};
+				};
+			};
+
+			csi1_bridge@30a90000 {
+				compatible = "fsl,imx8mq-csi\0fsl,imx6s-csi";
+				reg = <0x30a90000 0x10000>;
+				interrupts = <0x00 0x2a 0x04>;
+				clocks = <0x02 0x00 0x02 0xe0 0x02 0x00>;
+				clock-names = "disp-axi\0csi_mclk\0disp_dcic";
+				status = "disabled";
+				fsl,mipi-mode;
+				fsl,two-8bit-sensor-mode;
+
+				port {
+
+					endpoint {
+						remote-endpoint = <0x31>;
+						phandle = <0x30>;
+					};
+				};
+			};
+
+			mu@30aa0000 {
+				compatible = "fsl,imx8mq-mu\0fsl,imx6sx-mu";
+				reg = <0x30aa0000 0x10000>;
+				interrupts = <0x00 0x58 0x04>;
+				clocks = <0x02 0xfd>;
+				clock-names = "mu";
+				#mbox-cells = <0x02>;
+				phandle = <0x45>;
+			};
+
+			mmc@30b40000 {
+				compatible = "fsl,imx8mq-usdhc\0fsl,imx7d-usdhc";
+				reg = <0x30b40000 0x10000>;
+				interrupts = <0x00 0x16 0x04>;
+				clocks = <0x02 0xec 0x02 0x69 0x02 0xd2>;
+				clock-names = "ipg\0ahb\0per";
+				assigned-clocks = <0x02 0x8e>;
+				assigned-clock-rates = <0x17d78400>;
+				fsl,tuning-start-tap = <0x14>;
+				fsl,tuning-step = <0x02>;
+				bus-width = <0x04>;
+				status = "okay";
+				pinctrl-names = "default\0state_100mhz\0state_200mhz";
+				pinctrl-0 = <0x32>;
+				pinctrl-1 = <0x33>;
+				pinctrl-2 = <0x34>;
+				non-removable;
+				no-sdio;
+				no-1-8-v;
+			};
+
+			mmc@30b50000 {
+				compatible = "fsl,imx8mq-usdhc\0fsl,imx7d-usdhc";
+				reg = <0x30b50000 0x10000>;
+				interrupts = <0x00 0x17 0x04>;
+				clocks = <0x02 0xec 0x02 0x69 0x02 0xd3>;
+				clock-names = "ipg\0ahb\0per";
+				fsl,tuning-start-tap = <0x14>;
+				fsl,tuning-step = <0x02>;
+				bus-width = <0x04>;
+				status = "okay";
+				pinctrl-names = "default";
+				pinctrl-0 = <0x35>;
+				vmmc-supply = <0x36>;
+				mmc-pwrseq = <0x37>;
+				no-1-8-v;
+				non-removable;
+				pm-ignore-notify;
+				keep-power-in-suspend;
+				#address-cells = <0x01>;
+				#size-cells = <0x00>;
+
+				bcrmf@1 {
+					reg = <0x01>;
+					compatible = "brcm,bcm4329-fmac";
+					interrupt-parent = <0x38>;
+					interrupts = <0x0c 0x08>;
+					interrupt-names = "host-wake";
+				};
+			};
+
+			mipi_csi2@30b60000 {
+				compatible = "fsl,mxc-mipi-csi2_yav";
+				reg = <0x30b60000 0x1000>;
+				interrupts = <0x00 0x2d 0x04>;
+				clocks = <0x02 0xaa 0x02 0xac 0x02 0xab>;
+				clock-names = "clk_core\0clk_esc\0clk_pxl";
+				assigned-clocks = <0x02 0xaa 0x02 0xab 0x02 0xac>;
+				assigned-clock-rates = <0x7ed6b40 0x5f5e100 0x3ef1480>;
+				power-domains = <0x39>;
+				csis-phy-reset = <0x22 0x50 0x07>;
+				phy-gpr = <0x2f 0xa4>;
+				status = "disabled";
+			};
+
+			csi2_bridge@30b80000 {
+				compatible = "fsl,imx8mq-csi\0fsl,imx6s-csi";
+				reg = <0x30b80000 0x10000>;
+				interrupts = <0x00 0x2b 0x04>;
+				clocks = <0x02 0x00 0x02 0xe1 0x02 0x00>;
+				clock-names = "disp-axi\0csi_mclk\0disp_dcic";
+				status = "disabled";
+			};
+
+			spi@30bb0000 {
+				#address-cells = <0x01>;
+				#size-cells = <0x00>;
+				compatible = "fsl,imx8mq-qspi\0fsl,imx7d-qspi";
+				reg = <0x30bb0000 0x10000 0x8000000 0x10000000>;
+				reg-names = "QuadSPI\0QuadSPI-memory";
+				interrupts = <0x00 0x6b 0x04>;
+				clocks = <0x02 0xc3 0x02 0xc3>;
+				clock-names = "qspi_en\0qspi";
+				status = "disabled";
+			};
+
+			sdma@30bd0000 {
+				compatible = "fsl,imx8mq-sdma\0fsl,imx7d-sdma";
+				reg = <0x30bd0000 0x10000>;
+				interrupts = <0x00 0x02 0x04>;
+				clocks = <0x02 0xe3 0x02 0x74>;
+				clock-names = "ipg\0ahb";
+				#dma-cells = <0x03>;
+				fsl,sdma-ram-script-name = "imx/sdma/sdma-imx7d.bin";
+				phandle = <0x1f>;
+			};
+
+			ethernet@30be0000 {
+				compatible = "fsl,imx8mq-fec\0fsl,imx6sx-fec";
+				reg = <0x30be0000 0x10000>;
+				interrupts = <0x00 0x76 0x04 0x00 0x77 0x04 0x00 0x78 0x04>;
+				clocks = <0x02 0xb6 0x02 0xb6 0x02 0x8a 0x02 0x89 0x02 0x8b>;
+				clock-names = "ipg\0ahb\0ptp\0enet_clk_ref\0enet_out";
+				fsl,num-tx-queues = <0x03>;
+				fsl,num-rx-queues = <0x03>;
+				nvmem-cells = <0x3a>;
+				nvmem-cell-names = "mac-address";
+				nvmem_macaddr_swap;
+				stop-mode = <0x2f 0x10 0x03>;
+				fsl,wakeup_irq = <0x02>;
+				status = "okay";
+				pinctrl-names = "default";
+				pinctrl-0 = <0x3b>;
+				phy-mode = "rgmii-id";
+				phy-handle = <0x3c>;
+				fsl,magic-packet;
+				phy-reset-gpios = <0x28 0x09 0x01>;
+
+				mdio {
+					#address-cells = <0x01>;
+					#size-cells = <0x00>;
+
+					ethernet-phy@4 {
+						compatible = "ethernet-phy-ieee802.3-c22";
+						reg = <0x04>;
+						at803x,eee-disabled;
+						phandle = <0x3c>;
+					};
+				};
+			};
+		};
+
+		bus@32c00000 {
+			compatible = "fsl,imx8mq-aips-bus\0simple-bus";
+			#address-cells = <0x01>;
+			#size-cells = <0x01>;
+			ranges = <0x32c00000 0x32c00000 0x400000>;
+
+			hdmi@32c00000 {
+				reg = <0x32c00000 0x100000 0x32e40000 0x40000>;
+				interrupts = <0x00 0x10 0x04 0x00 0x19 0x04>;
+				interrupt-names = "plug_in\0plug_out";
+			};
+
+			interrupt-controller@32e2d000 {
+				compatible = "fsl,imx8m-irqsteer\0fsl,imx-irqsteer";
+				reg = <0x32e2d000 0x1000>;
+				interrupts = <0x00 0x12 0x04>;
+				clocks = <0x02 0xf8>;
+				clock-names = "ipg";
+				fsl,channel = <0x00>;
+				fsl,num-irqs = <0x40>;
+				interrupt-controller;
+				#interrupt-cells = <0x01>;
+				status = "okay";
+				phandle = <0x3d>;
+			};
+
+			display-controller@32e00000 {
+				#address-cells = <0x01>;
+				#size-cells = <0x00>;
+				compatible = "nxp,imx8mq-dcss";
+				reg = <0x32e00000 0x2d000 0x32e2f000 0x1000>;
+				interrupts = <0x06 0x08 0x09 0x10 0x11>;
+				interrupt-names = "ctx_ld\0ctxld_kick\0vblank\0dtrc_ch1\0dtrc_ch2";
+				interrupt-parent = <0x3d>;
+				clocks = <0x02 0xf8 0x02 0xf7 0x02 0xf9 0x02 0xfe 0x02 0x7a 0x02 0x10a 0x02 0x10b>;
+				clock-names = "apb\0axi\0rtrm\0pix\0dtrc\0pll_src\0pll_phy_ref";
+				assigned-clocks = <0x02 0x6b 0x02 0x6d 0x02 0x10a>;
+				assigned-clock-parents = <0x02 0x4e 0x02 0x4e 0x02 0x03>;
+				assigned-clock-rates = <0x2faf0800 0x17d78400>;
+				status = "disabled";
+			};
+		};
+
+		gpu@38000000 {
+			compatible = "vivante,gc";
+			reg = <0x38000000 0x40000>;
+			interrupts = <0x00 0x03 0x04>;
+			clocks = <0x02 0xd7 0x02 0x66 0x02 0x6f 0x02 0x70>;
+			clock-names = "core\0shader\0bus\0reg";
+			assigned-clocks = <0x02 0x61 0x02 0x64 0x02 0x6f 0x02 0x70 0x02 0x10>;
+			assigned-clock-parents = <0x02 0x11 0x02 0x11 0x02 0x11 0x02 0x11 0x02 0x0f>;
+			assigned-clock-rates = <0x2faf0800 0x2faf0800 0x2faf0800 0x2faf0800 0x00>;
+			power-domains = <0x3e>;
+			status = "disabled";
+		};
+
+		usb@38100000 {
+			compatible = "fsl,imx8mq-dwc3\0snps,dwc3";
+			reg = <0x38100000 0x10000>;
+			clocks = <0x02 0xce 0x02 0x98 0x02 0x01>;
+			clock-names = "bus_early\0ref\0suspend";
+			assigned-clocks = <0x02 0x6e 0x02 0x98>;
+			assigned-clock-parents = <0x02 0x56 0x02 0x48>;
+			assigned-clock-rates = <0x1dcd6500 0x5f5e100>;
+			interrupts = <0x00 0x28 0x04>;
+			phys = <0x3f 0x3f>;
+			phy-names = "usb2-phy\0usb3-phy";
+			usb3-resume-missing-cas;
+			snps,power-down-scale = <0x02>;
+			status = "okay";
+			dr_mode = "host";
+		};
+
+		usb-phy@381f0040 {
+			compatible = "fsl,imx8mq-usb-phy";
+			reg = <0x381f0040 0x40>;
+			clocks = <0x02 0xd0>;
+			clock-names = "phy";
+			assigned-clocks = <0x02 0x99>;
+			assigned-clock-parents = <0x02 0x48>;
+			assigned-clock-rates = <0x5f5e100>;
+			#phy-cells = <0x00>;
+			status = "okay";
+			phandle = <0x3f>;
+		};
+
+		usb@38200000 {
+			compatible = "fsl,imx8mq-dwc3\0snps,dwc3";
+			reg = <0x38200000 0x10000>;
+			clocks = <0x02 0xcf 0x02 0x98 0x02 0x01>;
+			clock-names = "bus_early\0ref\0suspend";
+			assigned-clocks = <0x02 0x6e 0x02 0x98>;
+			assigned-clock-parents = <0x02 0x56 0x02 0x48>;
+			assigned-clock-rates = <0x1dcd6500 0x5f5e100>;
+			interrupts = <0x00 0x29 0x04>;
+			phys = <0x40 0x40>;
+			phy-names = "usb2-phy\0usb3-phy";
+			power-domains = <0x41>;
+			usb3-resume-missing-cas;
+			snps,power-down-scale = <0x02>;
+			status = "okay";
+			dr_mode = "host";
+		};
+
+		usb-phy@382f0040 {
+			compatible = "fsl,imx8mq-usb-phy";
+			reg = <0x382f0040 0x40>;
+			clocks = <0x02 0xd1>;
+			clock-names = "phy";
+			assigned-clocks = <0x02 0x99>;
+			assigned-clock-parents = <0x02 0x48>;
+			assigned-clock-rates = <0x5f5e100>;
+			#phy-cells = <0x00>;
+			status = "okay";
+			phandle = <0x40>;
+		};
+
+		dma-apbh@33000000 {
+			compatible = "fsl,imx7d-dma-apbh\0fsl,imx28-dma-apbh";
+			reg = <0x33000000 0x2000>;
+			interrupts = <0x00 0x0c 0x04 0x00 0x0c 0x04 0x00 0x0c 0x04 0x00 0x0c 0x04>;
+			interrupt-names = "gpmi0\0gpmi1\0gpmi2\0gpmi3";
+			#dma-cells = <0x01>;
+			dma-channels = <0x04>;
+			clocks = <0x02 0x100>;
+			phandle = <0x42>;
+		};
+
+		gpmi-nand@33002000 {
+			compatible = "fsl,imx7d-gpmi-nand";
+			#address-cells = <0x01>;
+			#size-cells = <0x01>;
+			reg = <0x33002000 0x2000 0x33004000 0x4000>;
+			reg-names = "gpmi-nand\0bch";
+			interrupts = <0x00 0x0e 0x04>;
+			interrupt-names = "bch";
+			clocks = <0x02 0xe2 0x02 0x100>;
+			clock-names = "gpmi_io\0gpmi_bch_apb";
+			dmas = <0x42 0x00>;
+			dma-names = "rx-tx";
+			status = "disabled";
+		};
+
+		pcie@33800000 {
+			compatible = "fsl,imx8mq-pcie";
+			reg = <0x33800000 0x400000 0x1ff00000 0x80000>;
+			reg-names = "dbi\0config";
+			#address-cells = <0x03>;
+			#size-cells = <0x02>;
+			device_type = "pci";
+			bus-range = <0x00 0xff>;
+			ranges = <0x81000000 0x00 0x00 0x1ff80000 0x00 0x10000 0x82000000 0x00 0x18000000 0x18000000 0x00 0x7f00000>;
+			num-lanes = <0x01>;
+			num-viewport = <0x04>;
+			interrupts = <0x00 0x7a 0x04 0x00 0x7f 0x04>;
+			interrupt-names = "msi\0dma";
+			#interrupt-cells = <0x01>;
+			interrupt-map-mask = <0x00 0x00 0x00 0x07>;
+			interrupt-map = <0x00 0x00 0x00 0x01 0x07 0x00 0x7d 0x04 0x00 0x00 0x00 0x02 0x07 0x00 0x7c 0x04 0x00 0x00 0x00 0x03 0x07 0x00 0x7b 0x04 0x00 0x00 0x00 0x04 0x07 0x00 0x7a 0x04>;
+			fsl,max-link-speed = <0x02>;
+			power-domains = <0x43>;
+			resets = <0x22 0x1a 0x22 0x1c 0x22 0x1d>;
+			reset-names = "pciephy\0apps\0turnoff";
+			status = "disabled";
+		};
+
+		pcie@33c00000 {
+			compatible = "fsl,imx8mq-pcie";
+			reg = <0x33c00000 0x400000 0x27f00000 0x80000>;
+			reg-names = "dbi\0config";
+			#address-cells = <0x03>;
+			#size-cells = <0x02>;
+			device_type = "pci";
+			ranges = <0x81000000 0x00 0x00 0x27f80000 0x00 0x10000 0x82000000 0x00 0x20000000 0x20000000 0x00 0x7f00000>;
+			num-lanes = <0x01>;
+			num-viewport = <0x04>;
+			interrupts = <0x00 0x4a 0x04 0x00 0x50 0x04>;
+			interrupt-names = "msi\0dma";
+			#interrupt-cells = <0x01>;
+			interrupt-map-mask = <0x00 0x00 0x00 0x07>;
+			interrupt-map = <0x00 0x00 0x00 0x01 0x07 0x00 0x4d 0x04 0x00 0x00 0x00 0x02 0x07 0x00 0x4c 0x04 0x00 0x00 0x00 0x03 0x07 0x00 0x4b 0x04 0x00 0x00 0x00 0x04 0x07 0x00 0x4a 0x04>;
+			fsl,max-link-speed = <0x02>;
+			power-domains = <0x43>;
+			resets = <0x22 0x22 0x22 0x24 0x22 0x25>;
+			reset-names = "pciephy\0apps\0turnoff";
+			status = "disabled";
+		};
+
+		interrupt-controller@38800000 {
+			compatible = "arm,gic-v3";
+			reg = <0x38800000 0x10000 0x38880000 0xc0000 0x31000000 0x2000 0x31010000 0x2000 0x31020000 0x2000>;
+			#interrupt-cells = <0x03>;
+			interrupt-controller;
+			interrupts = <0x01 0x09 0x04>;
+			interrupt-parent = <0x07>;
+			phandle = <0x07>;
+		};
+
+		ddr-pmu@3d800000 {
+			compatible = "fsl,imx8mq-ddr-pmu\0fsl,imx8m-ddr-pmu";
+			reg = <0x3d800000 0x400000>;
+			interrupt-parent = <0x07>;
+			interrupts = <0x00 0x62 0x04>;
+		};
+
+		vpu@38300000 {
+			compatible = "nxp,imx8mq-hantro";
+			reg = <0x38300000 0x200000>;
+			reg-names = "regs_hantro";
+			interrupts = <0x00 0x07 0x04 0x00 0x08 0x04>;
+			interrupt-names = "irq_hantro_g1\0irq_hantro_g2";
+			clocks = <0x02 0xe5 0x02 0xe6 0x02 0xdf>;
+			clock-names = "clk_hantro_g1\0clk_hantro_g2\0clk_hantro_bus";
+			assigned-clocks = <0x02 0x78 0x02 0x79 0x02 0x6a>;
+			assigned-clock-parents = <0x02 0x16 0x02 0x16 0x02 0x4e>;
+			assigned-clock-rates = <0x23c34600 0x23c34600 0x2faf0800>;
+			power-domains = <0x44>;
+			status = "okay";
+		};
+	};
+
+	gpu3d@38000000 {
+		compatible = "fsl,imx8mq-gpu\0fsl,imx6q-gpu";
+		reg = <0x00 0x38000000 0x00 0x40000 0x00 0x40000000 0x00 0xc0000000 0x00 0x00 0x00 0x10000000>;
+		reg-names = "iobase_3d\0phys_baseaddr\0contiguous_mem";
+		interrupts = <0x00 0x03 0x04>;
+		interrupt-names = "irq_3d";
+		clocks = <0x02 0xd7 0x02 0x66 0x02 0x6f 0x02 0x70>;
+		clock-names = "gpu3d_clk\0gpu3d_shader_clk\0gpu3d_axi_clk\0gpu3d_ahb_clk";
+		assigned-clocks = <0x02 0x61 0x02 0x64 0x02 0x6f 0x02 0x70>;
+		assigned-clock-parents = <0x02 0x11 0x02 0x11 0x02 0x11 0x02 0x11>;
+		assigned-clock-rates = <0x2faf0800 0x2faf0800 0x2faf0800 0x2faf0800>;
+		power-domains = <0x3e>;
+		status = "okay";
+	};
+
+	rpmsg {
+		compatible = "fsl,imx8mq-rpmsg";
+		mbox-names = "tx\0rx\0rxdb";
+		mboxes = <0x45 0x00 0x01 0x45 0x01 0x01 0x45 0x03 0x01>;
+		status = "disabled";
+	};
+
+	chosen {
+		stdout-path = "/soc@0/bus@30800000/serial@30860000";
+	};
+
+	memory@40000000 {
+		device_type = "memory";
+		reg = <0x00 0x40000000 0x00 0x80000000>;
+	};
+
+	reserved-memory {
+		#address-cells = <0x02>;
+		#size-cells = <0x02>;
+		ranges;
+
+		linux,cma {
+			compatible = "shared-dma-pool";
+			reusable;
+			size = <0x00 0x3c000000>;
+			alloc-ranges = <0x00 0x40000000 0x00 0x40000000>;
+			linux,cma-default;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-names = "default";
+		pinctrl-0 = <0x46>;
+		status = "okay";
+
+		sys_led {
+			label = "sys_led";
+			gpios = <0x28 0x05 0x00>;
+			default-state = "on";
+			linux,default-trigger = "heartbeat";
+		};
+
+		usr_led {
+			label = "usr_led";
+			gpios = <0x28 0x08 0x00>;
+			default-state = "on";
+		};
+	};
+
+	gpio_keys {
+		compatible = "gpio-keys";
+		pinctrl-names = "default";
+		pinctrl-0 = <0x47>;
+
+		home {
+			label = "home Button";
+			gpios = <0x2b 0x07 0x01>;
+			linux,code = <0x66>;
+			gpio-key,wakeup;
+		};
+
+		back {
+			label = "back Button";
+			gpios = <0x2b 0x06 0x01>;
+			linux,code = <0x19c>;
+		};
+	};
+
+	gpiomem {
+		compatible = "maaxboard,maaxboard-gpiomem";
+		status = "okay";
+	};
+
+	sound-hdmi {
+		compatible = "fsl,imx8mq-evk-cdnhdmi\0fsl,imx-audio-cdnhdmi";
+		model = "imx-audio-hdmi";
+		audio-cpu = <0x48>;
+		protocol = <0x01>;
+		hdmi-out;
+		constraint-rate = <0xac44 0x15888 0x2b110 0x7d00 0xbb80 0x17700 0x2ee00>;
+		status = "disabled";
+	};
+
+	backlight {
+		compatible = "pwm-backlight";
+		pwms = <0x49 0x00 0x9c40 0x00>;
+		brightness-levels = <0x00 0x08 0x20 0x40 0x60 0x80 0xa0 0xc0 0xe0 0xff>;
+		default-brightness-level = <0x08>;
+		enable-pwm-on;
+		status = "disabled";
+	};
+
+	regulators {
+		compatible = "simple-bus";
+		#address-cells = <0x01>;
+		#size-cells = <0x00>;
+
+		regulator@1 {
+			compatible = "regulator-fixed";
+			reg = <0x01>;
+			pinctrl-names = "default";
+			pinctrl-0 = <0x4a>;
+			regulator-name = "WF_3V3";
+			regulator-min-microvolt = <0x325aa0>;
+			regulator-max-microvolt = <0x325aa0>;
+			gpio = <0x38 0x14 0x00>;
+			regulator-always-on;
+			enable-active-high;
+			phandle = <0x36>;
+		};
+
+		regulator-mipi-vcc {
+			compatible = "regulator-fixed";
+			pinctrl-names = "default";
+			pinctrl-0 = <0x4b>;
+			regulator-name = "mipi_vcc_en";
+			regulator-min-microvolt = <0x325aa0>;
+			regulator-max-microvolt = <0x325aa0>;
+			enable-active-high;
+			startup-delay-us = <0x27100>;
+			gpio = <0x2b 0x0c 0x00>;
+		};
+	};
+
+	sdio-pwrseq {
+		compatible = "mmc-pwrseq-simple";
+		pinctrl-names = "default";
+		pinctrl-0 = <0x4c>;
+		reset-gpios = <0x38 0x13 0x01>;
+		phandle = <0x37>;
+	};
+
+	bt_reset {
+		compatible = "gpio-reset";
+		reset-gpios = <0x4d 0x0b 0x01>;
+		reset-delay-us = <0x3e8>;
+		reset-post-delay-ms = <0x28>;
+		#reset-cells = <0x00>;
+		phandle = <0x2d>;
+	};
+
+	clock-pmic {
+		compatible = "fixed-clock";
+		#clock-cells = <0x00>;
+		clock-frequency = <0x8000>;
+		clock-output-names = "pmic_osc";
+		phandle = <0x27>;
+	};
+};

--- a/tools/dts/update-dts.sh
+++ b/tools/dts/update-dts.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env sh
 #
 # Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+# Copyright 2022, Capgemini Engineering
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #
@@ -61,6 +62,7 @@ freescale/fsl-imx8mq-evk=imx8mq-evk
 freescale/fsl-imx8mm-evk=imx8mm-evk
 rockchip/rk3399-rockpro64=rockpro64
 broadcom/bcm2711-rpi-4-b=rpi4
+avnet/maaxboard=maaxboard
 "
 
 extract_dts() {


### PR DESCRIPTION
This pull request is a call for feedback and comment on an initial implementation for supporting seL4 on the Avnet MaaXBoard, with the intention of the changes below being merged back to the main seL4 repository.

This pull request contains the following changes:
* Addition of a device tree (DTS) file sourced from Avnet.
* The creation of an 32-bit overlay DTS file to provide memory clamping and exclusion of devices (the GPU) that extend outside of the 32-bit memory range, in order to support running seL4 under AArch32.
* The creation of a general overlay DTS file, to provide nodes for general purpose timers that exist in the SOC documentation (i.MX8) for the Avnet MaaXBoard, but where not present in the DTS sourced from Avnet, as well as the relevant interrupts for these timers. The overlay also modifies the USB nodes to use the dwc3 driver.
* The modification of the `tools/dts/update-dts.sh` script to include the above DTS files.
* Creation of a CMAKE configuration file to support building seL4 for the Avnet MaaXBoard.
* Creation of a header file for platform-specific includes for the MaaXBoard, albeit being identical to the includes for the imx8mq-evk evaluation board, which was already supported.

There are two other pull requests dependent on this pull request, one in the seL4_tools repository, and the other in util_libs.

seL4test has been tested with these changes only on the MaaXBoard itself, but all tests run as expected resulting in a `All is well in the universe` message. No other platforms have been tested.

Test with: seL4/seL4_tools#144, seL4/util_libs#129