### PR TITLE
MCS: Fix passive server core migration during ReplyRecv

### DIFF
--- a/include/object/tcb.h
+++ b/include/object/tcb.h
@@ -69,13 +69,24 @@ void remoteTCBStall(tcb_t *tcb);
     remoteQueueUpdate(_t);          \
 } while (0)
 
+
+#define SCHED_ENQUEUE_CURRENT_TCB do {                                    \
+    assert(NODE_STATE(ksCurThread)->tcbAffinity == getCurrentCPUIndex()); \
+    tcbSchedEnqueue(NODE_STATE(ksCurThread));                             \
+} while (0)
+#define SCHED_APPEND_CURRENT_TCB do {                                     \
+    assert(NODE_STATE(ksCurThread)->tcbAffinity == getCurrentCPUIndex()); \
+    tcbSchedAppend(NODE_STATE(ksCurThread));                              \
+} while (0)
+
 #else
 #define SCHED_ENQUEUE(_t)           tcbSchedEnqueue(_t)
 #define SCHED_APPEND(_t)            tcbSchedAppend(_t)
-#endif /* ENABLE_SMP_SUPPORT */
 
 #define SCHED_ENQUEUE_CURRENT_TCB   tcbSchedEnqueue(NODE_STATE(ksCurThread))
 #define SCHED_APPEND_CURRENT_TCB    tcbSchedAppend(NODE_STATE(ksCurThread))
+#endif /* ENABLE_SMP_SUPPORT */
+
 
 #ifdef CONFIG_KERNEL_MCS
 /* Add TCB into the priority ordered endpoint queue */

--- a/src/kernel/thread.c
+++ b/src/kernel/thread.c
@@ -357,7 +357,8 @@ void schedule(void)
 
     if (NODE_STATE(ksSchedulerAction) != SchedulerAction_ResumeCurrentThread) {
         bool_t was_runnable;
-        if (isSchedulable(NODE_STATE(ksCurThread))) {
+        if (isSchedulable(NODE_STATE(ksCurThread))
+            SMP_COND_STATEMENT( && NODE_STATE(ksCurThread)->tcbAffinity == getCurrentCPUIndex())) {
             was_runnable = true;
             SCHED_ENQUEUE_CURRENT_TCB;
         } else {
@@ -375,7 +376,8 @@ void schedule(void)
              * information flow in non-fastpath cases. */
             bool_t fastfail =
                 NODE_STATE(ksCurThread) == NODE_STATE(ksIdleThread)
-                || (candidate->tcbPriority < NODE_STATE(ksCurThread)->tcbPriority);
+                || (candidate->tcbPriority < NODE_STATE(ksCurThread)->tcbPriority)
+                SMP_COND_STATEMENT( || NODE_STATE(ksCurThread)->tcbAffinity != getCurrentCPUIndex());
             if (fastfail &&
                 !isHighestPrio(ksCurDomain, candidate->tcbPriority)) {
                 SCHED_ENQUEUE(candidate);

--- a/src/object/endpoint.c
+++ b/src/object/endpoint.c
@@ -249,6 +249,11 @@ void receiveIPC(tcb_t *thread, cap_t cap, bool_t isBlocking)
                     bool_t canDonate = sender->tcbSchedContext != NULL
                                        && seL4_Fault_get_seL4_FaultType(sender->tcbFault) != seL4_Fault_Timeout;
                     reply_push(sender, thread, replyPtr, canDonate);
+#ifdef ENABLE_SMP_SUPPORT
+                    if (isSchedulable(thread) && thread->tcbAffinity != getCurrentCPUIndex()) {
+                        possibleSwitchTo(thread);
+                    }
+#endif
                 } else {
                     setThreadState(sender, ThreadState_Inactive);
                 }


### PR DESCRIPTION
Fixes an issue where passive servers are not scheduled after migrating to another core during ReplyRecv. If during the handling of the receive part of ReplyRecv, the current thread migrates to a remote core, it will be inserted into the scheduling queues of the remote core, but no reschedule IPI will be sent to the remote core. In the worst case, if the remote core is running the idle thread, the passive server may never be scheduled. This commit fixes this by sending a reschedule IPI after the current thread is enqueued, if necessary.

Note that while handling the receive part of the syscall, while the current thread will receive the caller's scheduling context and have its tcbAffinity set to the remote core, it will not be enqueued on the remote core. It is only during the call to schedule() after handling the syscall that the current thread, the affinity of which is now the remote core, will be enqueued on the remote core. However, this will only insert the TCB into the queue, it will not send a reschedule IPI to the remote core. If the remote core is running the idle thread, it will continue running the idle thread even if the kernel is entered via an interrupt, and even though the passive server's TCB is in the core's ready queues, because its scheduler action will not change from ResumeCurrentThread (the idle thread). This behaviour can be reliably reproduced with seL4test test IPC0028 (which was disabled for me, so double-check that it actually runs).

There are multiple ways that this issue could be fixed. For example, the enqueue+IPI could be done during the handling of the syscall. However this would probably necessitate changing the scheduling code anyway, as it will still call SCHED_ENQUEUE_CURRENT_TCB. For now I have chosen the simple fix of adding an IPI where the enqueue is done.

See also #941 for more discussion.

Test with: https://github.com/seL4/sel4test/pull/123