### PR TITLE
github: switch proofs to Isabelle2021-1

### DIFF
--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -37,7 +37,7 @@ jobs:
       uses: seL4/ci-actions/aws-proofs@master
       with:
         L4V_ARCH: ${{ matrix.arch }}
-        isa_branch: ts-2021
+        isa_branch: ts-2021-1
         session: ${{ matrix.session }}
         manifest: default.xml
       env:


### PR DESCRIPTION
Setting the correct branch for the isabelle repository.