### PR TITLE
fastpatch: use thread passed as parameter

### DIFF
--- a/include/arch/arm/arch/32/mode/fastpath/fastpath.h
+++ b/include/arch/arm/arch/32/mode/fastpath/fastpath.h
@@ -119,11 +119,11 @@ static inline void NORETURN FORCE_INLINE fastpath_restore(word_t badge, word_t m
     c_exit_hook();
 
 #ifdef CONFIG_ARM_CP14_SAVE_AND_RESTORE_NATIVE_THREADS
-    restore_user_debug_context(NODE_STATE(ksCurThread));
+    restore_user_debug_context(cur_thread);
 #endif
 
 #ifdef CONFIG_HAVE_FPU
-    lazyFPURestore(NODE_STATE(ksCurThread));
+    lazyFPURestore(cur_thread);
 #endif /* CONFIG_HAVE_FPU */
 
     register word_t badge_reg asm("r0") = badge;

--- a/include/arch/arm/arch/64/mode/fastpath/fastpath.h
+++ b/include/arch/arm/arch/64/mode/fastpath/fastpath.h
@@ -103,7 +103,7 @@ static inline void NORETURN FORCE_INLINE fastpath_restore(word_t badge, word_t m
     c_exit_hook();
 
 #ifdef CONFIG_HAVE_FPU
-    lazyFPURestore(NODE_STATE(ksCurThread));
+    lazyFPURestore(cur_thread);
 #endif /* CONFIG_HAVE_FPU */
 
     register word_t badge_reg asm("x0") = badge;

--- a/include/arch/riscv/arch/fastpath/fastpath.h
+++ b/include/arch/riscv/arch/fastpath/fastpath.h
@@ -108,8 +108,8 @@ static inline void NORETURN FORCE_INLINE fastpath_restore(word_t badge, word_t m
     c_exit_hook();
 
 #ifdef CONFIG_HAVE_FPU
-    lazyFPURestore(NODE_STATE(ksCurThread));
-    set_tcb_fs_state(NODE_STATE(ksCurThread), isFpuEnable());
+    lazyFPURestore(cur_thread);
+    set_tcb_fs_state(cur_thread, isFpuEnable());
 #endif
 
     register word_t badge_reg asm("a0") = badge;


### PR DESCRIPTION
Use the thread passed as parameter instead of making assumption that this is in sync with the global state.

Using `NODE_STATE(ksCurThread)` feels semantically wrong when `cur_thread` is passed to the function. It seems this function is not supposed to ever be called with `cur_thread` being different to `NODE_STATE(ksCurThread)`, so I wonder if an explicit assert in the code should be added then to state this (and catch potential copy/paste porting errors).
