### PR TITLE
zynq7000: fix DTS overlay on MCS

### DIFF
--- a/src/plat/zynq7000/mcs-overlay-zynq7000.dts
+++ b/src/plat/zynq7000/mcs-overlay-zynq7000.dts
@@ -6,6 +6,9 @@
 
 / {
     chosen {
+        seL4,elfloader-devices =
+            "serial0",
+            &{/amba/slcr@f8000000/rstc@200};
         seL4,kernel-devices =
             "serial0",
             &{/amba/interrupt-controller@f8f01000},


### PR DESCRIPTION
Apply changes from commit 0f619780 for MCS also. Without them there is no output visible when running e.g. sel4test (tested on QEMU only)