### PR TITLE
Polarfire fixes

### DIFF
--- a/src/plat/polarfire/config.cmake
+++ b/src/plat/polarfire/config.cmake
@@ -16,7 +16,7 @@ if(KernelPlatformPolarfire)
     list(APPEND KernelDTSList "tools/dts/mpfs_icicle.dts")
     list(APPEND KernelDTSList "src/plat/polarfire/overlay-polarfire.dts")
     declare_default_headers(
-        TIMER_FREQUENCY 10000000 PLIC_MAX_NUM_INT 186
+        TIMER_FREQUENCY 1000000 PLIC_MAX_NUM_INT 186
         INTERRUPT_CONTROLLER drivers/irq/riscv_plic0.h
     )
 else()

--- a/tools/dts/mpfs_icicle.dts
+++ b/tools/dts/mpfs_icicle.dts
@@ -465,7 +465,8 @@
 
 	timer0: timer@20125000 {
 		compatible = "timer";
-                reg = <0x0 20125000 0x0 0x400>;
+                status = "okay";
+                reg = <0x0 20125000 0x0 0x1000>;
                 interrupt-parent = <&L1>;
                 interrupts = <82 83>;
                 timer-width = < 0x20 >;

--- a/tools/dts/mpfs_icicle.dts
+++ b/tools/dts/mpfs_icicle.dts
@@ -466,7 +466,7 @@
 	timer0: timer@20125000 {
 		compatible = "timer";
                 status = "okay";
-                reg = <0x0 20125000 0x0 0x1000>;
+                reg = <0x0 0x20125000 0x0 0x1000>;
                 interrupt-parent = <&L1>;
                 interrupts = <82 83>;
                 timer-width = < 0x20 >;


### PR DESCRIPTION
A few small commits fixing the timer node in the device tree and the TIMER_FREQUENCY in the config for the polarfire platform.