### PR TITLE
gcc: add x86 cross-compiler for arm host

### DIFF
--- a/gcc.cmake
+++ b/gcc.cmake
@@ -109,6 +109,9 @@ if("${CROSS_COMPILER_PREFIX}" STREQUAL "")
         if(CMAKE_HOST_APPLE)
             # CMAKE_HOST_APPLE is a CMake variable that evaluates to True on a Mac OSX system
             FindPrefixedGCC(CROSS_COMPILER_PREFIX "x86_64-linux-gnu-" "x86_64-unknown-linux-gnu-")
+        elseif("${CMAKE_HOST_SYSTEM_PROCESSOR}" STREQUAL "aarch64")
+            # If we're on an aarch64 host, gcc won't support x86. Set an x86 compatible toolchain
+            FindPrefixedGCC(CROSS_COMPILER_PREFIX "x86_64-linux-gnu-" "x86_64-unknown-linux-gnu-")
         endif()
     endif()
 endif()


### PR DESCRIPTION
When compiling in the Docker container on an M1 MacBook, or any other ARM host, the CMAKE_HOST_APPLE variable is not set. Therefore, no CROSS_COMPILER_PREFIX is set and x86 applications will not compile.

This commit adds another check to see if the host processor is an ARM chipset, and sets the appropriate CROSS_COMPILER_PREFIX variable.

M1 docker issues described here: https://github.com/seL4/seL4-CAmkES-L4v-dockerfiles/issues/40