### PR TITLE
risc-v: support rv32 targets for qemu-riscv-virt

### DIFF
--- a/include/drivers/irq/riscv_plic0.h
+++ b/include/drivers/irq/riscv_plic0.h
@@ -69,12 +69,12 @@
 
 
 
-static inline uint32_t readl(uint64_t addr)
+static inline uint32_t readl(word_t addr)
 {
     return *((volatile uint32_t *)(addr));
 }
 
-static inline void writel(uint32_t val, uint64_t addr)
+static inline void writel(uint32_t val, word_t addr)
 {
     *((volatile uint32_t *)(addr)) = val;
 }
@@ -136,7 +136,7 @@ static inline void plic_complete_claim(irq_t irq)
 
 static inline void plic_mask_irq(bool_t disable, irq_t irq)
 {
-    uint64_t addr = 0;
+    word_t addr = 0;
     uint32_t val = 0;
     uint32_t bit = 0;
 

--- a/src/plat/qemu-riscv-virt/config.cmake
+++ b/src/plat/qemu-riscv-virt/config.cmake
@@ -90,10 +90,19 @@ if(KernelPlatformQEMURiscVVirt)
             endif()
 
             if(NOT DEFINED QEMU_MEMORY)
-                # Having 3 GiB of memory as default seems a good trade-off. It's
-                # sufficient for test/demo systems, but still something the host
-                # can provide without running short on resources.
-                set(QEMU_MEMORY "3072")
+                if(KernelSel4ArchRiscV32)
+                    # The memory starts at 2 GiB (0x80000000), so 2 GiB can be
+                    # accessed using 32-bit addresses. While RV32's Sv32 MMU
+                    # scheme supports accessing a 34-bit physical address space,
+                    # the 32-bit version of seL4 can access physical addresses
+                    # in the 32-bit range only.
+                    set(QEMU_MEMORY "2048")
+                else()
+                    # Having 3 GiB of memory as default seems a good trade-off.
+                    # It's sufficient for test/demo systems, but still something
+                    # the host can provide without running short on resources.
+                    set(QEMU_MEMORY "3072")
+                endif()
             endif()
 
             if(KernelMaxNumNodes)


### PR DESCRIPTION
Fix a build breaker.

Test with: seL4/ci-actions#234