### PR TITLE
libsel4: use `LIBSEL4_INLINE_FUNC` attributes for `seL4_NBWait`

### DIFF
--- a/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/syscalls.h
+++ b/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/syscalls.h
@@ -223,7 +223,7 @@ LIBSEL4_INLINE_FUNC seL4_MessageInfo_t seL4_WaitWithMRs(seL4_CPtr src, seL4_Word
     return info;
 }
 
-static inline seL4_MessageInfo_t seL4_NBWait(seL4_CPtr src, seL4_Word *sender)
+LIBSEL4_INLINE_FUNC seL4_MessageInfo_t seL4_NBWait(seL4_CPtr src, seL4_Word *sender)
 {
     seL4_MessageInfo_t info;
     seL4_Word badge;


### PR DESCRIPTION
Currently, building `libsel4` as a static library with `KernelIsMCS` enabled fails with the following error:

```
/path/to/build/sel4/libsel4/include/sel4/sel4_arch/syscalls.h:226:34: error: static declaration of 'seL4_NBWait' follows non-static declaration
/path/to/build/sel4/libsel4/include/sel4/syscalls_mcs.h:251:1: note: previous declaration is here`
```

This [was mentioned][1] in the original PR that modified exported functions to use `LIBSEL4_INLINE_FUNC`.

[1]: https://github.com/seL4/seL4/pull/101#issuecomment-442010551

Signed-off-by: Klim Tsoutsman <klim@tsoutsman.com>