### PR TITLE
remove redundant definitions

### DIFF
--- a/src/machine/capdl.c
+++ b/src/machine/capdl.c
@@ -106,18 +106,14 @@ void obj_tcb_print_attrs(tcb_t *tcb)
 
 #ifdef CONFIG_KERNEL_MCS
 
-/* to make compilers happy */
-#define REFILL_INDEX(sc, index) (((refill_t *) (SC_REF(sc) + sizeof(sched_context_t)))[index])
-#define REFILL_HEAD(sc) REFILL_INDEX((sc), (sc)->scRefillHead)
-
 static inline ticks_t sc_get_budget(sched_context_t *sc)
 {
-    ticks_t sum = REFILL_HEAD(sc).rAmount;
+    ticks_t sum = refill_head(sc)->rAmount;
     word_t current = sc->scRefillHead;
 
     while (current != sc->scRefillTail) {
         current = ((current == sc->scRefillMax - 1u) ? (0) : current + 1u);
-        sum += REFILL_INDEX(sc, current).rAmount;
+        sum += refill_index(sc, current)->rAmount;
     }
 
     return sum;


### PR DESCRIPTION
Commit b181184d75a4a74509b95d19ded54f445b3bd538 turned the macro `REFILL_HEAD` into a function `refill_head()` in `include/kernel/sporadic.h`. It seems that commit a403d0d66c9fc1ec7593de965dd6fc4cb4ccc6fd created `capdl.c` in a parallel branch, so so `REFILL_HEAD` was added here again. This is not necessary, `refill_head()` can be used because we include `include/kernel/sporadic.h`.

The preprocess/AARCH64 error seem to come from the changes of https://github.com/seL4/seL4/pull/911, where an update is still missing.