### PR TITLE
Rocketchip bug fixes + zcu102 softcore

### DIFF
--- a/include/drivers/irq/riscv_plic0.h
+++ b/include/drivers/irq/riscv_plic0.h
@@ -14,7 +14,8 @@
  * this driver is confirmed to be working on other platforms. */
 #if !defined(CONFIG_PLAT_HIFIVE) && \
     !defined(CONFIG_PLAT_POLARFIRE) && \
-    !defined(CONFIG_PLAT_QEMU_RISCV_VIRT)
+    !defined(CONFIG_PLAT_QEMU_RISCV_VIRT) && \
+    !defined(CONFIG_PLAT_ROCKETCHIP_ZCU102)
 #error "Check if this platform suppots a PLIC."
 #endif
 

--- a/src/arch/riscv/common_riscv.lds
+++ b/src/arch/riscv/common_riscv.lds
@@ -2,6 +2,7 @@
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  * Copyright 2015, 2016 Hesham Almatary <heshamelmatary@gmail.com>
  * Copyright 2021, HENSOLDT Cyber
+ * Copyright 2023, DornerWorks
  *
  * SPDX-License-Identifier: GPL-2.0-only
  */
@@ -90,6 +91,12 @@ SECTIONS
 
         /* large data such as the globals frame and global PD */
         *(.bss.aligned)
+#if defined(CONFIG_PLAT_ROCKETCHIP_ZCU102)
+        /* softcore instantiation on ZCU102 needs these bytes to
+         * avoid userspace issues
+         */
+        . = . + 8;
+#endif
     }
 
     . = ALIGN(4K);

