### PR TITLE
boot/arm: remove activate_global_pd usage

### DIFF
--- a/include/arch/arm/arch/64/mode/kernel/vspace.h
+++ b/include/arch/arm/arch/64/mode/kernel/vspace.h
@@ -11,7 +11,6 @@
 #include <api/failures.h>
 #include <object/structures.h>
 
-#define activate_global_pd activate_kernel_vspace
 #define MODE_RESERVED 0
 
 /* ==================== BOOT CODE FINISHES HERE ==================== */

--- a/include/arch/arm/arch/kernel/vspace.h
+++ b/include/arch/arm/arch/kernel/vspace.h
@@ -21,7 +21,7 @@ cap_t create_mapped_it_frame_cap(cap_t pd_cap, pptr_t pptr, vptr_t vptr, asid_t 
 
 void map_kernel_window(void);
 void map_kernel_frame(paddr_t paddr, pptr_t vaddr, vm_rights_t vm_rights, vm_attributes_t vm_attributes);
-void activate_global_pd(void);
+void activate_kernel_vspace(void);
 void write_it_asid_pool(cap_t it_ap_cap, cap_t it_pd_cap);
 
 /* ==================== BOOT CODE FINISHES HERE ==================== */

--- a/src/arch/arm/32/kernel/vspace.c
+++ b/src/arch/arm/32/kernel/vspace.c
@@ -542,7 +542,7 @@ BOOT_CODE cap_t create_mapped_it_frame_cap(cap_t pd_cap, pptr_t pptr, vptr_t vpt
 
 #ifndef CONFIG_ARM_HYPERVISOR_SUPPORT
 
-BOOT_CODE void activate_global_pd(void)
+BOOT_CODE void activate_kernel_vspace(void)
 {
     /* Ensure that there's nothing stale in newly-mapped regions, and
        that everything we've written (particularly the kernel page tables)
@@ -556,7 +556,7 @@ BOOT_CODE void activate_global_pd(void)
 
 #else
 
-BOOT_CODE void activate_global_pd(void)
+BOOT_CODE void activate_kernel_vspace(void)
 {
     uint32_t r;
     /* Ensure that there's nothing stale in newly-mapped regions, and

--- a/src/arch/arm/kernel/boot.c
+++ b/src/arch/arm/kernel/boot.c
@@ -179,7 +179,7 @@ BOOT_CODE static bool_t init_cpu(void)
     }
 #endif
 
-    activate_global_pd();
+    activate_kernel_vspace();
     if (config_set(CONFIG_ARM_HYPERVISOR_SUPPORT)) {
         vcpu_boot_init();
     }


### PR DESCRIPTION
`activate_global_pd` is just an alias for `activate_kernel_vspace` nowadays. Seems the C parts is trivial, not sure about the impact on the proofs.
