### PR TITLE
smp: Address MCS timekeeping issues in ipiStallCoreCallback

### DIFF
--- a/src/smp/ipi.c
+++ b/src/smp/ipi.c
@@ -29,7 +29,14 @@ void ipiStallCoreCallback(bool_t irqPath)
     word_t cpu = getCurrentCPUIndex();
     clh_node_t *node = &big_kernel_lock.node[cpu];
 
-    if (clh_is_self_in_queue() && !irqPath) {
+    // There's 3 ways that this function can be called:
+    // - On the IRQ path where the lock isn't acquired
+    // - On the IRQ path where the lock is attempted to be acquired
+    // - On the non-IRQ path where the lock is attempted to be acquired
+    // !irqPath implies clh_is_self_in_queue()
+    assert(clh_is_self_in_queue() || irqPath);
+
+    if (!irqPath) {
         /* The current thread is running as we would replace this thread with an idle thread
          *
          * The instruction should be re-executed if we are in kernel to handle syscalls.

--- a/src/smp/ipi.c
+++ b/src/smp/ipi.c
@@ -133,6 +133,25 @@ void handleIPI(irq_t irq, bool_t irqPath)
 
     if (IRQT_TO_IRQ(irq) == irq_remote_call_ipi) {
         handleRemoteCall(ipi->remoteCall, ipi->args[0], ipi->args[1], ipi->args[2], irqPath);
+        if (irqPath) {
+#ifdef CONFIG_KERNEL_MCS
+            assert(!NODE_STATE(ksCurThread)->tcbYieldTo);
+            assert(NODE_STATE(ksReprogram) == false);
+#endif
+            assert(NODE_STATE(ksSchedulerAction) == SchedulerAction_ResumeCurrentThread);
+            assert(ARCH_NODE_STATE(ipiReschedulePending) == 0);
+            switch (thread_state_get_tsType(NODE_STATE(ksCurThread)->tcbState)) {
+                case ThreadState_Running:
+                case ThreadState_IdleThreadState:
+            #ifdef CONFIG_VTX
+                case ThreadState_RunningVM:
+            #endif
+            break;
+            default:
+                fail("Current thread is blocked");
+
+            }
+        }
     } else if (IRQT_TO_IRQ(irq) == irq_reschedule_ipi) {
         rescheduleRequired();
 #ifdef CONFIG_ARCH_RISCV

--- a/src/smp/ipi.c
+++ b/src/smp/ipi.c
@@ -21,6 +21,11 @@
  * or this call will idle forever */
 void ipiStallCoreCallback(bool_t irqPath)
 {
+    // ipiStallCore can only be called for a single core at a time to be able to assume
+    // kernel mutual exclusion as the caller node is blocked until this stall completes
+    // and all other nodes are out of the kernel or blocked on the lock.
+    assert(big_kernel_lock.ipi.totalCoreBarrier == 1);
+
     word_t cpu = getCurrentCPUIndex();
     clh_node_t *node = &big_kernel_lock.node[cpu];
 


### PR DESCRIPTION
Update (5.Mar.2025): With https://github.com/seL4/seL4/pull/867 being recently merged, this PR needs to be rebased. I think the top 5 commits are still worth reapplying so I'll keep the PR open. 
Because it's been so long since doing this work, I can't find the issue it was addressing. But essentially when a TCB with an SC on one core performs an operation that requires remotely stalling another core, the time consumed by this stall isn't properly accounted. But there's also some correctness bugs where some operations are performed outside of the kernel lock.