### PR TITLE
Move getActiveIRQ() close to use site

### DIFF
--- a/src/api/syscall.c
+++ b/src/api/syscall.c
@@ -38,7 +38,6 @@ exception_t handleInterruptEntry(void)
 {
     irq_t irq;
 
-    irq = getActiveIRQ();
 #ifdef CONFIG_KERNEL_MCS
     if (SMP_TERNARY(clh_is_self_in_queue(), 1)) {
         updateTimestamp();
@@ -46,6 +45,7 @@ exception_t handleInterruptEntry(void)
     }
 #endif
 
+    irq = getActiveIRQ();
     if (IRQT_TO_IRQ(irq) != IRQT_TO_IRQ(irqInvalid)) {
         handleInterrupt(irq);
     } else {
@@ -521,8 +521,8 @@ exception_t handleSyscall(syscall_t syscall)
         case SysSend:
             ret = handleInvocation(false, true, false, false, getRegister(NODE_STATE(ksCurThread), capRegister));
             if (unlikely(ret != EXCEPTION_NONE)) {
-                irq = getActiveIRQ();
                 mcsPreemptionPoint();
+                irq = getActiveIRQ();
                 if (IRQT_TO_IRQ(irq) != IRQT_TO_IRQ(irqInvalid)) {
                     handleInterrupt(irq);
                 }
@@ -533,8 +533,8 @@ exception_t handleSyscall(syscall_t syscall)
         case SysNBSend:
             ret = handleInvocation(false, false, false, false, getRegister(NODE_STATE(ksCurThread), capRegister));
             if (unlikely(ret != EXCEPTION_NONE)) {
-                irq = getActiveIRQ();
                 mcsPreemptionPoint();
+                irq = getActiveIRQ();
                 if (IRQT_TO_IRQ(irq) != IRQT_TO_IRQ(irqInvalid)) {
                     handleInterrupt(irq);
                 }
@@ -544,8 +544,8 @@ exception_t handleSyscall(syscall_t syscall)
         case SysCall:
             ret = handleInvocation(true, true, true, false, getRegister(NODE_STATE(ksCurThread), capRegister));
             if (unlikely(ret != EXCEPTION_NONE)) {
-                irq = getActiveIRQ();
                 mcsPreemptionPoint();
+                irq = getActiveIRQ();
                 if (IRQT_TO_IRQ(irq) != IRQT_TO_IRQ(irqInvalid)) {
                     handleInterrupt(irq);
                 }
@@ -586,8 +586,8 @@ exception_t handleSyscall(syscall_t syscall)
             cptr_t dest = getNBSendRecvDest();
             ret = handleInvocation(false, false, true, true, dest);
             if (unlikely(ret != EXCEPTION_NONE)) {
-                irq = getActiveIRQ();
                 mcsPreemptionPoint();
+                irq = getActiveIRQ();
                 if (IRQT_TO_IRQ(irq) != IRQT_TO_IRQ(irqInvalid)) {
                     handleInterrupt(irq);
                 }
@@ -600,8 +600,8 @@ exception_t handleSyscall(syscall_t syscall)
         case SysNBSendWait:
             ret = handleInvocation(false, false, true, true, getRegister(NODE_STATE(ksCurThread), replyRegister));
             if (unlikely(ret != EXCEPTION_NONE)) {
-                irq = getActiveIRQ();
                 mcsPreemptionPoint();
+                irq = getActiveIRQ();
                 if (IRQT_TO_IRQ(irq) != IRQT_TO_IRQ(irqInvalid)) {
                     handleInterrupt(irq);
                 }


### PR DESCRIPTION
The computation in `mcsPreemptionPoint()` no longer depends on the irq, so `getActiveIRQ()` can be called closer to the actual use site of the irq.

This makes things slightly easier for verification because we don't need to reason about potential side effects of mcsPreemptionPoint before the irq value is used.

Closes #472

(Depends on #992 and should be merged after)