### PR TITLE
boot: remove unused return values

### DIFF
--- a/include/kernel/boot.h
+++ b/include/kernel/boot.h
@@ -48,7 +48,7 @@ cap_t create_root_cnode(void);
 bool_t provide_cap(cap_t root_cnode_cap, cap_t cap);
 cap_t create_it_asid_pool(cap_t root_cnode_cap);
 void write_it_pd_pts(cap_t root_cnode_cap, cap_t it_pd_cap);
-bool_t create_idle_thread(void);
+void create_idle_thread(void);
 bool_t create_untypeds(cap_t root_cnode_cap, region_t boot_mem_reuse_reg);
 void bi_finalise(void);
 void create_domain_cap(cap_t root_cnode_cap);

--- a/src/arch/arm/kernel/boot.c
+++ b/src/arch/arm/kernel/boot.c
@@ -543,10 +543,7 @@ static BOOT_CODE bool_t try_init_kernel(
 #endif
 
     /* create the idle thread */
-    if (!create_idle_thread()) {
-        printf("ERROR: could not create idle thread\n");
-        return false;
-    }
+    create_idle_thread();
 
     /* Before creating the initial thread (which also switches to it)
      * we clean the cache so that any page table information written

--- a/src/arch/riscv/kernel/boot.c
+++ b/src/arch/riscv/kernel/boot.c
@@ -395,10 +395,7 @@ static BOOT_CODE bool_t try_init_kernel(
 #endif
 
     /* create the idle thread */
-    if (!create_idle_thread()) {
-        printf("ERROR: could not create idle thread\n");
-        return false;
-    }
+    create_idle_thread();
 
     /* create the initial thread */
     tcb_t *initial = create_initial_thread(

--- a/src/arch/x86/kernel/boot.c
+++ b/src/arch/x86/kernel/boot.c
@@ -299,9 +299,7 @@ BOOT_CODE bool_t init_sys_state(
 #endif
 
     /* create the idle thread */
-    if (!create_idle_thread()) {
-        return false;
-    }
+    create_idle_thread();
 
     /* create the initial thread */
     tcb_t *initial = create_initial_thread(root_cnode_cap,


### PR DESCRIPTION
Remove the return value from `configure_sched_context()`, because it never fails. As a consequence, `create_idle_thread()` also never fails and does not need a return value.