### PR TITLE
Add new model_id for recent Skylake

### DIFF
--- a/include/arch/x86/arch/machine.h
+++ b/include/arch/x86/arch/machine.h
@@ -55,6 +55,7 @@
  */
 #define SKYLAKE_1_MODEL_ID      0x4E
 #define SKYLAKE_2_MODEL_ID      0x5E
+#define SKYLAKE_X_MODEL_ID      0x55
 #define BROADWELL_1_MODEL_ID    0x4D
 #define BROADWELL_2_MODEL_ID    0x56
 #define BROADWELL_3_MODEL_ID    0x4F

--- a/src/arch/x86/kernel/boot_sys.c
+++ b/src/arch/x86/kernel/boot_sys.c
@@ -270,6 +270,7 @@ static BOOT_CODE bool_t is_compiled_for_microarchitecture(void)
     switch (model_info->model) {
     case SKYLAKE_1_MODEL_ID:
     case SKYLAKE_2_MODEL_ID:
+    case SKYLAKE_X_MODEL_ID:
         if (microarch_generation > 7) {
             return false;
         }

--- a/src/plat/pc99/machine/ioapic.c
+++ b/src/plat/pc99/machine/ioapic.c
@@ -63,6 +63,12 @@ static void single_ioapic_init(word_t ioapic, cpu_id_t delivery_cpu)
     nirqs = (ioapic_read(ioapic, IOAPIC_WINDOW) >> 16) + 1;
     ioapic_nirqs[ioapic] = nirqs;
 
+    /*
+     * All current implementations have 24 or fewer lines
+     * Protect against the future one that may have more
+     */
+    assert(nirqs <= IOAPIC_IRQ_LINES);
+
     /* Mask all the IRQs. In doing so we happen to set
      * the vector to 0, which we can assert against in
      * mask_interrupt to ensure a vector is assigned


### PR DESCRIPTION
Recent skylake processors use a different model_id.  
Add it to the list that seL4 understands.

Signed-of-by: Peter Chubb <peter.chubb@unsw.edu.au>