### PR TITLE
mcs: add AUXUPD and GHOSTUPD comments for verification

### DIFF
--- a/src/object/objecttype.c
+++ b/src/object/objecttype.c
@@ -573,10 +573,24 @@ cap_t createObject(object_t t, void *regionBase, word_t userSize, bool_t deviceM
 
 #ifdef CONFIG_KERNEL_MCS
     case seL4_SchedContextObject:
+        /** AUXUPD:
+            "(True,
+              ptr_retyps (refills_len (unat \<acute>userSize)
+                                      (size_of TYPE(sched_context_C))
+                                      (size_of TYPE(refill_C)))
+                         (Ptr ((ptr_val \<acute>regionBase) +
+                               word_of_nat (size_of TYPE(sched_context_C))) :: refill_C ptr)
+              \<circ> ptr_retyp (Ptr (ptr_val \<acute>regionBase) :: sched_context_C ptr))" */
+        /** GHOSTUPD:
+            "(True, gs_new_refill_buffer_length (ptr_val \<acute>regionBase)
+                                                (refills_len (unat \<acute>userSize)
+                                                             (size_of TYPE(sched_context_C))
+                                                             (size_of TYPE(refill_C))))" */
         memzero(regionBase, BIT(userSize));
         return cap_sched_context_cap_new(SC_REF(regionBase), userSize);
 
     case seL4_ReplyObject:
+        /** AUXUPD: "(True, ptr_retyp (Ptr (ptr_val \<acute>regionBase) :: reply_C ptr))" */
         memzero(regionBase, 1UL << seL4_ReplyBits);
         return cap_reply_cap_new(REPLY_REF(regionBase), true);
 #endif


### PR DESCRIPTION
This adds AUXUPD and GHOSTUPD comments to aid verification in
reasoning about the length and type of the refill buffer
associated with scheduling contexts

This also add a AUXUPD comment for replies

Signed-off-by: Michael McInerney <michael.mcinerney@proofcraft.systems>