### PR TITLE
update versions for GitHub actions + Isabelle

### DIFF
--- a/.github/workflows/compilation-checks.yml
+++ b/.github/workflows/compilation-checks.yml
@@ -26,7 +26,7 @@ jobs:
           - arch: RISCV64
             compiler: llvm
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: seL4/ci-actions/standalone-kernel@master
       with:
         ARCH: ${{ matrix.arch }}

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: seL4/ci-actions/seL4-manual@master
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: PDF
         path: manual/manual.pdf

--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -46,7 +46,7 @@ jobs:
         AWS_SSH: ${{ secrets.AWS_SSH }}
         GH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
     - name: Upload logs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: logs-${{ matrix.arch }}
         path: logs.tar.xz

--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -37,7 +37,7 @@ jobs:
       uses: seL4/ci-actions/aws-proofs@master
       with:
         L4V_ARCH: ${{ matrix.arch }}
-        isa_branch: ts-2021-1
+        isa_branch: ts-2022
         session: ${{ matrix.session }}
         manifest: default.xml
       env:

--- a/.github/workflows/sel4bench-pr.yml
+++ b/.github/workflows/sel4bench-pr.yml
@@ -49,7 +49,7 @@ jobs:
         xml: ${{ needs.code.outputs.xml }}
         march: ${{ matrix.march }}
     - name: Upload images
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: images-${{ matrix.march }}
         path: '*-images.tar.gz'
@@ -80,7 +80,7 @@ jobs:
     concurrency: sel4bench-hw-pr-${{ github.event.number }}-${{ strategy.job-index }}
     steps:
       - name: Get machine queue
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: seL4/machine_queue
           path: machine_queue
@@ -91,7 +91,7 @@ jobs:
         with:
           platform: ${{ matrix.platform }}
       - name: Download image
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: images-${{ steps.plat.outputs.march }}
       - name: Run
@@ -103,7 +103,7 @@ jobs:
         env:
           HW_SSH: ${{ secrets.HW_SSH }}
       - name: Upload results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           # funky expression below is to work around lack of ternary operator
           name: sel4bench-results-${{ matrix.platform }}${{ matrix.req != '' && format('-{0}', matrix.req) || '' }}

--- a/.github/workflows/sel4test-deploy.yml
+++ b/.github/workflows/sel4test-deploy.yml
@@ -71,7 +71,7 @@ jobs:
         march: ${{ matrix.march }}
         compiler: ${{ matrix.compiler }}
     - name: Upload images
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: images-${{ matrix.march }}-${{ matrix.compiler }}
         path: '*-images.tar.gz'
@@ -98,13 +98,13 @@ jobs:
     concurrency: hw-run-${{ strategy.job-index }}
     steps:
       - name: Get machine queue
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: seL4/machine_queue
           path: machine_queue
           token: ${{ secrets.PRIV_REPO_TOKEN }}
       - name: Download image
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: images-${{ matrix.march }}-${{ matrix.compiler }}
       - name: Run

--- a/.github/workflows/sel4test-hw.yml
+++ b/.github/workflows/sel4test-hw.yml
@@ -46,7 +46,7 @@ jobs:
         compiler: ${{ matrix.compiler }}
         sha: ${{ github.event.pull_request.head.sha }}
     - name: Upload images
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: images-${{ matrix.march }}-${{ matrix.compiler }}
         path: '*-images.tar.gz'
@@ -78,13 +78,13 @@ jobs:
       matrix: ${{ fromJson(needs.the_matrix.outputs.matrix) }}
     steps:
       - name: Get machine queue
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: seL4/machine_queue
           path: machine_queue
           token: ${{ secrets.PRIV_REPO_TOKEN }}
       - name: Download image
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: images-${{ matrix.march }}-${{ matrix.compiler }}
       - name: Run

--- a/.github/workflows/xml_lint.yml
+++ b/.github/workflows/xml_lint.yml
@@ -31,7 +31,7 @@ jobs:
       run: sudo apt-get update
     - name: install xmllint
       run: sudo apt-get install libxml2-utils
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: run xmllint
       run: |
         find libsel4 -name "sel4*.xml" | \


### PR DESCRIPTION
- update GitHub action versions, because the old ones are now deprecated
- update Isabelle to 2022 version