### PR TITLE
Prevent overmapping on aarch32, aarch64, x86

### DIFF
--- a/include/arch/x86/arch/kernel/vspace.h
+++ b/include/arch/x86/arch/kernel/vspace.h
@@ -90,7 +90,7 @@ void unmapPage(vm_page_size_t page_size, asid_t asid, vptr_t vptr, void *pptr);
 /* returns whether the translation was removed and needs to be flushed from the hardware (i.e. tlb) */
 bool_t modeUnmapPage(vm_page_size_t page_size, vspace_root_t *vroot, vptr_t vptr, void *pptr);
 exception_t decodeX86ModeMapPage(word_t invLabel, vm_page_size_t page_size, cte_t *cte, cap_t cap,
-                                 vspace_root_t *vroot, vptr_t vptr, paddr_t paddr, vm_rights_t vm_rights, vm_attributes_t vm_attr);
+                                 vspace_root_t *vroot, vptr_t vptr, paddr_t paddr, vm_rights_t vm_rights, vm_attributes_t vm_attr, asid_t frame_asid);
 void setVMRoot(tcb_t *tcb);
 bool_t CONST isValidVTableRoot(cap_t cap);
 bool_t CONST isValidNativeRoot(cap_t cap);

--- a/include/arch/x86/arch/kernel/vspace.h
+++ b/include/arch/x86/arch/kernel/vspace.h
@@ -90,7 +90,7 @@ void unmapPage(vm_page_size_t page_size, asid_t asid, vptr_t vptr, void *pptr);
 /* returns whether the translation was removed and needs to be flushed from the hardware (i.e. tlb) */
 bool_t modeUnmapPage(vm_page_size_t page_size, vspace_root_t *vroot, vptr_t vptr, void *pptr);
 exception_t decodeX86ModeMapPage(word_t invLabel, vm_page_size_t page_size, cte_t *cte, cap_t cap,
-                                 vspace_root_t *vroot, vptr_t vptr, paddr_t paddr, vm_rights_t vm_rights, vm_attributes_t vm_attr, asid_t frame_asid);
+                                 vspace_root_t *vroot, vptr_t vptr, paddr_t paddr, vm_rights_t vm_rights, vm_attributes_t vm_attr, bool_t is_remap);
 void setVMRoot(tcb_t *tcb);
 bool_t CONST isValidVTableRoot(cap_t cap);
 bool_t CONST isValidNativeRoot(cap_t cap);

--- a/src/arch/arm/32/kernel/vspace.c
+++ b/src/arch/arm/32/kernel/vspace.c
@@ -1662,7 +1662,11 @@ createSafeMappingEntries_PTE
 
         /* Check that we are not overwriting an existing mapping */
         if (pte_ptr_get_pteType(ret.pte_entries.base) != pte_pte_invalid) {
+#ifndef CONFIG_ARM_HYPERVISOR_SUPPORT   
             paddr_t pte_paddr = pte_pte_large_ptr_get_address(ret.pte_entries.base);
+#else
+            paddr_t pte_paddr = pte_pte_small_ptr_get_address(ret.pte_entries.base);
+#endif
             if (pte_paddr && frame_asid == asidInvalid) {
                 userError("Virtual address already mapped");
                 current_syscall_error.type = seL4_DeleteFirst;

--- a/src/arch/arm/32/kernel/vspace.c
+++ b/src/arch/arm/32/kernel/vspace.c
@@ -1561,7 +1561,7 @@ typedef struct create_mappings_pde_return create_mappings_pde_return_t;
 static create_mappings_pte_return_t
 createSafeMappingEntries_PTE
 (paddr_t base, word_t vaddr, vm_page_size_t frameSize,
- vm_rights_t vmRights, vm_attributes_t attr, pde_t *pd)
+ vm_rights_t vmRights, vm_attributes_t attr, pde_t *pd, asid_t frame_asid)
 {
 
     create_mappings_pte_return_t ret;
@@ -1607,6 +1607,17 @@ createSafeMappingEntries_PTE
             return ret;
         }
 
+        /* Check that we are not overwriting an existing mapping */
+        if (pte_ptr_get_pteType(ret.pte_entries.base) != pte_pte_invalid) {
+            paddr_t pte_paddr = pte_pte_small_ptr_get_address(ret.pte_entries.base);
+            if (pte_paddr && frame_asid == asidInvalid) {
+                userError("Virtual address already mapped");
+                current_syscall_error.type = seL4_DeleteFirst;
+                ret.status = EXCEPTION_SYSCALL_ERROR;
+                return ret;
+            }  
+        }
+
         ret.status = EXCEPTION_NONE;
         return ret;
 
@@ -1649,6 +1660,17 @@ createSafeMappingEntries_PTE
             }
         }
 
