### PR TITLE
SMP: Improve kernel lock

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@ description indicates whether it is SOURCE-COMPATIBLE, BINARY-COMPATIBLE, or BRE
 * Added `zynqmp` and `rpi4` to the set of verified AArch64 configs.
 * riscv: Change default cmake options KernelRiscvExtF and KernelRiscvExtD from OFF to ON.
   Except for RISCV32 with LLVM clang enabled will default KernelRiscvExtD to OFF.
+* Multiple SMP related bugs fixed.
 
 ### Platforms
 


### PR DESCRIPTION
The main thing this achieves is reverting commit [3d2ae69f](https://github.com/seL4/seL4/commit/3d2ae69f9cb184c34b6b56d1365e57693e832db4) and fixing the underlaying delay problem properly.

CAS can take very long to finish on ARM if the exclusive reservation granule (ERG) is large for the platform, as any writes on other cores within up to 2Kb could make the CAS fail. The correct fix is to add padding around the global lock equal to ERG to make CAS fast, making the fudgy extra IPI check redundant.

This incorporates @kent-mcleod and @axel-h recent improvements to the kernel locking code.
