### PR TITLE
cmake: add a sanity check

### DIFF
--- a/configs/seL4Config.cmake
+++ b/configs/seL4Config.cmake
@@ -60,6 +60,8 @@ macro(declare_seL4_arch sel4_arch)
         config_set(KernelWordSize WORD_SIZE 64)
         set(Kernel64 ON CACHE INTERNAL "")
         set(Kernel32 OFF CACHE INTERNAL "")
+    else()
+        message(FATAL_ERROR "unsupported seL4 architecture: '${sel4_arch}'")
     endif()
 
 endmacro()


### PR DESCRIPTION
Ensure the configuration is within the expectation. This catches potential porting problems early, and avoids quite odd errors and undefined behavior later on that is more difficult to understand.