### PR TITLE
user proper field from thread context structure

### DIFF
--- a/include/arch/arm/arch/32/mode/fastpath/fastpath.h
+++ b/include/arch/arm/arch/32/mode/fastpath/fastpath.h
@@ -128,7 +128,7 @@ static inline void NORETURN FORCE_INLINE fastpath_restore(word_t badge, word_t m
 
     register word_t badge_reg asm("r0") = badge;
     register word_t msgInfo_reg asm("r1") = msgInfo;
-    register word_t cur_thread_reg asm("r2") = (word_t)cur_thread;
+    register word_t cur_thread_reg asm("r2") = (word_t)cur_thread->tcbArch.tcbContext.registers;
 
     if (config_set(CONFIG_ARM_HYPERVISOR_SUPPORT)) {
         asm volatile( /* r0 and r1 should be preserved */

--- a/include/arch/riscv/arch/fastpath/fastpath.h
+++ b/include/arch/riscv/arch/fastpath/fastpath.h
@@ -98,11 +98,13 @@ static inline void NORETURN FORCE_INLINE fastpath_restore(word_t badge, word_t m
 {
     NODE_UNLOCK_IF_HELD;
 
+    word_t cur_thread_regs = (word_t)cur_thread->tcbArch.tcbContext.registers;
+
 #ifdef ENABLE_SMP_SUPPORT
     word_t sp;
     asm volatile("csrr %0, sscratch" : "=r"(sp));
     sp -= sizeof(word_t);
-    *((word_t *)sp) = TCB_REF(cur_thread);
+    *((word_t *)sp) = cur_thread_regs;
 #endif
 
     c_exit_hook();
@@ -114,7 +116,7 @@ static inline void NORETURN FORCE_INLINE fastpath_restore(word_t badge, word_t m
 
     register word_t badge_reg asm("a0") = badge;
     register word_t msgInfo_reg asm("a1") = msgInfo;
-    register word_t cur_thread_reg asm("t0") = TCB_REF(cur_thread);
+    register word_t cur_thread_reg asm("t0") = cur_thread_regs;
 
     asm volatile(
         LOAD_S "  ra, (0*%[REGSIZE])(t0)  \n"


### PR DESCRIPTION
The thread context structure layout is explicitly designed to have the register context first, as this simplifies saving the user context on entry in assembly code. On the exit path there is no need to hard-code this assumption, stick to the semantics and leave details to the compiler.