### PR TITLE
Small common_riscv.lds improvements

### DIFF
--- a/src/arch/arm/common_arm.lds
+++ b/src/arch/arm/common_arm.lds
@@ -59,7 +59,7 @@ SECTIONS
         *(.data)
     }
 
-    .bss . : AT(ADDR(.bss) - KERNEL_OFFSET)
+    .bss . (NOLOAD): AT(ADDR(.bss) - KERNEL_OFFSET)
     {
         *(.bss)
         *(COMMON) /* fallback in case '-fno-common' is not used */

--- a/src/arch/riscv/common_riscv.lds
+++ b/src/arch/riscv/common_riscv.lds
@@ -72,6 +72,12 @@ SECTIONS
         *(.data)
     }
 
+    /* The kernel's idle thread section contains no code or data. */
+    ._idle_thread . (NOLOAD): AT(ADDR(._idle_thread) - KERNEL_OFFSET)
+    {
+        *(._idle_thread)
+    }
+
     .bss . : AT(ADDR(.bss) - KERNEL_OFFSET)
     {
         *(.bss)

--- a/src/arch/riscv/common_riscv.lds
+++ b/src/arch/riscv/common_riscv.lds
@@ -78,7 +78,7 @@ SECTIONS
         *(._idle_thread)
     }
 
-    .bss . : AT(ADDR(.bss) - KERNEL_OFFSET)
+    .bss . (NOLOAD): AT(ADDR(.bss) - KERNEL_OFFSET)
     {
         *(.bss)
         *(COMMON) /* fallback in case '-fno-common' is not used */

--- a/src/arch/riscv/common_riscv.lds
+++ b/src/arch/riscv/common_riscv.lds
@@ -33,6 +33,10 @@ SECTIONS
     {
         *(.boot.data)
     }
+    .boot.bss . : AT(ADDR(.boot.bss) - KERNEL_OFFSET)
+    {
+        *(.boot.bss)
+    }
     . = ALIGN(4K);
 
     ki_boot_end = .;


### PR DESCRIPTION
- Move the .boot.bss section into the range of memory that can be reclaimed after boot.
- Mark the idle thread symbol as NOLOAD to avoid it taking up space in the ELF file. 