### PR TITLE
Fix gcc-12 spurious array bounds warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,6 +202,10 @@ add_compile_options(
     # - https://gcc.gnu.org/gcc-10/changes.html
     # - https://releases.llvm.org/11.0.0/tools/clang/docs/ReleaseNotes.html
     -fno-common
+    # gcc-12 assumes pointers into the first page are always errors.
+    # Allow low pointers by making the assumed page size 0.
+    --param=min-pagesize=0
+
 )
 
 # Linker parameters. There are two kinds actually:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,10 +202,6 @@ add_compile_options(
     # - https://gcc.gnu.org/gcc-10/changes.html
     # - https://releases.llvm.org/11.0.0/tools/clang/docs/ReleaseNotes.html
     -fno-common
-    # gcc-12 assumes pointers into the first page are always errors.
-    # Allow low pointers by making the assumed page size 0.
-    --param=min-pagesize=0
-
 )
 
 # Linker parameters. There are two kinds actually:

--- a/src/arch/x86/kernel/cmdline.c
+++ b/src/arch/x86/kernel/cmdline.c
@@ -108,11 +108,13 @@ void cmdline_parse(const char *cmdline, cmdline_opt_t *cmdline_opt)
 #if defined(CONFIG_PRINTING) || defined(CONFIG_DEBUG_BUILD)
     /* use BIOS data area to read serial configuration. The BDA is not
      * fully standardized and parts are absolete. See http://wiki.osdev.org/Memory_Map_(x86)#BIOS_Data_Area_.28BDA.29
-     * for an explanation */
-/*
- * gcc-12 gives array bounds warning (treated as errors by the  build system)
- * for any address below 4096.  Turn that off fo accessing the BIOS area.
- */
+     * for an explanation
+     */
+    /*
+     * gcc-12 gives array bounds warning (treated as errors by the
+     * build system) for any address below 4096.  Turn that off for
+     * accessing the BIOS area.
+     */
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"
 

--- a/src/arch/x86/kernel/cmdline.c
+++ b/src/arch/x86/kernel/cmdline.c
@@ -109,7 +109,9 @@ void cmdline_parse(const char *cmdline, cmdline_opt_t *cmdline_opt)
     /* use BIOS data area to read serial configuration. The BDA is not
      * fully standardized and parts are absolete. See http://wiki.osdev.org/Memory_Map_(x86)#BIOS_Data_Area_.28BDA.29
      * for an explanation */
-#pragma  GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+
     const unsigned short *bda_port = (unsigned short *)0x400;
     const unsigned short *bda_equi = (unsigned short *)0x410;
     int const bda_ports_count       = (*bda_equi >> 9) & 0x7;
@@ -155,5 +157,4 @@ void cmdline_parse(const char *cmdline, cmdline_opt_t *cmdline_opt)
     cmdline_opt->disable_iommu = parse_bool(cmdline, cmdline_str_disable_iommu);
     printf("Boot config: disable_iommu = %s\n", cmdline_opt->disable_iommu ? "true" : "false");
 }
-
 #pragma GCC diagnostic pop

--- a/src/arch/x86/kernel/cmdline.c
+++ b/src/arch/x86/kernel/cmdline.c
@@ -109,6 +109,7 @@ void cmdline_parse(const char *cmdline, cmdline_opt_t *cmdline_opt)
     /* use BIOS data area to read serial configuration. The BDA is not
      * fully standardized and parts are absolete. See http://wiki.osdev.org/Memory_Map_(x86)#BIOS_Data_Area_.28BDA.29
      * for an explanation */
+#pragma  GCC diagnostic ignored "-Warray-bounds"
     const unsigned short *bda_port = (unsigned short *)0x400;
     const unsigned short *bda_equi = (unsigned short *)0x410;
     int const bda_ports_count       = (*bda_equi >> 9) & 0x7;
@@ -154,3 +155,5 @@ void cmdline_parse(const char *cmdline, cmdline_opt_t *cmdline_opt)
     cmdline_opt->disable_iommu = parse_bool(cmdline, cmdline_str_disable_iommu);
     printf("Boot config: disable_iommu = %s\n", cmdline_opt->disable_iommu ? "true" : "false");
 }
+
+#pragma GCC diagnostic pop

--- a/src/arch/x86/kernel/cmdline.c
+++ b/src/arch/x86/kernel/cmdline.c
@@ -109,6 +109,10 @@ void cmdline_parse(const char *cmdline, cmdline_opt_t *cmdline_opt)
     /* use BIOS data area to read serial configuration. The BDA is not
      * fully standardized and parts are absolete. See http://wiki.osdev.org/Memory_Map_(x86)#BIOS_Data_Area_.28BDA.29
      * for an explanation */
+/*
+ * gcc-12 gives array bounds warning (treated as errors by the  build system)
+ * for any address below 4096.  Turn that off fo accessing the BIOS area.
+ */
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"
 

--- a/src/arch/x86/kernel/cmdline.c
+++ b/src/arch/x86/kernel/cmdline.c
@@ -152,9 +152,9 @@ void cmdline_parse(const char *cmdline, cmdline_opt_t *cmdline_opt)
         x86KSdebugPort = cmdline_opt->debug_port;
         printf("Boot config: debug_port = 0x%x\n", cmdline_opt->debug_port);
     }
+#pragma GCC diagnostic pop
 #endif
 
     cmdline_opt->disable_iommu = parse_bool(cmdline, cmdline_str_disable_iommu);
     printf("Boot config: disable_iommu = %s\n", cmdline_opt->disable_iommu ? "true" : "false");
 }
-#pragma GCC diagnostic pop


### PR DESCRIPTION
Issue #875 shows how gcc-12 is much more aggressive in
array bounds checking.  By lying to gcc and telling it the
page size is zero, the warning can be avoided.

Signed-off-by: Peter Chubb <peter.chubb@unsw.edu.au>