+        /* Check that we are not overwriting an existing mapping */
+        if (pte_ptr_get_pteType(ret.pte_entries.base) != pte_pte_invalid) {
+            paddr_t pte_paddr = pte_pte_large_ptr_get_address(ret.pte_entries.base);
+            if (pte_paddr && frame_asid == asidInvalid) {
+                userError("Virtual address already mapped");
+                current_syscall_error.type = seL4_DeleteFirst;
+                ret.status = EXCEPTION_SYSCALL_ERROR;
+                return ret;
+            }
+        }
+
         ret.status = EXCEPTION_NONE;
         return ret;
 
@@ -1661,7 +1683,7 @@ createSafeMappingEntries_PTE
 static create_mappings_pde_return_t
 createSafeMappingEntries_PDE
 (paddr_t base, word_t vaddr, vm_page_size_t frameSize,
- vm_rights_t vmRights, vm_attributes_t attr, pde_t *pd)
+ vm_rights_t vmRights, vm_attributes_t attr, pde_t *pd, asid_t frame_asid)
 {
 
     create_mappings_pde_return_t ret;
@@ -1698,6 +1720,18 @@ createSafeMappingEntries_PDE
             return ret;
         }
 
+        /* Check that we are not overwriting an existing mapping */
+        if (pde_ptr_get_pdeType(ret.pde_entries.base) == pde_pde_section) {
+            paddr_t pde_paddr = pde_pde_section_ptr_get_address(ret.pde_entries.base); 
+            if (pde_paddr && frame_asid == asidInvalid) {
+                userError("Virtual address already mapped");
+                current_syscall_error.type = seL4_DeleteFirst;
+                ret.status = EXCEPTION_SYSCALL_ERROR;
+                return ret;
+            }
+        }
+
+
         ret.status = EXCEPTION_NONE;
         return ret;
 
@@ -1727,6 +1761,17 @@ createSafeMappingEntries_PDE
                 ret.status = EXCEPTION_SYSCALL_ERROR;
 
                 return ret;
+            }
+
+            /* Check that we are not overwriting an existing mapping */
+            if (pde_ptr_get_pdeType(ret.pde_entries.base) == pde_pde_section) {
+                paddr_t pde_paddr = pde_pde_section_ptr_get_address(&ret.pde_entries.base[i]); 
+                if (pde_paddr && frame_asid == asidInvalid) {
+                    userError("Virtual address already mapped");
+                    current_syscall_error.type = seL4_DeleteFirst;
+                    ret.status = EXCEPTION_SYSCALL_ERROR;
+                    return ret;
+                }
             }
         }
 
