### PR TITLE
ci: add MCS to preprocess-deploy

### DIFF
--- a/.github/workflows/preprocess-deploy.yml
+++ b/.github/workflows/preprocess-deploy.yml
@@ -31,11 +31,19 @@ jobs:
     strategy:
       matrix:
         arch: [ARM, ARM_HYP, AARCH64, RISCV64, X64]
-        # no MCS here, auto-updating mcs.xml should be a separate job.
+        feature: ["", MCS]
+        exclude:
+          - arch: ARM_HYP
+            feature: MCS
+          - arch: AARCH64
+            feature: MCS
+          - arch: X64
+            feature: MCS
     steps:
     - uses: seL4/ci-actions/preprocess@master
       with:
         L4V_ARCH: ${{ matrix.arch }}
+        L4V_FEATURES: ${{ matrix.feature }}
 
   deploy:
     name: Deploy manifest


### PR DESCRIPTION
This commit will cause the preprocess-deploy workflow to fail if there
are changes to the preprocessed seL4 sources in MCS configurations
covered by the proofs. This means that changes to proof-relevant MCS
configurations will require a manual verification manifest update.

Previously, only non-MCS configurations were covered, which meant that
new verification manifests would be automatically deployed even if there
were proof-relevant changes to MCS code.