### PR TITLE
cmake: support for supplying custom device trees

### DIFF
--- a/config.cmake
+++ b/config.cmake
@@ -92,6 +92,18 @@ include(src/arch/${KernelArch}/config.cmake)
 include(include/${KernelWordSize}/mode/config.cmake)
 include(src/config.cmake)
 
+set(KernelCustomDTS "" CACHE FILEPATH "Provide a device tree file to use instead of the \
+KernelPlatform's defaults")
+
+if(NOT "${KernelCustomDTS}" STREQUAL "")
+    if(NOT EXISTS ${KernelCustomDTS})
+        message(FATAL_ERROR "Can't open external dts file '${KernelCustomDTS}'!")
+    endif()
+    # Override list to hold only custom dts
+    set(KernelDTSList "${KernelCustomDTS}")
+    message(STATUS "Using custom ${KernelCustomDTS} device tree, ignoring default dts and overlays")
+endif()
+
 if(DEFINED KernelDTSList AND (NOT "${KernelDTSList}" STREQUAL ""))
     set(KernelDTSIntermediate "${CMAKE_CURRENT_BINARY_DIR}/kernel.dts")
     set(


### PR DESCRIPTION
Sometimes device trees may have differences between vanilla Linux and SoC vendor, and the changes can be tedious to override with a device tree overlay.

This change allows overriding the platform default dts and overlays with a custom dts.

It can be used together with `KernelCustomDTSOverlay` to pass custom base device tree and overlay.

For rpi4, we are using `linux-raspberrypi` kernel in guest VMs which contains quite many differences compared to dts in vanilla kernel. And that becomes a problem when passing through the devices to the guest. This change allows us to more easily manage and reason about the device trees used in a build without having to modify device trees in seL4 kernel.