### PR TITLE
Expose more files for external tools via `cmake --install`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -737,6 +737,23 @@ if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
         DESTINATION libsel4/include
         FILES_MATCHING
         PATTERN "*.h"
+        PATTERN "*.pbf"
+        PATTERN "api/syscall.xml"
+        PATTERN "api/syscall.xsd"
+        PATTERN "interfaces/sel4.xml"
+    )
+    # Manually resolve conflict between the two files name sel4arch.xml
+    install(
+        FILES
+            "${CMAKE_CURRENT_SOURCE_DIR}/libsel4/arch_include/${KernelArch}/interfaces/sel4arch.xml"
+        DESTINATION libsel4/include/interfaces
+        RENAME sel4-arch.xml
+    )
+    install(
+        FILES
+            "${CMAKE_CURRENT_SOURCE_DIR}/libsel4/sel4_arch_include/${KernelSel4Arch}/interfaces/sel4arch.xml"
+        DESTINATION libsel4/include/interfaces
+        RENAME sel4-sel4arch.xml
     )
     # Install libsel4 sources to libsel4/src
     install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/libsel4/src/" DESTINATION libsel4/src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -757,5 +757,12 @@ if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
     )
     # Install libsel4 sources to libsel4/src
     install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/libsel4/src/" DESTINATION libsel4/src)
+    # Install additional support files
+    if(DEFINED KernelDTBPath)
+        install(FILES ${KernelDTBPath} DESTINATION support)
+    endif()
+    if(DEFINED platform_yaml)
+        install(FILES ${platform_yaml} DESTINATION support)
+    endif()
 
 endif()

--- a/libsel4/CMakeLists.txt
+++ b/libsel4/CMakeLists.txt
@@ -106,14 +106,14 @@ endfunction(genbf)
 
 genbf(
     "libsel4_shared_types_gen"
-    "${CMAKE_CURRENT_BINARY_DIR}/generated/shared_types_gen/shared_types.pbf"
+    "${CMAKE_CURRENT_BINARY_DIR}/include/sel4/shared_types.pbf"
     "${CMAKE_CURRENT_SOURCE_DIR}/mode_include/${KernelWordSize}/sel4/shared_types.bf"
     "${CMAKE_CURRENT_BINARY_DIR}/include/sel4/shared_types_gen.h"
 )
 
 genbf(
     "libsel4_sel4_arch_types_gen"
-    "${CMAKE_CURRENT_BINARY_DIR}/generated/sel4_arch_shared_types/types.pbf"
+    "${CMAKE_CURRENT_BINARY_DIR}/sel4_arch_include/${KernelSel4Arch}/sel4/sel4_arch/types.pbf"
     "${CMAKE_CURRENT_SOURCE_DIR}/sel4_arch_include/${KernelSel4Arch}/sel4/sel4_arch/types.bf"
     "${CMAKE_CURRENT_BINARY_DIR}/sel4_arch_include/${KernelSel4Arch}/sel4/sel4_arch/types_gen.h"
 )


### PR DESCRIPTION
When the kernel is built as a top-level CMake project, the kernel and libsel4 can be installed using `cmake --install`. This PR adds some more files to that installation which can be useful to components surrounding the kernel, such as userspace bindings to the seL4 API in languages other than C.

Specifically, these files are:

- `sel4{,-arch,-sel4arch}.xml` and `syscall.xml`: Syscall and object interface definition files.
- `*.pbf`: Preprocessed `.bf` files.
- `kernel.dtb`: The device tree generated and used for the kernel build.
- `platform_gen.yaml`: Generated from `kernel.dtb` and used to generate `platform_gen.h`.

This PR includes the addition of a new subdirectory of the installation directory named `support/` which includes `kernel.dtb` and `platform_gen.yaml`. Perhaps there is a more descriptive name for this directory. Alternatively, these files could just be installed to the top-level of the installation directory.