### PR TITLE
Include change to MinSchedContextBits in CHANGES

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -45,6 +45,7 @@ Upcoming release: BREAKING
   This change is reflected in the definition of the seL4_UserTop constant that holds the largest user virtual address.
 * aarch32 VM fault messages now deliver original (untranslated) faulting IP in a hypervisor context, matching
   aarch64 behaviour.
+* Correct the minimum size of a scheduling context. This changes the value of `seL4_MinSchedContextBits`.
 
 ## Upgrade Notes
 ---


### PR DESCRIPTION
The motivation for this is that not everything uses the the seL4 API C headers for constants like `MinSchedContextBits` (e.g. seL4 Core Platform). Anything depending on the value may want to be aware of a change in the constant.