### PR TITLE
RPi3/4 updates and fixes

### DIFF
--- a/src/plat/bcm2711/overlay-rpi4-address-mapping.dts
+++ b/src/plat/bcm2711/overlay-rpi4-address-mapping.dts
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2021, Hensoldt Cyber GmbH
+ * Copyright 2022, Technology Innovation Institute
  *
  * SPDX-License-Identifier: GPL-2.0-only
  */
@@ -17,9 +18,6 @@
 	 * addresses in this overlay file.
 	 */
 	soc {
-		gpio@7e200000 {
-			reg = <0xfe200000 0xb4>;
-		};
 
 		serial@7e201400 {
 			reg = <0xfe201400 0x200>;

--- a/src/plat/bcm2711/overlay-rpi4-address-mapping.dts
+++ b/src/plat/bcm2711/overlay-rpi4-address-mapping.dts
@@ -18,6 +18,13 @@
 	 * addresses in this overlay file.
 	 */
 	soc {
+		timer@7e003000 {
+			reg = <0xfe003000 0x1000>;
+			/* Channels 0 and 2 used by VC, so just expose 1 and
+			 * 3. Otherwise we're spammed with spurious
+			 * interrupts. */
+			interrupts = <0x00 0x41 0x04 0x00 0x43 0x04>;
+		};
 
 		serial@7e201400 {
 			reg = <0xfe201400 0x200>;

--- a/src/plat/bcm2711/overlay-rpi4.dts
+++ b/src/plat/bcm2711/overlay-rpi4.dts
@@ -23,7 +23,7 @@
 	 * https://github.com/raspberrypi/firmware/issues/1374 for
 	 * reference.
 	 *
-	 * RPi4B seems to be in "low peripheral" mode by default.
+	 * RPi4B runs in "low peripheral" mode by default.
 	 * These values were observed from running
 	 * Raspbian instance from /proc/iomem and /sys/firmware/devicetree/base
 	 *
@@ -37,36 +37,18 @@
 	 * 0x01 0x00000000 0x80000000  2048MB
 	 * 0x01 0x80000000 0x80000000  2048MB
 	 *
-	 * Disjunct memory areas seem to work only
-	 * when declared in different memory DT nodes.
-	 *
-	 * If all of the declarations below are in the
-	 * same node, the kernel build system seems
-	 * to only understand the second 3008MB area
-	 * and ignores the rest.
 	 */
 
 	/delete-node/ memory;
 
 	memory@0 {
 		device_type = "memory";
-		reg = < 0x00000000 0x00000000 0x3b400000 >;
-	};
-
-	memory@40000000 {
-		device_type = "memory";
-		reg = < 0x00000000 0x40000000 0xbc000000 >;
-	};
-
-	memory@100000000 {
-		device_type = "memory";
-		reg = < 0x00000001 0x00000000 0x80000000
+		reg = < 0x00000000 0x00000000 0x3b400000
+			0x00000000 0x40000000 0xbc000000
+			0x00000001 0x00000000 0x80000000
 			0x00000001 0x80000000 0x80000000 >;
 	};
 
-	/* TODO: add DMA dedicated ranges
-	 * here also?
-	 */
 	reserved-memory {
 		#address-cells = <0x02>;
 		#size-cells = <0x01>;
@@ -93,7 +75,7 @@
 		 * by declaring it as reserved memory.
 		 */
 		reserved-memory@3b400000 {
-			reg = < 0x00000000 0x3b400000 0x04C00000 >;
+			reg = < 0x00000000 0x3b400000 0x04c00000 >;
 			no-map;
 		};
 	};

--- a/src/plat/bcm2711/overlay-rpi4.dts
+++ b/src/plat/bcm2711/overlay-rpi4.dts
@@ -1,6 +1,7 @@
 /*
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  * Copyright (C) 2021, Hensoldt Cyber GmbH
+ * Copyright 2021, Technology Innovation Institute
  *
  * SPDX-License-Identifier: GPL-2.0-only
  */
@@ -20,5 +21,26 @@
 	memory@0 {
 		/* This is configurable in the Pi's config.txt, but we use 128MiB of RAM by default. */
 		reg = <0x00 0x00000000 0x08000000>;
+	};
+
+	reserved-memory {
+		#address-cells = <0x01>;
+		#size-cells = <0x01>;
+		ranges;
+		/* Keep the first page of physical memory is reserved for the initial
+		 * bootloader (e.g. armstub). It has parked the secondary cores there,
+		 * they spin until they get released. When SMP is enabled, the kernel
+		 * will release them during boot and this memory can be reused.
+		 * However, we still have to ensure the kernel image itself is not
+		 * placed here. In non-SMP configurations, the cores must keep spinning
+		 * forever. Re-using this memory will cause the secondary cores to
+		 * execute whatever content is placed there, which likely makes them
+		 * run amok.
+		 * See also https://leiradel.github.io/2019/01/20/Raspberry-Pi-Stubs.html#armstub8s
+		 */
+		reserved-memory@0{
+			reg = <0x0 0x1000>;
+			no-map;
+		};
 	};
 };

--- a/src/plat/bcm2711/overlay-rpi4.dts
+++ b/src/plat/bcm2711/overlay-rpi4.dts
@@ -18,15 +18,60 @@
 		    &{/timer};
 	};
 
+	/*
+	 * See BCM2711 TRM section 1.2 and
+	 * https://github.com/raspberrypi/firmware/issues/1374 for
+	 * reference.
+	 *
+	 * RPi4B seems to be in "low peripheral" mode by default.
+	 * These values were observed from running
+	 * Raspbian instance from /proc/iomem and /sys/firmware/devicetree/base
+	 *
+	 * By default, the RPi 4B has 76MB reserved for the VideoCore/GPU.
+	 * So, we have following memory ranges available:
+	 *
+	 * VC GPU RAM 76MB -> 0x40000000-0x04C00000 = 0x3b400000
+	 *
+	 * 0x00 0x00000000 0x3b400000  948MB
+	 * 0x00 0x40000000 0xbc000000  3008MB
+	 * 0x01 0x00000000 0x80000000  2048MB
+	 * 0x01 0x80000000 0x80000000  2048MB
+	 *
+	 * Disjunct memory areas seem to work only
+	 * when declared in different memory DT nodes.
+	 *
+	 * If all of the declarations below are in the
+	 * same node, the kernel build system seems
+	 * to only understand the second 3008MB area
+	 * and ignores the rest.
+	 */
+
+	/delete-node/ memory;
+
 	memory@0 {
-		/* This is configurable in the Pi's config.txt, but we use 128MiB of RAM by default. */
-		reg = <0x00 0x00000000 0x08000000>;
+		device_type = "memory";
+		reg = < 0x00000000 0x00000000 0x3b400000 >;
 	};
 
+	memory@40000000 {
+		device_type = "memory";
+		reg = < 0x00000000 0x40000000 0xbc000000 >;
+	};
+
+	memory@100000000 {
+		device_type = "memory";
+		reg = < 0x00000001 0x00000000 0x80000000
+			0x00000001 0x80000000 0x80000000 >;
+	};
+
+	/* TODO: add DMA dedicated ranges
+	 * here also?
+	 */
 	reserved-memory {
-		#address-cells = <0x01>;
+		#address-cells = <0x02>;
 		#size-cells = <0x01>;
 		ranges;
+
 		/* Keep the first page of physical memory is reserved for the initial
 		 * bootloader (e.g. armstub). It has parked the secondary cores there,
 		 * they spin until they get released. When SMP is enabled, the kernel
@@ -39,7 +84,16 @@
 		 * See also https://leiradel.github.io/2019/01/20/Raspberry-Pi-Stubs.html#armstub8s
 		 */
 		reserved-memory@0{
-			reg = <0x0 0x1000>;
+			reg = < 0x00000000 0x00000000 0x00001000 >;
+			no-map;
+		};
+
+		/* Enforce that nothing tries to
+		 * use the VideoCore memory area
+		 * by declaring it as reserved memory.
+		 */
+		reserved-memory@3b400000 {
+			reg = < 0x00000000 0x3b400000 0x04C00000 >;
 			no-map;
 		};
 	};

--- a/src/plat/bcm2837/overlay-rpi3.dts
+++ b/src/plat/bcm2837/overlay-rpi3.dts
@@ -41,4 +41,14 @@
 			no-map;
 		};
 	};
