### PR TITLE
mcs: remove `getKernelWcetTicks` term from `refill_ready`

### DIFF
--- a/include/arch/riscv/arch/machine/timer.h
+++ b/include/arch/riscv/arch/machine/timer.h
@@ -62,7 +62,6 @@ static inline ticks_t getCurrentTime(void)
 /* set the next deadline irq - deadline is absolute */
 static inline void setDeadline(ticks_t deadline)
 {
-    assert(deadline > NODE_STATE(ksCurTime));
     /* Setting the timer acknowledges any existing IRQs */
     sbi_set_timer(deadline);
 }

--- a/include/arch/x86/arch/machine/timer.h
+++ b/include/arch/x86/arch/machine/timer.h
@@ -62,7 +62,6 @@ static inline PURE time_t ticksToUs(ticks_t ticks)
 
 static inline void setDeadline(ticks_t deadline)
 {
-    assert(deadline > NODE_STATE(ksCurTime));
     if (likely(x86KSapicRatio == 0)) {
         x86_wrmsr(IA32_TSC_DEADLINE_MSR, deadline);
     } else {

--- a/include/arch/x86/arch/machine/timer.h
+++ b/include/arch/x86/arch/machine/timer.h
@@ -65,9 +65,10 @@ static inline void setDeadline(ticks_t deadline)
     if (likely(x86KSapicRatio == 0)) {
         x86_wrmsr(IA32_TSC_DEADLINE_MSR, deadline);
     } else {
-        /* convert deadline from tscKhz to apic khz */
-        deadline -= getCurrentTime();
-        apic_write_reg(APIC_TIMER_COUNT, div64(deadline, x86KSapicRatio));
+        /* Must not underflow */
+        deadline -= MIN(deadline, getCurrentTime());
+        /* Convert deadline from tscKhz to apic khz. Must be at least 1 tick. */
+        apic_write_reg(APIC_TIMER_COUNT, MAX(1, div64(deadline, x86KSapicRatio)));
     }
 }
 #else

--- a/include/drivers/timer/arm_generic.h
+++ b/include/drivers/timer/arm_generic.h
@@ -24,7 +24,6 @@ static inline ticks_t getCurrentTime(void)
 /** DONT_TRANSLATE **/
 static inline void setDeadline(ticks_t deadline)
 {
-    assert(deadline >= NODE_STATE(ksCurTime));
     SYSTEM_WRITE_64(CNT_CVAL, deadline);
 }
 

--- a/include/drivers/timer/arm_global.h
+++ b/include/drivers/timer/arm_global.h
@@ -70,7 +70,9 @@ static inline void setDeadline(ticks_t deadline)
     globalTimer->comparatorUpper = (uint32_t)(deadline >> 32llu);
     /* enable cmp */
     globalTimer->control |= BIT(COMP_ENABLE);
-    /* if this fails PRECISION is too low */
+    /* Assert that either the deadline is in the future or that the IRQ has already been raised.
+       This should be guaranteed by hardware from r2p0 on of the Cortex-A9 MPCore Technical
+       Reference Manual (r2p0 published in 2009) */
     assert(getCurrentTime() < deadline || globalTimer->isr == 1u);
 }
 

--- a/include/kernel/sporadic.h
+++ b/include/kernel/sporadic.h
@@ -126,7 +126,7 @@ static inline bool_t refill_sufficient(sched_context_t *sc, ticks_t usage)
  */
 static inline bool_t refill_ready(sched_context_t *sc)
 {
-    return refill_head(sc)->rTime <= (NODE_STATE(ksCurTime) + getKernelWcetTicks());
+    return refill_head(sc)->rTime <= NODE_STATE(ksCurTime);
 }
 
 /*

--- a/include/machine/timer.h
+++ b/include/machine/timer.h
@@ -16,7 +16,9 @@
 /* Read the current time from the timer. */
 /** MODIFIES: [*] */
 static inline ticks_t getCurrentTime(void);
-/* set the next deadline irq - deadline is absolute */
+/* Set the next deadline irq - deadline is absolute and may be slightly in
+   the past. If it is set in the past, we expect an interrupt to be raised
+   immediately after we leave the kernel. */
 /** MODIFIES: [*] */
 static inline void setDeadline(ticks_t deadline);
 /* ack previous deadline irq */

--- a/src/kernel/thread.c
+++ b/src/kernel/thread.c
@@ -585,6 +585,13 @@ void setNextInterrupt(void)
         next_interrupt = MIN(refill_head(NODE_STATE(ksReleaseHead)->tcbSchedContext)->rTime, next_interrupt);
     }
 
+    /* We should never be attempting to schedule anything earlier than ksCurTime */
+    assert(next_interrupt >= NODE_STATE(ksCurTime));
+
+    /* Our lower bound ksCurTime is slightly in the past (at kernel entry) and
+       we are further subtracting getTimerPrecision(), so we may be setting a
+       deadline in the past. If that is the case, we assume the IRQ will be
+       raised immediately after we leave the kernel. */
     setDeadline(next_interrupt - getTimerPrecision());
 }
 


### PR DESCRIPTION
Please see the commit message for a brief explanation of this change. I'll elaborate on that message a little here, but I should point out that I have made this change to the abstract specification, and the proofs for all the invariants we have (which are very detailed regarding the refill lists) all work very nicely.

`refill_ready` currently says that an sc is ready if its head `rTime` is at most the current time plus the kernel WCET. I think there are a couple problems with this. 

First, `refill_unblock_check` might be called on an sc that is ready, but whose head `rTime` is somewhere strictly between the current time, and the current time plus the kernel WCET. This would result in `refill_unblock_check` bringing the head refill forward. This breaks an invariant that the verification team have (we call it `window`, within` valid_refills`) that states that the `rTime` of the last refill in the list must be at most the period from the `rTime` of the head refill. This also seems to violate a general principle that the kernel functions should never bring a refill's time forward (but may take its time back).

More generally speaking, again consider a sc whose whose head `rTime` is somewhere strictly between the current time, and the current time plus the kernel WCET. Since the kernel WCET is the worst case execution time, the time to exit the kernel must be strictly less than the kernel WCET, and so we could end up in a situation where we have a thread running on an sc whose `rTime` is still in the future, which seems to be a violation of the timing model for MCS.

Removing the `getKernelWcetTicks` term from `refill_ready` solves both these issues.