### PR TITLE
aarch32: fix define check for debug feature

### DIFF
--- a/include/arch/arm/arch/32/mode/fastpath/fastpath.h
+++ b/include/arch/arm/arch/32/mode/fastpath/fastpath.h
@@ -118,7 +118,7 @@ static inline void NORETURN FORCE_INLINE fastpath_restore(word_t badge, word_t m
 
     c_exit_hook();
 
-#ifdef CONFIG_ARM_CP14_SAVE_AND_RESTORE_NATIVE_THREADS
+#ifdef ARM_CP14_SAVE_AND_RESTORE_NATIVE_THREADS
     restore_user_debug_context(NODE_STATE(ksCurThread));
 #endif
 


### PR DESCRIPTION
From reviewing the code, I think the refactoring of commit https://github.com/seL4/seL4/commit/4b491dcf0c2c19860c5c9b503539bf0e9b0d1667 picked the wrong define name here. In `include/arch/arm/arch/machine/debug_conf.h` the define `ARM_CP14_SAVE_AND_RESTORE_NATIVE_THREADS` is created. This change aligns the code with what  `restore_user_context()` does.

I have no setup to test this change at the moment. Given this exists since 2017 I assume nobody else is actively using this feature and could run a quick test?