@@ -2238,7 +2283,7 @@ static exception_t decodeARMFrameInvocation(word_t invLabel, word_t length,
         paddr_t capFBasePtr;
         cap_t pdCap;
         pde_t *pd;
-        asid_t asid;
+        asid_t asid, frame_asid;
         vm_rights_t capVMRights, vmRights;
         vm_page_size_t frameSize;
         vm_attributes_t attr;
@@ -2271,9 +2316,10 @@ static exception_t decodeARMFrameInvocation(word_t invLabel, word_t length,
         pd = PDE_PTR(cap_page_directory_cap_get_capPDBasePtr(
                          pdCap));
         asid = cap_page_directory_cap_get_capPDMappedASID(pdCap);
+        frame_asid = generic_frame_cap_get_capFMappedASID(cap);
 
         if (generic_frame_cap_get_capFIsMapped(cap)) {
-            if (generic_frame_cap_get_capFMappedASID(cap) != asid) {
+            if (frame_asid != asid) {
                 current_syscall_error.type = seL4_InvalidCapability;
                 current_syscall_error.invalidCapNumber = 1;
 
@@ -2344,7 +2390,7 @@ static exception_t decodeARMFrameInvocation(word_t invLabel, word_t length,
             create_mappings_pte_return_t map_ret;
             map_ret = createSafeMappingEntries_PTE(capFBasePtr, vaddr,
                                                    frameSize, vmRights,
-                                                   attr, pd);
+                                                   attr, pd, frame_asid);
             if (unlikely(map_ret.status != EXCEPTION_NONE)) {
 #ifdef CONFIG_PRINTING
                 if (current_syscall_error.type == seL4_DeleteFirst) {
@@ -2362,7 +2408,7 @@ static exception_t decodeARMFrameInvocation(word_t invLabel, word_t length,
             create_mappings_pde_return_t map_ret;
             map_ret = createSafeMappingEntries_PDE(capFBasePtr, vaddr,
                                                    frameSize, vmRights,
-                                                   attr, pd);
+                                                   attr, pd, frame_asid);
             if (unlikely(map_ret.status != EXCEPTION_NONE)) {
 #ifdef CONFIG_PRINTING
                 if (current_syscall_error.type == seL4_DeleteFirst) {

--- a/src/arch/arm/32/kernel/vspace.c
+++ b/src/arch/arm/32/kernel/vspace.c
@@ -1615,7 +1615,7 @@ createSafeMappingEntries_PTE
                 current_syscall_error.type = seL4_DeleteFirst;
                 ret.status = EXCEPTION_SYSCALL_ERROR;
                 return ret;
-            }  
+            }
         }
 
         ret.status = EXCEPTION_NONE;
@@ -1662,7 +1662,7 @@ createSafeMappingEntries_PTE
 
         /* Check that we are not overwriting an existing mapping */
         if (pte_ptr_get_pteType(ret.pte_entries.base) != pte_pte_invalid) {
-#ifndef CONFIG_ARM_HYPERVISOR_SUPPORT   
+#ifndef CONFIG_ARM_HYPERVISOR_SUPPORT
             paddr_t pte_paddr = pte_pte_large_ptr_get_address(ret.pte_entries.base);
 #else
             paddr_t pte_paddr = pte_pte_small_ptr_get_address(ret.pte_entries.base);
@@ -1726,7 +1726,7 @@ createSafeMappingEntries_PDE
 
         /* Check that we are not overwriting an existing mapping */
         if (pde_ptr_get_pdeType(ret.pde_entries.base) == pde_pde_section) {
-            paddr_t pde_paddr = pde_pde_section_ptr_get_address(ret.pde_entries.base); 
+            paddr_t pde_paddr = pde_pde_section_ptr_get_address(ret.pde_entries.base);
             if (pde_paddr && frame_asid == asidInvalid) {
                 userError("Virtual address already mapped");
                 current_syscall_error.type = seL4_DeleteFirst;
@@ -1766,16 +1766,16 @@ createSafeMappingEntries_PDE
 
                 return ret;
             }
+        }
 
-            /* Check that we are not overwriting an existing mapping */
-            if (pde_ptr_get_pdeType(ret.pde_entries.base) == pde_pde_section) {
-                paddr_t pde_paddr = pde_pde_section_ptr_get_address(&ret.pde_entries.base[i]); 
-                if (pde_paddr && frame_asid == asidInvalid) {
-                    userError("Virtual address already mapped");
-                    current_syscall_error.type = seL4_DeleteFirst;
-                    ret.status = EXCEPTION_SYSCALL_ERROR;
-                    return ret;
-                }
+        /* Check that we are not overwriting an existing mapping */
+        if (pde_ptr_get_pdeType(ret.pde_entries.base) == pde_pde_section) {
+            paddr_t pde_paddr = pde_pde_section_ptr_get_address(&ret.pde_entries.base[i]);
+            if (pde_paddr && frame_asid == asidInvalid) {
+                userError("Virtual address already mapped");
+                current_syscall_error.type = seL4_DeleteFirst;
+                ret.status = EXCEPTION_SYSCALL_ERROR;
+                return ret;
             }
         }
 

--- a/src/arch/arm/32/kernel/vspace.c
+++ b/src/arch/arm/32/kernel/vspace.c
@@ -1770,7 +1770,7 @@ createSafeMappingEntries_PDE
 
         /* Check that we are not overwriting an existing mapping */
         if (pde_ptr_get_pdeType(ret.pde_entries.base) == pde_pde_section) {
-            paddr_t pde_paddr = pde_pde_section_ptr_get_address(&ret.pde_entries.base[i]);
+            paddr_t pde_paddr = pde_pde_section_ptr_get_address(ret.pde_entries.base);
             if (pde_paddr && frame_asid == asidInvalid) {
                 userError("Virtual address already mapped");
                 current_syscall_error.type = seL4_DeleteFirst;

--- a/src/arch/arm/32/kernel/vspace.c
+++ b/src/arch/arm/32/kernel/vspace.c
@@ -1608,9 +1608,8 @@ createSafeMappingEntries_PTE
         }
 
         /* Check that we are not overwriting an existing mapping */
-        if (pte_ptr_get_pteType(ret.pte_entries.base) != pte_pte_invalid) {
-            paddr_t pte_paddr = pte_pte_small_ptr_get_address(ret.pte_entries.base);
-            if (pte_paddr && frame_asid == asidInvalid) {
+        if (pte_ptr_get_pteType(ret.pte_entries.base) == pte_pte_small) {
+            if (frame_asid == asidInvalid) {
                 userError("Virtual address already mapped");
                 current_syscall_error.type = seL4_DeleteFirst;
                 ret.status = EXCEPTION_SYSCALL_ERROR;
@@ -1661,13 +1660,13 @@ createSafeMappingEntries_PTE
         }
 
         /* Check that we are not overwriting an existing mapping */
-        if (pte_ptr_get_pteType(ret.pte_entries.base) != pte_pte_invalid) {
 #ifndef CONFIG_ARM_HYPERVISOR_SUPPORT
-            paddr_t pte_paddr = pte_pte_large_ptr_get_address(ret.pte_entries.base);
+        if (pte_ptr_get_pteType(ret.pte_entries.base) == pte_pte_large) {
 #else
-            paddr_t pte_paddr = pte_pte_small_ptr_get_address(ret.pte_entries.base);
+        if (pte_ptr_get_pteType(ret.pte_entries.base) == pte_pte_small) {
+
 #endif
-            if (pte_paddr && frame_asid == asidInvalid) {
+            if (frame_asid == asidInvalid) {
                 userError("Virtual address already mapped");
                 current_syscall_error.type = seL4_DeleteFirst;
                 ret.status = EXCEPTION_SYSCALL_ERROR;
@@ -1726,8 +1725,7 @@ createSafeMappingEntries_PDE
 
         /* Check that we are not overwriting an existing mapping */
         if (pde_ptr_get_pdeType(ret.pde_entries.base) == pde_pde_section) {
-            paddr_t pde_paddr = pde_pde_section_ptr_get_address(ret.pde_entries.base);
-            if (pde_paddr && frame_asid == asidInvalid) {
+            if (frame_asid == asidInvalid) {
                 userError("Virtual address already mapped");
                 current_syscall_error.type = seL4_DeleteFirst;
                 ret.status = EXCEPTION_SYSCALL_ERROR;
@@ -1770,8 +1768,7 @@ createSafeMappingEntries_PDE
 
         /* Check that we are not overwriting an existing mapping */
         if (pde_ptr_get_pdeType(ret.pde_entries.base) == pde_pde_section) {
-            paddr_t pde_paddr = pde_pde_section_ptr_get_address(ret.pde_entries.base);
-            if (pde_paddr && frame_asid == asidInvalid) {
+            if (frame_asid == asidInvalid) {
                 userError("Virtual address already mapped");
                 current_syscall_error.type = seL4_DeleteFirst;
                 ret.status = EXCEPTION_SYSCALL_ERROR;

--- a/src/arch/arm/64/kernel/vspace.c
+++ b/src/arch/arm/64/kernel/vspace.c
@@ -2123,13 +2123,17 @@ static exception_t decodeARMFrameInvocation(word_t invLabel, unsigned int length
         frame_asid = cap_frame_cap_ptr_get_capFMappedASID(&cap);
 
         if (frame_asid != asidInvalid) {
+            /* The invoked frame cap is currently mapped in a different vspace */
             if (frame_asid != asid) {
                 userError("ARMPageMap: Attempting to remap a frame that does not belong to the passed address space");
                 current_syscall_error.type = seL4_InvalidCapability;
                 current_syscall_error.invalidArgumentNumber = 0;
                 return EXCEPTION_SYSCALL_ERROR;
 
-            } else if (cap_frame_cap_get_capFMappedAddress(cap) != vaddr) {
+            }
+
+            /* The invoked frame cap is already mapped to a different address in this vspace  */
+            if (cap_frame_cap_get_capFMappedAddress(cap) != vaddr) {
                 userError("ARMPageMap: Attempting to map frame into multiple addresses");
                 current_syscall_error.type = seL4_InvalidArgument;
                 current_syscall_error.invalidArgumentNumber = 2;
@@ -2157,6 +2161,13 @@ static exception_t decodeARMFrameInvocation(word_t invLabel, unsigned int length
                 return EXCEPTION_SYSCALL_ERROR;
             }
 
+            /* Check that we are not overwriting an existing mapping */
+            if (frame_asid == asidInvalid && unlikely(pte_ptr_get_present(lu_ret.ptSlot))) {
+                userError("Virtual address already mapped");
+                current_syscall_error.type = seL4_DeleteFirst;
+                return EXCEPTION_SYSCALL_ERROR;
+            }
+
             setThreadState(NODE_STATE(ksCurThread), ThreadState_Restart);
             return performSmallPageInvocationMap(asid, cap, cte,
                                                  makeUser3rdLevel(base, vmRights, attributes), lu_ret.ptSlot);
@@ -2170,6 +2181,13 @@ static exception_t decodeARMFrameInvocation(word_t invLabel, unsigned int length
                 return EXCEPTION_SYSCALL_ERROR;
             }
 
+            /* Check that we are not overwriting an existing mapping */
+            if (frame_asid == asidInvalid && unlikely(pde_pde_large_ptr_get_present(lu_ret.pdSlot))) {
+                userError("Virtual address already mapped");
+                current_syscall_error.type = seL4_DeleteFirst;
+                return EXCEPTION_SYSCALL_ERROR;
+            }
+
             setThreadState(NODE_STATE(ksCurThread), ThreadState_Restart);
             return performLargePageInvocationMap(asid, cap, cte,
                                                  makeUser2ndLevel(base, vmRights, attributes), lu_ret.pdSlot);
@@ -2180,6 +2198,13 @@ static exception_t decodeARMFrameInvocation(word_t invLabel, unsigned int length
             if (unlikely(lu_ret.status != EXCEPTION_NONE)) {
                 current_syscall_error.type = seL4_FailedLookup;
                 current_syscall_error.failedLookupWasSource = false;
+                return EXCEPTION_SYSCALL_ERROR;
+            }
+            
+            /* Check that we are not overwriting an existing mapping */
+            if (frame_asid == asidInvalid && unlikely(pude_pude_1g_ptr_get_present(lu_ret.pudSlot))) {
+                userError("Virtual address already mapped");
+                current_syscall_error.type = seL4_DeleteFirst;
                 return EXCEPTION_SYSCALL_ERROR;
             }
 

--- a/src/arch/arm/64/kernel/vspace.c
+++ b/src/arch/arm/64/kernel/vspace.c
@@ -2200,7 +2200,7 @@ static exception_t decodeARMFrameInvocation(word_t invLabel, unsigned int length
                 current_syscall_error.failedLookupWasSource = false;
                 return EXCEPTION_SYSCALL_ERROR;
             }
-            
+
             /* Check that we are not overwriting an existing mapping */
             if (frame_asid == asidInvalid && unlikely(pude_pude_1g_ptr_get_present(lu_ret.pudSlot))) {
                 userError("Virtual address already mapped");

--- a/src/arch/x86/32/kernel/vspace.c
+++ b/src/arch/x86/32/kernel/vspace.c
@@ -651,7 +651,7 @@ bool_t modeUnmapPage(vm_page_size_t page_size, vspace_root_t *vroot, vptr_t vadd
 }
 
 exception_t decodeX86ModeMapPage(word_t invLabel, vm_page_size_t page_size, cte_t *cte, cap_t cap,
-                                 vspace_root_t *vroot, vptr_t vaddr, paddr_t paddr, vm_rights_t vm_rights, vm_attributes_t vm_attr, asid_t frame_asid)
+                                 vspace_root_t *vroot, vptr_t vaddr, paddr_t paddr, vm_rights_t vm_rights, vm_attributes_t vm_attr, bool_t is_remap)
 {
     fail("Invalid Page type");
 }

--- a/src/arch/x86/32/kernel/vspace.c
+++ b/src/arch/x86/32/kernel/vspace.c
@@ -651,7 +651,7 @@ bool_t modeUnmapPage(vm_page_size_t page_size, vspace_root_t *vroot, vptr_t vadd
 }
 
 exception_t decodeX86ModeMapPage(word_t invLabel, vm_page_size_t page_size, cte_t *cte, cap_t cap,
-                                 vspace_root_t *vroot, vptr_t vaddr, paddr_t paddr, vm_rights_t vm_rights, vm_attributes_t vm_attr)
+                                 vspace_root_t *vroot, vptr_t vaddr, paddr_t paddr, vm_rights_t vm_rights, vm_attributes_t vm_attr, asid_t frame_asid)
 {
     fail("Invalid Page type");
 }

--- a/src/arch/x86/64/kernel/vspace.c
+++ b/src/arch/x86/64/kernel/vspace.c
@@ -1506,7 +1506,7 @@ static create_mapping_pdpte_return_t createSafeMappingEntries_PDPTE(paddr_t base
             current_syscall_error.type = seL4_DeleteFirst;
             ret.status = EXCEPTION_SYSCALL_ERROR;
             return ret;
-        } 
+        }
     }
 
 

--- a/src/arch/x86/kernel/vspace.c
+++ b/src/arch/x86/kernel/vspace.c
@@ -865,7 +865,7 @@ typedef struct create_mapping_pte_return create_mapping_pte_return_t;
 
 static create_mapping_pte_return_t createSafeMappingEntries_PTE(paddr_t base, word_t vaddr, vm_rights_t vmRights,
                                                                 vm_attributes_t attr,
-                                                                vspace_root_t *vspace)
+                                                                vspace_root_t *vspace, asid_t frame_asid)
 {
     create_mapping_pte_return_t ret;
     lookupPTSlot_ret_t          lu_ret;
@@ -876,6 +876,14 @@ static create_mapping_pte_return_t createSafeMappingEntries_PTE(paddr_t base, wo
         current_syscall_error.failedLookupWasSource = false;
         ret.status = EXCEPTION_SYSCALL_ERROR;
         /* current_lookup_fault will have been set by lookupPTSlot */
+        return ret;
+    }
+
+    /* Check that we are not overwriting an existing mapping */
+    if (pte_ptr_get_present(lu_ret.ptSlot) && frame_asid == asidInvalid) {
+        userError("Virtual address already mapped");
+        current_syscall_error.type = seL4_DeleteFirst;
+        ret.status = EXCEPTION_SYSCALL_ERROR;
         return ret;
     }
 
@@ -894,7 +902,7 @@ typedef struct create_mapping_pde_return create_mapping_pde_return_t;
 
 static create_mapping_pde_return_t createSafeMappingEntries_PDE(paddr_t base, word_t vaddr, vm_rights_t vmRights,
                                                                 vm_attributes_t attr,
-                                                                vspace_root_t *vspace)
+                                                                vspace_root_t *vspace, asid_t frame_asid)
 {
     create_mapping_pde_return_t ret;
     lookupPDSlot_ret_t          lu_ret;
@@ -917,6 +925,15 @@ static create_mapping_pde_return_t createSafeMappingEntries_PDE(paddr_t base, wo
         return ret;
     }
 
+    /* Check that we are not overwriting an existing mapping */
+    if (pde_ptr_get_page_size(ret.pdSlot) == pde_pde_large) {
+        if (pde_pde_large_ptr_get_present(ret.pdSlot) && frame_asid == asidInvalid) {
+            userError("Virtual address already mapped");
+            current_syscall_error.type = seL4_DeleteFirst;
+            ret.status = EXCEPTION_SYSCALL_ERROR;
+            return ret;
+        }   
+    }
 
     ret.pde = makeUserPDELargePage(base, attr, vmRights);
     ret.status = EXCEPTION_NONE;
@@ -945,7 +962,7 @@ exception_t decodeX86FrameInvocation(
         vm_rights_t     vmRights;
         vm_attributes_t vmAttr;
         vm_page_size_t  frameSize;
-        asid_t          asid;
+        asid_t          asid, frame_asid;
 
         if (length < 3 || current_extra_caps.excaprefs[0] == NULL) {
             current_syscall_error.type = seL4_TruncatedMessage;
@@ -970,9 +987,10 @@ exception_t decodeX86FrameInvocation(
         }
         vspace = (vspace_root_t *)pptr_of_cap(vspaceCap);
         asid = cap_get_capMappedASID(vspaceCap);
+        frame_asid = cap_frame_cap_get_capFMappedASID(cap);
 
-        if (cap_frame_cap_get_capFMappedASID(cap) != asidInvalid) {
-            if (cap_frame_cap_get_capFMappedASID(cap) != asid) {
+        if (frame_asid != asidInvalid) {
+            if (frame_asid != asid) {
                 current_syscall_error.type = seL4_InvalidCapability;
                 current_syscall_error.invalidCapNumber = 1;
 
@@ -1044,7 +1062,7 @@ exception_t decodeX86FrameInvocation(
         case X86_SmallPage: {
             create_mapping_pte_return_t map_ret;
 
-            map_ret = createSafeMappingEntries_PTE(paddr, vaddr, vmRights, vmAttr, vspace);
+            map_ret = createSafeMappingEntries_PTE(paddr, vaddr, vmRights, vmAttr, vspace, frame_asid);
             if (map_ret.status != EXCEPTION_NONE) {
                 return map_ret.status;
             }
@@ -1057,7 +1075,7 @@ exception_t decodeX86FrameInvocation(
         case X86_LargePage: {
             create_mapping_pde_return_t map_ret;
 
-            map_ret = createSafeMappingEntries_PDE(paddr, vaddr, vmRights, vmAttr, vspace);
+            map_ret = createSafeMappingEntries_PDE(paddr, vaddr, vmRights, vmAttr, vspace, frame_asid);
             if (map_ret.status != EXCEPTION_NONE) {
                 return map_ret.status;
             }
@@ -1067,7 +1085,7 @@ exception_t decodeX86FrameInvocation(
         }
 
         default: {
-            return decodeX86ModeMapPage(invLabel, frameSize, cte, cap, vspace, vaddr, paddr, vmRights, vmAttr);
+            return decodeX86ModeMapPage(invLabel, frameSize, cte, cap, vspace, vaddr, paddr, vmRights, vmAttr, frame_asid);
         }
         }
 

--- a/src/arch/x86/kernel/vspace.c
+++ b/src/arch/x86/kernel/vspace.c
@@ -932,7 +932,7 @@ static create_mapping_pde_return_t createSafeMappingEntries_PDE(paddr_t base, wo
             current_syscall_error.type = seL4_DeleteFirst;
             ret.status = EXCEPTION_SYSCALL_ERROR;
             return ret;
-        }   
+        }
     }
 
     ret.pde = makeUserPDELargePage(base, attr, vmRights);


### PR DESCRIPTION
Last year, I published a [pre-rfc](https://sel4.discourse.group/t/pre-rfc-protectn/478) regarding new mapping operations which allowed you to batch unmaps and access right changes in order to make operations on a process' virtual address space more efficient. While discussing the RFC, we found some problems with my implementation based on a misunderstanding of if over-mapping is allowed to occur. 

Over-mapping refers to when you overwrite an existing mapping with a new one i.e. you invoke seL4_ARCH_map on a frame cap B and overwrite an existing mapping of a page that was backed by frame cap A. My implementation assumed that over-mapping was always allowed to happen and left stale capabilities, since frame cap A would retain internal book-keeping which linked it to the page even though it was now associated with frame cap B. 

The reason I thought this is because the ARM and x86 platforms both allow for over-mapping to occur, and I was originally developing my code on AARCH64. However, spurred on by the issues raised in the RFC, I looked into the implementation of the `Page_Map` on RISCV and found that it did not allow over-mapping. This means that there are different semantics in the implementation of mapping pages between the architectures, which is likely problematic. As pointed out by Kent in the RFC discussion, the [API ](https://github.com/seL4/seL4/blob/master/libsel4/arch_include/arm/interfaces/sel4arch.xml#L161) states that `seL4_DeleteFirst` should be returned if  `A mapping already exists in <texttt text="vspace"/> at <texttt text="vaddr"`, which seems to suggest that the RISCV interpretation is correct.

This PR changes all of the architectures to be consistent with the behavior of RISCV. It passes the seL4test suite on x86_64 and aarch64 but breaks the `PT0002` test on AARCH32, as this relies on overmapping.  I have also added a [set of new tests](https://github.com/seL4/sel4test/pull/88) across these architectures to check that overmapping no longer works.

Test with: seL4/sel4test#88