### PR TITLE
Don't clobber msgInfo register after an invocation

### DIFF
--- a/include/arch/arm/arch/kernel/vspace.h
+++ b/include/arch/arm/arch/kernel/vspace.h
@@ -40,7 +40,7 @@ vm_rights_t CONST maskVMRights(vm_rights_t vm_rights,
                                seL4_CapRights_t cap_rights_mask);
 
 exception_t decodeARMMMUInvocation(word_t invLabel, word_t length, cptr_t cptr,
-                                   cte_t *cte, cap_t cap, word_t *buffer);
+                                   cte_t *cte, cap_t cap, bool_t call, word_t *buffer);
 
 #ifdef CONFIG_PRINTING
 void Arch_userStackTrace(tcb_t *tptr);

--- a/include/arch/riscv/arch/kernel/vspace.h
+++ b/include/arch/riscv/arch/kernel/vspace.h
@@ -50,7 +50,7 @@ exception_t checkValidIPCBuffer(vptr_t vptr, cap_t cap);
 vm_rights_t CONST maskVMRights(vm_rights_t vm_rights,
                                seL4_CapRights_t cap_rights_mask);
 exception_t decodeRISCVMMUInvocation(word_t label, word_t length, cptr_t cptr,
-                                     cte_t *cte, cap_t cap, word_t *buffer);
+                                     cte_t *cte, cap_t cap, bool_t call, word_t *buffer);
 exception_t performPageTableInvocationMap(cap_t cap, cte_t *ctSlot,
                                           pte_t lvl1pt, pte_t *ptSlot);
 exception_t performPageTableInvocationUnmap(cap_t cap, cte_t *ctSlot);

--- a/include/arch/x86/arch/kernel/vspace.h
+++ b/include/arch/x86/arch/kernel/vspace.h
@@ -99,16 +99,17 @@ vm_rights_t CONST maskVMRights(vm_rights_t vm_rights, seL4_CapRights_t cap_right
 void flushTable(vspace_root_t *vspace, word_t vptr, pte_t *pt, asid_t asid);
 
 exception_t decodeX86MMUInvocation(word_t invLabel, word_t length, cptr_t cptr, cte_t *cte,
-                                   cap_t cap, word_t *buffer);
+                                   cap_t cap, bool_t call, word_t *buffer);
 
 exception_t decodeX86ModeMMUInvocation(word_t invLabel, word_t length, cptr_t cptr, cte_t *cte,
-                                       cap_t cap, word_t *buffer);
+                                       cap_t cap, bool_t call, word_t *buffer);
 
 exception_t decodeIA32PageDirectoryInvocation(word_t invLabel, word_t length, cte_t *cte, cap_t cap,
-                                              word_t *buffer);
+                                              bool_t call, word_t *buffer);
 
 /* common functions for x86 */
-exception_t decodeX86FrameInvocation(word_t invLabel, word_t length, cte_t *cte, cap_t cap, word_t *buffer);
+exception_t decodeX86FrameInvocation(word_t invLabel, word_t length, cte_t *cte, cap_t cap,
+                                     bool_t call, word_t *buffer);
 
 uint32_t CONST WritableFromVMRights(vm_rights_t vm_rights);
 uint32_t CONST SuperUserFromVMRights(vm_rights_t vm_rights);

--- a/include/arch/x86/arch/object/objecttype.h
+++ b/include/arch/x86/arch/object/objecttype.h
@@ -32,7 +32,7 @@ finaliseCap_ret_t Mode_finaliseCap(cap_t cap, bool_t final);
 bool_t CONST Mode_sameRegionAs(cap_t cap_a, cap_t cap_b);
 cap_t Mode_createObject(object_t t, void *regionBase, word_t userSize, bool_t deviceMemory);
 exception_t Mode_decodeInvocation(word_t invLabel, word_t length, cptr_t cptr, cte_t *slot, cap_t cap,
-                                  word_t *buffer);
+                                  bool_t call, word_t *buffer);
 word_t Mode_getObjectSize(word_t t);
 
 void Arch_postCapDeletion(cap_t cap);

