### PR TITLE
gic_v3: Clear the correct EOImode bit number

### DIFF
--- a/src/arch/arm/machine/gic_v3.c
+++ b/src/arch/arm/machine/gic_v3.c
@@ -277,7 +277,7 @@ BOOT_CODE static void cpu_iface_init(void)
 
     /* EOI drops priority and deactivates the interrupt: ICC_CTLR_EL1 */
     SYSTEM_READ_WORD(ICC_CTLR_EL1, icc_ctlr);
-    icc_ctlr &= ~BIT(GICC_CTLR_EL1_EOImode_drop);
+    icc_ctlr &= ~GICC_CTLR_EL1_EOImode_drop;
     SYSTEM_WRITE_WORD(ICC_CTLR_EL1, icc_ctlr);
 
     /* Enable Group1 interrupts: ICC_IGRPEN1_EL1 */


### PR DESCRIPTION
BIT(BIT(...)) results on the wrong bit number

Signed-off-by: Jorge Pereira <jorgepereira89@gmail.com>