--- a/src/arch/riscv/kernel/boot.c
+++ b/src/arch/riscv/kernel/boot.c
@@ -233,6 +233,13 @@ static BOOT_CODE bool_t try_init_kernel(
     /* If a DTB was provided, pass the data on as extra bootinfo */
     p_region_t dtb_p_reg = P_REG_EMPTY;
     if (dtb_size > 0) {
+#ifdef CONFIG_PLAT_ROCKETCHIP_ZCU102
+        /* The softcore rocketchip instantiation doesn't work well when this
+         * page isn't reserved. Round up so the whole page is reserved to
+         * avoid the problem
+         */
+        dtb_size = ROUND_UP(dtb_size, PAGE_BITS);
+#endif
         paddr_t dtb_phys_end = dtb_phys_addr + dtb_size;
         if (dtb_phys_end < dtb_phys_addr) {
             /* An integer overflow happened in DTB end address calculation, the

--- a/src/arch/riscv/machine/hardware.c
+++ b/src/arch/riscv/machine/hardware.c
@@ -102,6 +102,12 @@ static inline irq_t getActiveIRQ(void)
          * has claimed it in a multicore system.
          */
         irq = plic_get_claim();
+#ifdef CONFIG_PLAT_QEMU_RISCV_VIRT
+        /* QEMU bug requires external interrupts to be immediately claimed. For
+         * other platforms, the claim is done in invokeIRQHandler_AckIRQ.
+         */
+        plic_complete_claim(irq);
+#endif
 #ifdef ENABLE_SMP_SUPPORT
     } else if (sip & BIT(SIP_SSIP)) {
         sbi_clear_ipi();

--- a/src/object/interrupt.c
+++ b/src/object/interrupt.c
@@ -134,8 +134,15 @@ exception_t decodeIRQHandlerInvocation(word_t invLabel, irq_t irq)
 void invokeIRQHandler_AckIRQ(irq_t irq)
 {
 #ifdef CONFIG_ARCH_RISCV
+#if !defined(CONFIG_PLAT_QEMU_RISCV_VIRT)
+    /* QEMU has a bug where interrupts must be
+     * immediately claimed, which is done in getActiveIRQ. For other
+     * platforms, the claim can wait and be done here.
+     */
     plic_complete_claim(irq);
+#endif
 #else
+
 #if defined ENABLE_SMP_SUPPORT && defined CONFIG_ARCH_ARM
     if (IRQ_IS_PPI(irq) && IRQT_TO_CORE(irq) != getCurrentCPUIndex()) {
         doRemoteMaskPrivateInterrupt(IRQT_TO_CORE(irq), false, IRQT_TO_IDX(irq));

--- a/src/plat/rocketchip/config.cmake
+++ b/src/plat/rocketchip/config.cmake
@@ -1,6 +1,7 @@
 #
 # Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
 # Copyright 2021, HENSOLDT Cyber
+# Copyright 2023, DornerWorks
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #
@@ -9,12 +10,36 @@ cmake_minimum_required(VERSION 3.7.2)
 
 declare_platform(rocketchip KernelPlatformRocketchip PLAT_ROCKETCHIP KernelArchRiscV)
 
+set(c_configs PLAT_ROCKETCHIP_BASE PLAT_ROCKETCHIP_ZCU102)
+set(cmake_configs KernelPlatformRocketchipBase KernelPlatformRocketchipZCU102)
+
+set(plat_lists rocketchip-base rocketchip-zcu102)
+foreach(config IN LISTS cmake_configs)
+    unset(${config} CACHE)
+endforeach()
+
 if(KernelPlatformRocketchip)
     declare_seL4_arch(riscv64)
-    config_set(KernelRiscVPlatform RISCV_PLAT "rocketchip")
+
+    check_platform_and_fallback_to_default(KernelRiscVPlatform "rocketchip-base")
+    list(FIND plat_lists ${KernelRiscVPlatform} index)
+    if("${index}" STREQUAL "-1")
+        message(FATAL_ERROR "Which rocketchip platform not specified")
+    endif()
+    list(GET c_configs ${index} c_config)
+    list(GET cmake_configs ${index} cmake_config)
+    config_set(KernelRiscVPlatform RISCV_PLAT ${KernelRiscVPlatform})
+    config_set(${cmake_config} ${c_config} ON)
+
     config_set(KernelPlatformFirstHartID FIRST_HART_ID 0)
     config_set(KernelOpenSBIPlatform OPENSBI_PLATFORM "generic")
     list(APPEND KernelDTSList "tools/dts/rocketchip.dts")
+    # The Rocketchip-ZCU102 is a softcore instantiation that runs on the ZCU102's
+    # FPGA fabric. Information on generating and running seL4 on the platform can
+    # be found at https://docs.sel4.systems/Hardware/
+    if(KernelPlatformRocketchipZCU102)
+        list(APPEND KernelDTSList "src/plat/rocketchip/overlay-rocketchip-zcu102.dts")
+    endif()
     # This is an experimental platform that supports accessing peripherals, but
     # the status of support for external interrupts via a PLIC is unclear and
     # may differ depending on the version that is synthesized. Declaring no

--- a/src/plat/rocketchip/config.cmake
+++ b/src/plat/rocketchip/config.cmake
@@ -44,18 +44,23 @@ if(KernelPlatformRocketchip)
         # repo is added as a remote to the tools/opensbi project in the seL4 codebase
         config_set(KernelOpenSBIPlatform OPENSBI_PLATFORM "rocket-fpga-zcu104")
         list(APPEND KernelDTSList "src/plat/rocketchip/overlay-rocketchip-zcu102.dts")
+        # The zcu102 instantiation supports the PLIC and external interrupts
+        declare_default_headers(
+            TIMER_FREQUENCY 10000000 PLIC_MAX_NUM_INT 128
+            INTERRUPT_CONTROLLER drivers/irq/riscv_plic0.h
+        )
     else()
         config_set(KernelOpenSBIPlatform OPENSBI_PLATFORM "generic")
+        # This is an experimental platform that supports accessing peripherals, but
+        # the status of support for external interrupts via a PLIC is unclear and
+        # may differ depending on the version that is synthesized. Declaring no
+        # interrupts and using the dummy PLIC driver seems the best option for now
+        # to avoid confusion or even crashes.
+        declare_default_headers(
+            TIMER_FREQUENCY 10000000 PLIC_MAX_NUM_INT 0
+            INTERRUPT_CONTROLLER drivers/irq/riscv_plic_dummy.h
+        )
     endif()
-    # This is an experimental platform that supports accessing peripherals, but
-    # the status of support for external interrupts via a PLIC is unclear and
-    # may differ depending on the version that is synthesized. Declaring no
-    # interrupts and using the dummy PLIC driver seems the best option for now
-    # to avoid confusion or even crashes.
-    declare_default_headers(
-        TIMER_FREQUENCY 10000000 PLIC_MAX_NUM_INT 0
-        INTERRUPT_CONTROLLER drivers/irq/riscv_plic_dummy.h
-    )
 else()
     unset(KernelPlatformFirstHartID CACHE)
 endif()

--- a/src/plat/rocketchip/config.cmake
+++ b/src/plat/rocketchip/config.cmake
@@ -32,13 +32,20 @@ if(KernelPlatformRocketchip)
     config_set(${cmake_config} ${c_config} ON)
 
     config_set(KernelPlatformFirstHartID FIRST_HART_ID 0)
-    config_set(KernelOpenSBIPlatform OPENSBI_PLATFORM "generic")
     list(APPEND KernelDTSList "tools/dts/rocketchip.dts")
     # The Rocketchip-ZCU102 is a softcore instantiation that runs on the ZCU102's
     # FPGA fabric. Information on generating and running seL4 on the platform can
     # be found at https://docs.sel4.systems/Hardware/
     if(KernelPlatformRocketchipZCU102)
+        # The rocket-fpga-zcu104 platform can be found at the following git repo:
+        # https://github.com/bao-project/opensbi/tree/bao/rocket
+        #
+        # In order for this to function, please ensure the bao-project/opensbi
+        # repo is added as a remote to the tools/opensbi project in the seL4 codebase
+        config_set(KernelOpenSBIPlatform OPENSBI_PLATFORM "rocket-fpga-zcu104")
         list(APPEND KernelDTSList "src/plat/rocketchip/overlay-rocketchip-zcu102.dts")
+    else()
+        config_set(KernelOpenSBIPlatform OPENSBI_PLATFORM "generic")
     endif()
     # This is an experimental platform that supports accessing peripherals, but
     # the status of support for external interrupts via a PLIC is unclear and

--- a/src/plat/rocketchip/overlay-rocketchip-zcu102.dts
+++ b/src/plat/rocketchip/overlay-rocketchip-zcu102.dts
@@ -5,6 +5,11 @@
  */
 
 / {
+	chosen {
+		seL4,kernel-devices =
+		    &{/soc/interrupt-controller@c000000};
+	};
+
 	/delete-node/ memory@80000000;
 
 	L6: memory@40000000 {

--- a/src/plat/rocketchip/overlay-rocketchip-zcu102.dts
+++ b/src/plat/rocketchip/overlay-rocketchip-zcu102.dts
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023, DornerWorks
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+/ {
+	/delete-node/ memory@80000000;
+
+	L6: memory@40000000 {
+		device_type = "memory";
+		reg = <0x40000000 0x40000000>;
+	};
+
+	uartclk: uartclk {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <100000000>;
+	};
+
+	serial@ff010000{
+		compatible = "cdns,uart-r1p12";
+		status = "okay";
+		interrupts = <2>;
+		interrupt-parent = <&L0>;
+		reg = <0x0 0xff010000 0x0 0x1000>;
+		clock-names = "uart_clk", "pclk";
+		clocks = <&uartclk>, <&uartclk>;
+	};
+};


### PR DESCRIPTION
This PR does two things:

1. Differentiates the base Rocketchip platform with a version generated for the ZCU102 FPGA fabric
2. Fixes bugs we encountered running on the softcore implementation

We tested this with the VMM created by @yyshen  