### PR TITLE
trivial: fix typo

### DIFF
--- a/src/arch/arm/64/head.S
+++ b/src/arch/arm/64/head.S
@@ -71,7 +71,7 @@ BEGIN_FUNC(_start)
     mov     x7, x4
     mov     x8, x5
 
-    /* Make sure interrupts are disable */
+    /* Make sure interrupts are disabled */
     msr daifset, #DAIFSET_MASK
 
     /* Initialise sctlr_el1 or sctlr_el2 register */


### PR DESCRIPTION
The preprocess/AARCH64 error seem to come from the changes of https://github.com/seL4/seL4/pull/911, where an update is still missing.