### PR TITLE
mcs: remove redundant memzero from createObject

### DIFF
--- a/src/object/objecttype.c
+++ b/src/object/objecttype.c
@@ -582,12 +582,10 @@ cap_t createObject(object_t t, void *regionBase, word_t userSize, bool_t deviceM
                                word_of_nat (size_of TYPE(sched_context_C))) :: refill_C ptr)
               \<circ> ptr_retyp (Ptr (ptr_val \<acute>regionBase) :: sched_context_C ptr))" */
         /** GHOSTUPD: "(True, gs_new_sc_size (ptr_val \<acute>regionBase) (unat \<acute>userSize))" */
-        memzero(regionBase, BIT(userSize));
         return cap_sched_context_cap_new(SC_REF(regionBase), userSize);
 
     case seL4_ReplyObject:
         /** AUXUPD: "(True, ptr_retyp (Ptr (ptr_val \<acute>regionBase) :: reply_C ptr))" */
-        memzero(regionBase, 1UL << seL4_ReplyBits);
         return cap_reply_cap_new(REPLY_REF(regionBase), true);
 #endif
 


### PR DESCRIPTION
This removes a memzero call from the seL4_SchedContextObject and seL4_ReplyObject cases of createObject. The memory is now cleared via clearMemory within resetUntypedCap

Signed-off-by: Michael McInerney <michael.mcinerney@proofcraft.systems>