### PR TITLE
Allow copy of untyped regions with children

### DIFF
--- a/src/object/objecttype.c
+++ b/src/object/objecttype.c
@@ -79,12 +79,8 @@ deriveCap_ret_t deriveCap(cte_t *slot, cap_t cap)
         break;
 
     case cap_untyped_cap:
-        ret.status = ensureNoChildren(slot);
-        if (ret.status != EXCEPTION_NONE) {
-            ret.cap = cap_null_cap_new();
-        } else {
-            ret.cap = cap;
-        }
+        ret.status = EXCEPTION_NONE;
+        ret.cap = cap;
         break;
 
 #ifndef CONFIG_KERNEL_MCS


### PR DESCRIPTION
The new cap is copied from the old one and thus it has the correct
FreeIndex. Nothing else is needed for correctness, as long as the
source cap gets marked full so that free space accounting is only
done on the newest cap.

Signed-off-by: Indan Zupancic <Indan.Zupancic@mep-info.com>