### PR TITLE
mcs: remove unused tcbReply field from tcb struct

### DIFF
--- a/include/object/structures.h
+++ b/include/object/structures.h
@@ -300,10 +300,6 @@ struct tcb {
     struct tcb *tcbEPNext;
     struct tcb *tcbEPPrev;
 
-#ifdef CONFIG_KERNEL_MCS
-    /* if tcb is in a call, pointer to the reply object, 1 word */
-    reply_t *tcbReply;
-#endif
 #ifdef CONFIG_BENCHMARK_TRACK_UTILISATION
     /* 16 bytes (12 bytes aarch32) */
     benchmark_util_t benchmark;


### PR DESCRIPTION
The pointer to a reply object, if any, can be accessed via the replyObject in the thread state

Signed-off-by: Michael McInerney <michael.mcinerney@proofcraft.systems>