### PR TITLE
cmake: mention gen_config.h change in CHANGES

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -46,6 +46,9 @@ Upcoming release: BREAKING
 * aarch32 VM fault messages now deliver original (untranslated) faulting IP in a hypervisor context, matching
   aarch64 behaviour.
 * Correct the minimum size of a scheduling context. This changes the value of `seL4_MinSchedContextBits`.
+* Changed how `gen_config.h` files are generated. Previously, they were generated at CMake configure time. Now, they
+  are generated at build time as a dependency of the `${prefix}_Gen` target. To manually build the kernel
+  `gen_config.h` file after running `cmake`, run `ninja gen_config/kernel/gen_config.h`.
 
 ## Upgrade Notes
 ---


### PR DESCRIPTION
`gen_config.h` files are now generated at build time rather than configure time.

This change was introduced by https://github.com/seL4/seL4/pull/975/