### PR TITLE
manual: Fix a typo in threads.tex

### DIFF
--- a/manual/parts/threads.tex
+++ b/manual/parts/threads.tex
@@ -596,7 +596,7 @@ the thread. The contents of the IPC message are given below.\\
 \textbf{Meaning} & \textbf{IPC buffer location} \\
 \midrule
     Program counter to restart execution at. & \ipcbloc{seL4\_VMFault\_IP} \\
-Address that caused the fault. & \ipcbloc{seL4\_VMFault\_SP} \\
+Address that caused the fault. & \ipcbloc{seL4\_VMFault\_Addr} \\
     Instruction fault (1 if the fault was caused by an instruction fetch). & \ipcbloc{seL4\_VMFault\_PrefetchFault}  \\
 Fault status register (FSR). Contains information about the cause of the fault. Architecture dependent. & \ipcbloc{seL4\_VMFault\_FSR} \\
 \bottomrule


### PR DESCRIPTION
👋 In the following table, an undefined field `seL4_VMFault_SP` is referenced despite `seL4_VMFault_Addr` is not documented here. I guess it's just a typo.

<img width="632" alt="Screenshot 2023-01-07 at 21 28 22" src="https://user-images.githubusercontent.com/5053714/211150622-be054492-a1b3-42ec-b332-07d1855eccf9.png">
