### PR TITLE
use types time_t and tickts_t properly

### DIFF
--- a/include/api/types.h
+++ b/include/api/types.h
@@ -20,6 +20,11 @@
 /* seL4_CapRights_t defined in mode/api/shared_types.bf */
 
 typedef word_t prio_t;
+
+/* The kernel uses ticks_t internally to represent time to make it easy to
+ * interact with hardware timers. The userland API uses time in micro seconds,
+ * which is represented by time_t in the kernel.
+ */
 typedef uint64_t ticks_t;
 typedef uint64_t time_t;
 

--- a/include/arch/arm/arch/32/mode/machine/timer.h
+++ b/include/arch/arm/arch/32/mode/machine/timer.h
@@ -16,7 +16,9 @@
  * CLK_MAGIC and TIMER_CLOCK_MHZ -- these definitions might need to move
  * if we come across an arm platform that does not suit this model */
 
-/* get the max value ticksToUs can be passed without overflowing */
+/* Get the max. ticks_t value that can be expressed in time_t (time in us). This
+ * is the max. value ticksToUs() can be passed without overflowing.
+ */
 static inline CONST ticks_t getMaxTicksToUs(void)
 {
 #if USE_KHZ

--- a/include/arch/arm/arch/64/mode/machine/timer.h
+++ b/include/arch/arm/arch/64/mode/machine/timer.h
@@ -12,6 +12,10 @@
 #include <util.h>
 
 /* timer function definitions that work for all 64 bit arm platforms */
+
+/* Get the max. ticks_t value that can be expressed in time_t (time in us). This
+ * is the max. value ticksToUs() can be passed without overflowing.
+ */
 static inline CONST ticks_t getMaxTicksToUs(void)
 {
 #if USE_KHZ

--- a/include/arch/arm/arch/machine/timer.h
+++ b/include/arch/arm/arch/machine/timer.h
@@ -26,7 +26,9 @@
 
 void initTimer(void);
 
-/* get the max value usToTicks can be passed without overflowing */
+/* Get the max. time_t value (time in us) that can be expressed in ticks_t. This
+ * is the max. value usToTicks() can be passed without overflowing.
+ */
 static inline CONST time_t getMaxUsToTicks(void)
 {
 #if USE_KHZ
@@ -40,7 +42,7 @@ static inline CONST ticks_t usToTicks(time_t us)
 {
 #if USE_KHZ
     /* reciprocal division overflows too quickly for dividing by KHZ_IN_MHZ.
-     * This operation isn't  used frequently or on many platforms, so use manual
+     * This operation isn't used frequently or on many platforms, so use manual
      * division here */
     return div64(us * TIMER_CLOCK_KHZ, KHZ_IN_MHZ);
 #else

--- a/include/arch/riscv/arch/machine/timer.h
+++ b/include/arch/riscv/arch/machine/timer.h
@@ -37,11 +37,17 @@ static inline PURE ticks_t getTimerPrecision(void)
     return usToTicks(1);
 }
 
+/* Get the max. ticks_t value that can be expressed in time_t (time in us). This
+ * is the max. value ticksToUs() can be passed without overflowing.
+ */
 static inline CONST ticks_t getMaxTicksToUs(void)
 {
     return UINT64_MAX;
 }
 
+/* Get the max. time_t value (time in us) that can be expressed in ticks_t. This
+ * is the max. value usToTicks() can be passed without overflowing.
+ */
 static inline CONST time_t getMaxUsToTicks(void)
 {
     return UINT64_MAX / TICKS_IN_US;

--- a/include/arch/x86/arch/machine/timer.h
+++ b/include/arch/x86/arch/machine/timer.h
@@ -25,6 +25,9 @@ static inline PURE ticks_t usToTicks(time_t us)
     return us * x86KStscMhz;
 }
 
+/* Get the max. time_t value (time in us) that can be expressed in ticks_t. This
+ * is the max. value usToTicks() can be passed without overflowing.
+ */
 static inline PURE time_t getMaxUsToTicks(void)
 {
     return div64(UINT64_MAX, x86KStscMhz);
@@ -44,6 +47,9 @@ static inline ticks_t getCurrentTime(void)
     return x86_rdtsc();
 }
 
+/* Get the max. ticks_t value that can be expressed in time_t (time in us). This
+ * is the max. value ticksToUs() can be passed without overflowing.
+ */
 static inline CONST ticks_t getMaxTicksToUs(void)
 {
     return UINT64_MAX;

--- a/include/kernel/thread.h
+++ b/include/kernel/thread.h
@@ -230,10 +230,10 @@ void chargeBudget(ticks_t consumed, bool_t canTimeoutFault);
  */
 static inline void updateTimestamp(void)
 {
-    time_t prev = NODE_STATE(ksCurTime);
+    ticks_t prev = NODE_STATE(ksCurTime);
     NODE_STATE(ksCurTime) = getCurrentTime();
     assert(NODE_STATE(ksCurTime) < MAX_RELEASE_TIME);
-    time_t consumed = (NODE_STATE(ksCurTime) - prev);
+    ticks_t consumed = (NODE_STATE(ksCurTime) - prev);
     NODE_STATE(ksConsumed) += consumed;
     if (numDomains > 1) {
         if ((consumed + MIN_BUDGET) >= ksDomainTime) {

--- a/include/model/statedata.h
+++ b/include/model/statedata.h
@@ -65,8 +65,8 @@ NODE_STATE_DECLARE(tcb_t, *ksSchedulerAction);
 
 #ifdef CONFIG_KERNEL_MCS
 NODE_STATE_DECLARE(tcb_t, *ksReleaseHead);
-NODE_STATE_DECLARE(time_t, ksConsumed);
-NODE_STATE_DECLARE(time_t, ksCurTime);
+NODE_STATE_DECLARE(ticks_t, ksConsumed);
+NODE_STATE_DECLARE(ticks_t, ksCurTime);
 NODE_STATE_DECLARE(bool_t, ksReprogram);
 NODE_STATE_DECLARE(sched_context_t, *ksCurSC);
 NODE_STATE_DECLARE(sched_context_t, *ksIdleSC);

--- a/src/config/default_domain.c
+++ b/src/config/default_domain.c
@@ -8,7 +8,7 @@
 #include <object/structures.h>
 #include <model/statedata.h>
 
-/* Default schedule. */
+/* Default schedule. The length is in ms */
 const dschedule_t ksDomSchedule[] = {
     { .domain = 0, .length = 1 },
 };

--- a/src/kernel/thread.c
+++ b/src/kernel/thread.c
@@ -574,8 +574,8 @@ void postpone(sched_context_t *sc)
 
 void setNextInterrupt(void)
 {
-    time_t next_interrupt = NODE_STATE(ksCurTime) +
-                            refill_head(NODE_STATE(ksCurThread)->tcbSchedContext)->rAmount;
+    ticks_t next_interrupt = NODE_STATE(ksCurTime) +
+                             refill_head(NODE_STATE(ksCurThread)->tcbSchedContext)->rAmount;
 
     if (numDomains > 1) {
         next_interrupt = MIN(next_interrupt, NODE_STATE(ksCurTime) + ksDomainTime);

--- a/src/machine/capdl.c
+++ b/src/machine/capdl.c
@@ -122,11 +122,13 @@ static inline ticks_t sc_get_budget(sched_context_t *sc)
 void obj_sc_print_attrs(cap_t sc_cap)
 {
     sched_context_t *sc = SC_PTR(cap_sched_context_cap_get_capSCPtr(sc_cap));
-    printf("(period: %lu, budget: %lu, %lu bits)\n",
-           (long unsigned int)ticksToUs(sc->scPeriod),
-           (long unsigned int)ticksToUs(sc_get_budget(sc)),
-           (word_t)cap_sched_context_cap_get_capSCSizeBits(sc_cap)
-          );
+    ticks_t period = sc->scPeriod;
+    ticks_t budget = sc_get_budget(sc);
+    printf("(period: %"PRIu64" us (%"PRIu64" ticks), budget: %"PRIu64 " us "
+           "(%"PRIu64" ticks), %"SEL4_PRIu_word" bits)\n",
+           ticksToUs(period), period,
+           ticksToUs(budget), budget,
+           (word_t)cap_sched_context_cap_get_capSCSizeBits(sc_cap));
 }
 #endif /* CONFIG_KERNEL_MCS */
 


### PR DESCRIPTION
- doc: improve comments
- use types time_t and tickts_t properly, currently the semantics are incorrect
- print period and budget with units

The PR in seL4_libs is not necessary, it's just another bit of semantic cleanup. 