--- a/include/arch/x86/arch/object/vcpu.h
+++ b/include/arch/x86/arch/object/vcpu.h
@@ -326,6 +326,7 @@ exception_t decodeX86VCPUInvocation(
     cptr_t cptr,
     cte_t *slot,
     cap_t cap,
+    bool_t call,
     word_t *buffer
 );
 

--- a/src/arch/arm/32/object/objecttype.c
+++ b/src/arch/arm/32/object/objecttype.c
@@ -556,7 +556,7 @@ exception_t Arch_decodeInvocation(word_t invLabel, word_t length, cptr_t cptr,
 #else
 {
 #endif
-    return decodeARMMMUInvocation(invLabel, length, cptr, slot, cap, buffer);
+    return decodeARMMMUInvocation(invLabel, length, cptr, slot, cap, call, buffer);
 }
 }
 

--- a/src/arch/arm/64/kernel/vspace.c
+++ b/src/arch/arm/64/kernel/vspace.c
@@ -1660,14 +1660,20 @@ static exception_t performPageFlush(int invLabel, vspace_root_t *vspaceRoot, asi
     return EXCEPTION_NONE;
 }
 
-static exception_t performPageGetAddress(pptr_t base_ptr)
+static exception_t performPageGetAddress(pptr_t base_ptr, bool_t call)
 {
     paddr_t base = pptr_to_paddr((void *)base_ptr);
 
-    setRegister(NODE_STATE(ksCurThread), msgRegisters[0], base);
-    setRegister(NODE_STATE(ksCurThread), msgInfoRegister,
-                wordFromMessageInfo(seL4_MessageInfo_new(0, 0, 0, 1)));
-
+    tcb_t *thread;
+    thread = NODE_STATE(ksCurThread);
+    if (call) {
+        word_t *ipcBuffer = lookupIPCBuffer(true, thread);
+        setRegister(thread, badgeRegister, 0);
+        unsigned int length = setMR(thread, ipcBuffer, 0, base);
+        setRegister(thread, msgInfoRegister, wordFromMessageInfo(
+                        seL4_MessageInfo_new(0, 0, 0, length)));
+    }
+    setThreadState(NODE_STATE(ksCurThread), ThreadState_Running);
     return EXCEPTION_NONE;
 }
 
