### PR TITLE
boot: Check that predicted page tables were used

### DIFF
--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -832,6 +832,12 @@ BOOT_CODE bool_t create_untypeds(cap_t root_cnode_cap)
 
 BOOT_CODE void bi_finalise(void)
 {
+
+    if (rootserver.paging.start != rootserver.paging.end) {
+        printf("WARNING: internal book keeping errror. Less pagetables allocated than predicted: "
+               "%ld page tables allocated but not used.\n", (rootserver.paging.end - rootserver.paging.start) >> seL4_PageTableBits);
+    }
+
     ndks_boot.bi_frame->empty = (seL4_SlotRegion) {
         .start = ndks_boot.slot_pos_cur,
         .end   = BIT(CONFIG_ROOT_CNODE_SIZE_BITS)


### PR DESCRIPTION
During boot, all dynamic memory allocated by the kernel is precalculated and then allocated in one chunk. The precalculation is supposed to match the allocation logic precisely which means any left over objects indicated an inconsistency between the precalculation and reality. The kernel should print an error and potentially abort if it encounters this situation.

I noticed that there's a page table calculation error in vtd_get_n_paging for calculating page tables required to map iommu reserved regions that over estimates the number of page tables required quite significantly (for example 14337 extra tables on the haswell test machines we use).  This check should detect any other similar calculation errors in the startup paths that we test. 

