### PR TITLE
qemu-arm-virt: Add support for 32bit arm hyp mode configurations

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -29,6 +29,7 @@ Upcoming release: BINARY COMPATIBLE
  * Added support for the ARM Cortex A55
  * Added support for the ODroid C4
  * Added support for the Avnet MaaXBoard
+ * Added support for arm_hyp on qemu-arm-virt platfrom with cortex-a15 CPU
  * Rename libsel4 config option ENABLE_SMP_SUPPORT to CONFIG_ENABLE_SMP_SUPPORT to be namespace compliant.
  * Rename libsel4 config option AARCH64_VSPACE_S2_START_L1 to CONFIG_AARCH64_VSPACE_S2_START_L1 to be namespace
    compliant.

--- a/include/arch/arm/arch/32/mode/fastpath/fastpath.h
+++ b/include/arch/arm/arch/32/mode/fastpath/fastpath.h
@@ -144,7 +144,7 @@ static inline void NORETURN FORCE_INLINE fastpath_restore(word_t badge, word_t m
             "msr elr_hyp, lr    \n"
             /* prepare the user status register */
             "ldr lr, [sp, #8]   \n"
-            "msr spsr_hyp, lr   \n"
+            "msr spsr, lr       \n"
             /* Finally, pop our LR */
             "pop {lr}           \n"
             /* Return to user */

--- a/include/arch/arm/arch/32/mode/hardware.h
+++ b/include/arch/arm/arch/32/mode/hardware.h
@@ -85,6 +85,10 @@
 #ifndef __ASSEMBLER__
 /* It is required that USER_TOP must be aligned to at least 20 bits */
 compile_assert(USER_TOP_correctly_aligned, IS_ALIGNED(USER_TOP, 20));
+/* It is required on arm_hyp that USER_TOP isn't lower than the top GiB */
+#ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
+compile_assert(USER_TOP_top_gb, USER_TOP >= 0xC0000000);
+#endif
 
 #include <plat/machine/hardware.h>
 #endif

--- a/src/arch/arm/32/c_traps.c
+++ b/src/arch/arm/32/c_traps.c
@@ -48,7 +48,7 @@ void VISIBLE NORETURN restore_user_context(void)
             "msr elr_hyp, lr           \n"
             /* prepare the user status register */
             "ldr lr, [sp, #8]          \n"
-            "msr spsr_hyp, lr          \n"
+            "msr spsr, lr              \n"
             /* Finally, pop our LR */
             "pop {lr}                  \n"
             /* Return to user */

--- a/src/arch/arm/32/hyp_traps.S
+++ b/src/arch/arm/32/hyp_traps.S
@@ -98,7 +98,7 @@ END_FUNC(arm_vector_table)
     mrs lr, elr_hyp
     str lr, [sp, #4]
     /* Store SPSR */
-    mrs lr, spsr_hyp
+    mrs lr, spsr
     str lr, [sp, #8]
     /* Store SP_usr */
     mrs lr, sp_usr


### PR DESCRIPTION
Add support for the qemu-arm-virt simulation platform to run seL4 in hyp mode.