### PR TITLE
x86_64: Fix x86_64 gcc compile error with sysexitq

### DIFF
--- a/include/arch/x86/arch/64/mode/fastpath/fastpath.h
+++ b/include/arch/x86/arch/64/mode/fastpath/fastpath.h
@@ -203,7 +203,7 @@ static inline void NORETURN FORCE_INLINE fastpath_restore(word_t badge, word_t m
 #endif /* CONFIG_KERNEL_SKIM_WINDOW */
 #endif /* defined(ENABLE_SMP_SUPPORT) && defined(CONFIG_KERNEL_SKIM_WINDOW) */
             "sti\n"
-            "sysexitq\n"
+            SYSEXITQ"\n"
             :
             : "c"(&cur_thread->tcbArch.tcbContext.registers[RAX]),
             "D"(badge),

--- a/include/arch/x86/arch/64/mode/machine.h
+++ b/include/arch/x86/arch/64/mode/machine.h
@@ -13,6 +13,22 @@
 #include <arch/model/smp.h>
 #include <arch/machine.h>
 
+/*
+ * SYSEXIT  0F 35     ; Return to compatibility mode from fast system call.
+ * SYSEXITQ 48 0F 35  ; Return to 64-bit mode from fast system call.
+ *
+ * clang uses "sysexitq" and gcc uses "rex.w sysexit" to generate 0x48,0x0F,0x35
+ * only at gcc 12 or later "sysexitq" works on both compilers.
+ */
+#if (defined(__clang__))
+#define SYSEXITQ "sysexitq"
+#elif defined(__GNUC__)
+#define SYSEXITQ "rex.w sysexit"
+#else
+#error "unsupported compiler"
+#endif
+
+
 static inline cr3_t makeCR3(paddr_t addr, word_t pcid)
 {
     return cr3_new(addr, config_set(CONFIG_SUPPORT_PCID) ? pcid : 0);

--- a/src/arch/x86/64/c_traps.c
+++ b/src/arch/x86/64/c_traps.c
@@ -243,12 +243,7 @@ void VISIBLE NORETURN restore_user_context(void)
                 // More register but we can ignore and are done restoring
                 // enable interrupt disabled by sysenter
                 "sti\n"
-                /* Return to user.
-                 *
-                 * SYSEXIT  0F 35     ; Return to compatibility mode from fast system call.
-                 * SYSEXITQ 48 0F 35  ; Return to 64-bit mode from fast system call.
-                 * */
-                "sysexitq\n"
+                SYSEXITQ "\n"
                 :
                 : "r"(&cur_thread->tcbArch.tcbContext.registers[RDI]),
 #if defined(ENABLE_SMP_SUPPORT) && defined(CONFIG_KERNEL_SKIM_WINDOW)


### PR DESCRIPTION
sysexit requires a 64-bit operand to remain in 64-bit mode when
switching to user level. gcc versions older than 12 encode this as
"REX.W SYSEXIT" while clang encodes this as "SYSEXITQ". Both compilers
don't support the alternate encoding. We instead use ".byte
0x48,0x0F,0x35" which is the actual opcode of the required instruction
which will work with both compilers.

Signed-off-by: Kent McLeod <kent@kry10.com>