### PR TITLE
risc-v: remove K constraint in fcsr access wrapper

### DIFF
--- a/include/arch/riscv/arch/machine.h
+++ b/include/arch/riscv/arch/machine.h
@@ -141,12 +141,12 @@ static inline void clearMemory(void *ptr, unsigned int bits)
 
 static inline void write_satp(word_t value)
 {
-    asm volatile("csrw satp, %0" :: "rK"(value));
+    asm volatile("csrw satp, %0" :: "r"(value));
 }
 
 static inline void write_stvec(word_t value)
 {
-    asm volatile("csrw stvec, %0" :: "rK"(value));
+    asm volatile("csrw stvec, %0" :: "r"(value));
 }
 
 static inline word_t read_stval(void)
@@ -199,13 +199,13 @@ static inline word_t read_sie(void)
 static inline void set_sie_mask(word_t mask_high)
 {
     word_t temp;
-    asm volatile("csrrs %0, sie, %1" : "=r"(temp) : "rK"(mask_high));
+    asm volatile("csrrs %0, sie, %1" : "=r"(temp) : "r"(mask_high));
 }
 
 static inline void clear_sie_mask(word_t mask_low)
 {
     word_t temp;
-    asm volatile("csrrc %0, sie, %1" : "=r"(temp) : "rK"(mask_low));
+    asm volatile("csrrc %0, sie, %1" : "=r"(temp) : "r"(mask_low));
 }
 
 #ifdef CONFIG_HAVE_FPU
@@ -218,7 +218,7 @@ static inline uint32_t read_fcsr(void)
 
 static inline void write_fcsr(uint32_t value)
 {
-    asm volatile("csrw fcsr, %0" :: "rK"(value));
+    asm volatile("csrw fcsr, %0" :: "r"(value));
 }
 #endif
 


### PR DESCRIPTION
The 'K' constraint is for 5-bit unsigned integer immediate operands only in both GCC and LLVM. It does not apply to the value written.

See manuals:
- https://llvm.org/docs/LangRef.html#supported-constraint-code-list
-  https://gcc.gnu.org/onlinedocs/gcc/Machine-Constraints.html

In the Linux kernel there is this the commit https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/arch/riscv/include/asm/csr.h?id=5d8544e2d0075a5f3c9a2cf27152354d54360da1 that adds the 'K' constraint, which might explain the origin. Even if this has never been change, I still think this is incorrect usage.
