### PR TITLE
tools/bitfield_gen: ensure UTF-8 encoding

### DIFF
--- a/tools/bitfield_gen.py
+++ b/tools/bitfield_gen.py
@@ -2807,7 +2807,7 @@ class OutputFile(object):
             global temp_output_files
             temp_output_files.append(self)
         else:
-            self.file = open(filename, mode)
+            self.file = open(filename, mode, encoding="utf-8")
 
     def write(self, *args, **kwargs):
         self.file.write(*args, **kwargs)
@@ -2857,7 +2857,7 @@ if __name__ == '__main__':
 
     if len(args) > 0:
         in_filename = args[0]
-        in_file = open(in_filename)
+        in_file = open(in_filename, encoding="utf-8")
 
         if len(args) > 1:
             out_file = OutputFile(args[1])
@@ -2939,7 +2939,7 @@ if __name__ == '__main__':
 
         pruned_names = set()
         for filename in options.prune_files:
-            f = open(filename)
+            f = open(filename, encoding="utf-8")
             string = f.read()
 
             matched_tokens = set(search_re.findall(string))

--- a/tools/umm.py
+++ b/tools/umm.py
@@ -101,7 +101,7 @@ def paths_to_type(mp, f, start):
 
 
 def build_types(file):
-    in_file = open(file, 'r')
+    in_file = open(file, 'r', encoding='utf-8')
 
     lines = map(lambda x: x.rstrip(), in_file.readlines())
 


### PR DESCRIPTION
There are cases that reasonably require non-ASCII characters in the source code, hence tools/bitfield_gen.py must be able to handle them correctly. This commit makes sure the bitfield generator consistently opens all files with UTF-8 encoding.

This is a slightly tweaked version of #780 that applies UTF-8 encoding to all files the bitfield generator handles.
