### PR TITLE
Add newer Skylake model ID

### DIFF
--- a/include/arch/x86/arch/machine.h
+++ b/include/arch/x86/arch/machine.h
@@ -55,6 +55,7 @@
  */
 #define SKYLAKE_1_MODEL_ID      0x4E
 #define SKYLAKE_2_MODEL_ID      0x5E
+#define SKYLAKE_X_MODEL_ID      0x55
 #define BROADWELL_1_MODEL_ID    0x4D
 #define BROADWELL_2_MODEL_ID    0x56
 #define BROADWELL_3_MODEL_ID    0x4F

--- a/src/arch/x86/kernel/boot_sys.c
+++ b/src/arch/x86/kernel/boot_sys.c
@@ -270,6 +270,7 @@ static BOOT_CODE bool_t is_compiled_for_microarchitecture(void)
     switch (model_info->model) {
     case SKYLAKE_1_MODEL_ID:
     case SKYLAKE_2_MODEL_ID:
+    case SKYLAKE_X_MODEL_ID:
         if (microarch_generation > 7) {
             return false;
         }


### PR DESCRIPTION
At least some server-class Skylake processors use 0x55 as
their model ID.
These are Skylake X processors.

Signed-off-by: Peter Chubb <peter.chubb@unsw.edu.au>