+
+        soc {
+                timer@7e003000 {
+                        reg = <0x3F003000 0x1000>;
+			/* Channels 0 and 2 used by VC, so just expose 1 and
+			 * 3. Otherwise we're spammed with spurious
+			 * interrupts. */
+                        interrupts = <0x01 0x01 0x01 0x03>;
+                };
+        };
 };

--- a/tools/dts/rpi4.dts
+++ b/tools/dts/rpi4.dts
@@ -42,11 +42,6 @@
 			linux,cma-default;
 			alloc-ranges = <0x00 0x00 0x40000000>;
 		};
-
-		vc_mem {
-			size = <0xc0000000>;
-			alloc-ranges = <0x00 0x3ec00000 0xc0000000>;
-		};
 	};
 
 	thermal-zones {

--- a/tools/dts/rpi4.dts
+++ b/tools/dts/rpi4.dts
@@ -42,6 +42,11 @@
 			linux,cma-default;
 			alloc-ranges = <0x00 0x00 0x40000000>;
 		};
+
+		vc_mem {
+			size = <0xc0000000>;
+			alloc-ranges = <0x00 0x3ec00000 0xc0000000>;
+		};
 	};
 
 	thermal-zones {

--- a/tools/dts/rpi4.dts
+++ b/tools/dts/rpi4.dts
@@ -924,8 +924,6 @@
 			interrupts = <0x00 0x5d 0x04>;
 			clocks = <0x0c 0x00>;
 			status = "okay";
-			pinctrl-names = "default";
-			pinctrl-0 = <0x0d>;
 		};
 
 		spi@7e215080 {


### PR DESCRIPTION
This PR adds tested working DTS memory map for RPi4,
and DTS overrides for RPi3/4 so that the timer component
for TImeServer can be created directly from device tree.

Also system timer interrupts are fixed to avoid spurious
interrupts.

Test with: seL4/util_libs#140