### PR TITLE
qemu: avoid QEMU build/run crashing for 32-bit systems.

### DIFF
--- a/src/plat/qemu-arm-virt/config.cmake
+++ b/src/plat/qemu-arm-virt/config.cmake
@@ -135,6 +135,13 @@ if(KernelPlatformQEMUArmVirt)
                 # 2 GiB, which seems a good trade-off nowadays. It's sufficient
                 # for test/demo systems, but still something the host can
                 # provide without running short on resources.
+                # The memory starts at 1 GiB (0x40000000), so up to 3 GiB can be
+                # accessed before exceeding the 32-bit address space. For 32-bit
+                # systems, using memory beyond this point is non-trivial. While
+                # the LPAE MMU model supports accessing up to a 1 TiB (40-bit)
+                # physical address space even on 32-bit systems, the 32-bit
+                # version of seL4 can access physical addresses in the 32-bit
+                # range only.
                 set(QEMU_MEMORY "1024")
             endif()
 
@@ -218,6 +225,10 @@ if(KernelPlatformQEMUArmVirt)
     endif()
 
     list(APPEND KernelDTSList "${QEMU_DTS}" "${CMAKE_CURRENT_LIST_DIR}/overlay-qemu-arm-virt.dts")
+
+    if(KernelSel4ArchAarch32)
+        list(APPEND KernelDTSList "${CMAKE_CURRENT_LIST_DIR}/overlay-qemu-arm-virt32.dts")
+    endif()
 
     if(KernelArmHypervisorSupport OR KernelSel4ArchArmHyp)
         list(APPEND KernelDTSList "${CMAKE_CURRENT_LIST_DIR}/overlay-reserve-vm-memory.dts")

--- a/src/plat/qemu-arm-virt/overlay-qemu-arm-virt32.dts
+++ b/src/plat/qemu-arm-virt/overlay-qemu-arm-virt32.dts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022, HENSOLDT Cyber
+ *
+ *  * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/ {
+    reserved-memory {
+        #address-cells = <0x02>;
+        #size-cells = <0x02>;
+        ranges;
+
+        /* The 32-bit version of seL4 can handle a 32-bit physical
+         * address space (4 GiB) only, even if LPAE allows using a
+         * 40-bit physical address space. For now, reserving any memory
+         * starting at 0xffffffff is the easiest way to cope with
+         * platform configurations having pyhsical memory of exactly
+         * 4 GiB or above. The long-term fix is improving the seL4 build
+         * scripts to be aware of the 4 GiB limitation and never create
+         * any regions above. Furthermore, a way needs to be found to
+         * support using exactly 4 GiB also.
+         */
+        reserved-memory@ffffffff{
+            reg = < 0x00000000 0xffffffff 0xffffffff 0x00000001 >;
+            no-map;
+        };
+
+    };
+};

--- a/src/plat/qemu-riscv-virt/config.cmake
+++ b/src/plat/qemu-riscv-virt/config.cmake
@@ -189,6 +189,10 @@ if(KernelPlatformQEMURiscVVirt)
 
     list(APPEND KernelDTSList "${QEMU_DTS}" "${CMAKE_CURRENT_LIST_DIR}/overlay-qemu-riscv-virt.dts")
 
+    if(KernelSel4ArchRiscV32)
+        list(APPEND KernelDTSList "${CMAKE_CURRENT_LIST_DIR}/overlay-qemu-riscv-virt32.dts")
+    endif()
+
     # QEMU emulates a SiFive PLIC/CLINT with 127 interrupt sources by default.
     # The CLINT timer pretends to run at 10 MHz, but this speed may not hold in
     # practical measurements.

--- a/src/plat/qemu-riscv-virt/overlay-qemu-riscv-virt32.dts
+++ b/src/plat/qemu-riscv-virt/overlay-qemu-riscv-virt32.dts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022, HENSOLDT Cyber
+ *
+ *  * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/ {
+    reserved-memory {
+        #address-cells = <0x02>;
+        #size-cells = <0x02>;
+        ranges;
+
+        /* The 32-bit version of seL4 can handle a 32-bit physical
+         * address space (4 GiB) only, even if SV32 allows using a
+         * 34-bit physical address space. For now, reserving any memory
+         * starting at 0xffffffff is the easiest way to cope with
+         * platform configurations having pyhsical memory of exactly
+         * 4 GiB or above. The long-term fix is improving the seL4 build
+         * scripts to be aware of the 4 GiB limitation and never create
+         * any regions above. Furthermore, a way needs to be found to
+         * support using exactly 4 GiB also.
+         */
+        reserved-memory@ffffffff{
+            reg = < 0x00000000 0xffffffff 0xffffffff 0x00000001 >;
+            no-map;
+        };
+
+    };
+};


### PR DESCRIPTION
Use device tree overlay as a smart hack to avoid crashes if 32-bit QEMU is misconfigured or has >=4 GiB RAM.

This cope with the current inability of the seL4 build scripts to handle a full 4 GiB address space without overflows. It handles configurations where a 32-bit QEMU has RAM beyond the 4 GiB border (by accident or design) by simply reserving all memory beyond `0xffffffff`. It avoids that the seL4 build scripts generate regions addresses >= `0x100000000`, which break compilation, because such values don't fit into 32-bit variables used for physical addresses on 32-bit systems.
The long term solution should be a fix in the builds scripts, so a full 4 GiB address space is usable and everything beyond 4 GiB is ignored.