@@ -2061,7 +2067,7 @@ static exception_t decodeARMPageTableInvocation(word_t invLabel, unsigned int le
 }
 
 static exception_t decodeARMFrameInvocation(word_t invLabel, unsigned int length,
-                                            cte_t *cte, cap_t cap, word_t *buffer)
+                                            cte_t *cte, cap_t cap, bool_t call, word_t *buffer)
 {
     switch (invLabel) {
     case ARMPageMap: {
@@ -2259,7 +2265,7 @@ static exception_t decodeARMFrameInvocation(word_t invLabel, unsigned int length
 
     case ARMPageGetAddress:
         setThreadState(NODE_STATE(ksCurThread), ThreadState_Restart);
-        return performPageGetAddress(cap_frame_cap_get_capFBasePtr(cap));
+        return performPageGetAddress(cap_frame_cap_get_capFBasePtr(cap), call);
 
     default:
         current_syscall_error.type = seL4_IllegalOperation;
@@ -2268,7 +2274,7 @@ static exception_t decodeARMFrameInvocation(word_t invLabel, unsigned int length
 }
 
 exception_t decodeARMMMUInvocation(word_t invLabel, word_t length, cptr_t cptr,
-                                   cte_t *cte, cap_t cap, word_t *buffer)
+                                   cte_t *cte, cap_t cap, bool_t call, word_t *buffer)
 {
     switch (cap_get_capType(cap)) {
     case cap_vtable_root_cap:
@@ -2284,7 +2290,7 @@ exception_t decodeARMMMUInvocation(word_t invLabel, word_t length, cptr_t cptr,
         return decodeARMPageTableInvocation(invLabel, length, cte, cap, buffer);
 
     case cap_frame_cap:
-        return decodeARMFrameInvocation(invLabel, length, cte, cap, buffer);
+        return decodeARMFrameInvocation(invLabel, length, cte, cap, call, buffer);
 
     case cap_asid_control_cap: {
         unsigned int i;

--- a/src/arch/arm/64/object/objecttype.c
+++ b/src/arch/arm/64/object/objecttype.c
@@ -499,7 +499,7 @@ exception_t Arch_decodeInvocation(word_t label, word_t length, cptr_t cptr,
 #else
 {
 #endif
-    return decodeARMMMUInvocation(label, length, cptr, slot, cap, buffer);
+    return decodeARMMMUInvocation(label, length, cptr, slot, cap, call, buffer);
 }
 }
 

--- a/src/arch/riscv/kernel/vspace.c
+++ b/src/arch/riscv/kernel/vspace.c
@@ -34,7 +34,7 @@ struct resolve_ret {
 };
 typedef struct resolve_ret resolve_ret_t;
 
-static exception_t performPageGetAddress(void *vbase_ptr);
+static exception_t performPageGetAddress(void *vbase_ptr, bool_t call);
 
 static word_t CONST RISCVGetWriteFromVMRights(vm_rights_t vm_rights)
 {
@@ -792,7 +792,7 @@ static exception_t decodeRISCVPageTableInvocation(word_t label, word_t length,
 }
 
 static exception_t decodeRISCVFrameInvocation(word_t label, word_t length,
-                                              cte_t *cte, cap_t cap, word_t *buffer)
+                                              cte_t *cte, cap_t cap, bool_t call, word_t *buffer)
 {
     switch (label) {
     case RISCVPageMap: {
@@ -911,7 +911,7 @@ static exception_t decodeRISCVFrameInvocation(word_t label, word_t length,
         assert(n_msgRegisters >= 1);
 
         setThreadState(NODE_STATE(ksCurThread), ThreadState_Restart);
-        return performPageGetAddress((void *)cap_frame_cap_get_capFBasePtr(cap));
+        return performPageGetAddress((void *)cap_frame_cap_get_capFBasePtr(cap), call);
     }
 
     default:
@@ -924,7 +924,7 @@ static exception_t decodeRISCVFrameInvocation(word_t label, word_t length,
 }
 
 exception_t decodeRISCVMMUInvocation(word_t label, word_t length, cptr_t cptr,
-                                     cte_t *cte, cap_t cap, word_t *buffer)
+                                     cte_t *cte, cap_t cap, bool_t call, word_t *buffer)
 {
     switch (cap_get_capType(cap)) {
 
@@ -932,7 +932,7 @@ exception_t decodeRISCVMMUInvocation(word_t label, word_t length, cptr_t cptr,
         return decodeRISCVPageTableInvocation(label, length, cte, cap, buffer);
 
     case cap_frame_cap:
-        return decodeRISCVFrameInvocation(label, length, cte, cap, buffer);
+        return decodeRISCVFrameInvocation(label, length, cte, cap, call, buffer);
 
     case cap_asid_control_cap: {
         word_t     i;
@@ -1099,18 +1099,22 @@ exception_t performPageTableInvocationUnmap(cap_t cap, cte_t *ctSlot)
     return EXCEPTION_NONE;
 }
 
-static exception_t performPageGetAddress(void *vbase_ptr)
+static exception_t performPageGetAddress(void *vbase_ptr, bool_t call)
 {
-    paddr_t capFBasePtr;
-
     /* Get the physical address of this frame. */
+    paddr_t capFBasePtr;
     capFBasePtr = addrFromPPtr(vbase_ptr);
 
-    /* return it in the first message register */
-    setRegister(NODE_STATE(ksCurThread), msgRegisters[0], capFBasePtr);
-    setRegister(NODE_STATE(ksCurThread), msgInfoRegister,
-                wordFromMessageInfo(seL4_MessageInfo_new(0, 0, 0, 1)));
-
+    tcb_t *thread;
+    thread = NODE_STATE(ksCurThread);
+    if (call) {
+        word_t *ipcBuffer = lookupIPCBuffer(true, thread);
+        setRegister(thread, badgeRegister, 0);
+        unsigned int length = setMR(thread, ipcBuffer, 0, capFBasePtr);
+        setRegister(thread, msgInfoRegister, wordFromMessageInfo(
+                        seL4_MessageInfo_new(0, 0, 0, length)));
+    }
+    setThreadState(NODE_STATE(ksCurThread), ThreadState_Running);
     return EXCEPTION_NONE;
 }
 

--- a/src/arch/riscv/object/objecttype.c
+++ b/src/arch/riscv/object/objecttype.c
@@ -298,7 +298,7 @@ exception_t Arch_decodeInvocation(
     word_t *buffer
 )
 {
-    return decodeRISCVMMUInvocation(label, length, cptr, slot, cap, buffer);
+    return decodeRISCVMMUInvocation(label, length, cptr, slot, cap, call, buffer);
 }
 
 void Arch_prepareThreadDelete(tcb_t *thread)

--- a/src/arch/x86/32/kernel/vspace.c
+++ b/src/arch/x86/32/kernel/vspace.c
@@ -630,12 +630,13 @@ exception_t decodeX86ModeMMUInvocation(
     cptr_t cptr,
     cte_t *cte,
     cap_t cap,
+    bool_t call,
     word_t *buffer
 )
 {
     switch (cap_get_capType(cap)) {
     case cap_page_directory_cap:
-        return decodeIA32PageDirectoryInvocation(invLabel, length, cte, cap, buffer);
+        return decodeIA32PageDirectoryInvocation(invLabel, length, cte, cap, call, buffer);
 
     default:
         fail("Invalid arch cap type");

--- a/src/arch/x86/32/object/objecttype.c
+++ b/src/arch/x86/32/object/objecttype.c
@@ -196,6 +196,7 @@ exception_t Mode_decodeInvocation(
     cptr_t cptr,
     cte_t *slot,
     cap_t cap,
+    bool_t call,
     word_t *buffer
 )
 {
@@ -203,7 +204,7 @@ exception_t Mode_decodeInvocation(
     case cap_page_directory_cap:
     case cap_page_table_cap:
     case cap_frame_cap:
-        return decodeX86MMUInvocation(invLabel, length, cptr, slot, cap, buffer);
+        return decodeX86MMUInvocation(invLabel, length, cptr, slot, cap, call, buffer);
     default:
         current_syscall_error.type = seL4_InvalidCapability;
         current_syscall_error.invalidCapNumber = 0;

--- a/src/arch/x86/64/kernel/vspace.c
+++ b/src/arch/x86/64/kernel/vspace.c
@@ -1407,6 +1407,7 @@ exception_t decodeX86ModeMMUInvocation(
     cptr_t cptr,
     cte_t *cte,
     cap_t cap,
+    bool_t call,
     word_t *buffer
 )
 {

--- a/src/arch/x86/64/object/objecttype.c
+++ b/src/arch/x86/64/object/objecttype.c
@@ -320,6 +320,7 @@ exception_t Mode_decodeInvocation(
     cptr_t cptr,
     cte_t *slot,
     cap_t cap,
+    bool_t call,
     word_t *buffer
 )
 {
@@ -329,7 +330,7 @@ exception_t Mode_decodeInvocation(
     case cap_page_directory_cap:
     case cap_page_table_cap:
     case cap_frame_cap:
-        return decodeX86MMUInvocation(label, length, cptr, slot, cap, buffer);
+        return decodeX86MMUInvocation(label, length, cptr, slot, cap, call, buffer);
 
     default:
         current_syscall_error.type = seL4_InvalidCapability;

--- a/src/arch/x86/kernel/vspace.c
+++ b/src/arch/x86/kernel/vspace.c
@@ -15,21 +15,24 @@
 #include <mode/kernel/tlb.h>
 #include <mode/kernel/vspace.h>
 
-static exception_t performPageGetAddress(void *vbase_ptr)
+static exception_t performPageGetAddress(void *vbase_ptr, bool_t call)
 {
-    paddr_t capFBasePtr;
-
     /* Get the physical address of this frame. */
-    capFBasePtr = pptr_to_paddr(vbase_ptr);
+    paddr_t capFBasePtr;
+    capFBasePtr = addrFromPPtr(vbase_ptr);
 
-    /* return it in the first message register */
-    setRegister(NODE_STATE(ksCurThread), msgRegisters[0], capFBasePtr);
-    setRegister(NODE_STATE(ksCurThread), msgInfoRegister,
-                wordFromMessageInfo(seL4_MessageInfo_new(0, 0, 0, 1)));
-
+    tcb_t *thread;
+    thread = NODE_STATE(ksCurThread);
+    if (call) {
+        word_t *ipcBuffer = lookupIPCBuffer(true, thread);
+        setRegister(thread, badgeRegister, 0);
+        unsigned int length = setMR(thread, ipcBuffer, 0, capFBasePtr);
+        setRegister(thread, msgInfoRegister, wordFromMessageInfo(
+                        seL4_MessageInfo_new(0, 0, 0, length)));
+    }
+    setThreadState(NODE_STATE(ksCurThread), ThreadState_Running);
     return EXCEPTION_NONE;
 }
-
 
 void deleteASIDPool(asid_t asid_base, asid_pool_t *pool)
 {
@@ -926,6 +929,7 @@ exception_t decodeX86FrameInvocation(
     word_t length,
     cte_t *cte,
     cap_t cap,
+    bool_t call,
     word_t *buffer
 )
 {
@@ -1091,7 +1095,7 @@ exception_t decodeX86FrameInvocation(
         assert(n_msgRegisters >= 1);
 
         setThreadState(NODE_STATE(ksCurThread), ThreadState_Restart);
-        return performPageGetAddress((void *)cap_frame_cap_get_capFBasePtr(cap));
+        return performPageGetAddress((void *)cap_frame_cap_get_capFBasePtr(cap), call);
     }
 
     default:
@@ -1248,13 +1252,14 @@ exception_t decodeX86MMUInvocation(
     cptr_t cptr,
     cte_t *cte,
     cap_t cap,
+    bool_t call,
     word_t *buffer
 )
 {
     switch (cap_get_capType(cap)) {
 
     case cap_frame_cap:
-        return decodeX86FrameInvocation(invLabel, length, cte, cap, buffer);
+        return decodeX86FrameInvocation(invLabel, length, cte, cap, call, buffer);
 
     case cap_page_table_cap:
         return decodeX86PageTableInvocation(invLabel, length, cte, cap, buffer);
@@ -1396,6 +1401,6 @@ exception_t decodeX86MMUInvocation(
     }
 
     default:
-        return decodeX86ModeMMUInvocation(invLabel, length, cptr, cte, cap, buffer);
+        return decodeX86ModeMMUInvocation(invLabel, length, cptr, cte, cap, call, buffer);
     }
 }

--- a/src/arch/x86/object/objecttype.c
+++ b/src/arch/x86/object/objecttype.c
@@ -514,7 +514,7 @@ exception_t Arch_decodeInvocation(
     switch (cap_get_capType(cap)) {
     case cap_asid_control_cap:
     case cap_asid_pool_cap:
-        return decodeX86MMUInvocation(invLabel, length, cptr, slot, cap, buffer);
+        return decodeX86MMUInvocation(invLabel, length, cptr, slot, cap, call, buffer);
     case cap_io_port_control_cap:
         return decodeX86PortControlInvocation(invLabel, length, cptr, slot, cap, buffer);
     case cap_io_port_cap:
@@ -527,7 +527,7 @@ exception_t Arch_decodeInvocation(
 #endif
 #ifdef CONFIG_VTX
     case cap_vcpu_cap:
-        return decodeX86VCPUInvocation(invLabel, length, cptr, slot, cap, buffer);
+        return decodeX86VCPUInvocation(invLabel, length, cptr, slot, cap, call, buffer);
     case cap_ept_pml4_cap:
     case cap_ept_pdpt_cap:
     case cap_ept_pd_cap:
@@ -535,7 +535,7 @@ exception_t Arch_decodeInvocation(
         return decodeX86EPTInvocation(invLabel, length, cptr, slot, cap, buffer);
 #endif
     default:
-        return Mode_decodeInvocation(invLabel, length, cptr, slot, cap, buffer);
+        return Mode_decodeInvocation(invLabel, length, cptr, slot, cap, call, buffer);
     }
 }
 


### PR DESCRIPTION
This PR updates https://github.com/seL4/seL4/pull/243 to make it better conform to the reply convention. In particular, we introduce a `call` parameter to guard message register updates. We ignore `setConsumed` for now, which will be fixed in a future PR addressing the `isReceiver` parameter of IPC buffer lookups.

Signed-off-by: Ryan Barry <ryan.barry@proofcraft.systems>