### PR TITLE
machine: compile time checks for multikernel

### DIFF
--- a/include/arch/arm/arch/32/mode/hardware.h
+++ b/include/arch/arm/arch/32/mode/hardware.h
@@ -89,10 +89,15 @@
 #ifndef __ASSEMBLER__
 /* It is required that USER_TOP must be aligned to at least 20 bits */
 compile_assert(USER_TOP_correctly_aligned, IS_ALIGNED(USER_TOP, 20));
+
 /* It is required on arm_hyp that USER_TOP isn't lower than the top GiB */
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
 compile_assert(USER_TOP_top_gb, USER_TOP >= 0xC0000000);
 #endif
+
+/* For alignment conditions to translate over addrFromPPtr, physBase must be
+   aligned to at least the size of a SuperSection. */
+compile_assert(physBase_aligned, IS_ALIGNED(PHYS_BASE_RAW, seL4_SuperSectionBits));
 
 #include <plat/machine/hardware.h>
 #endif

--- a/include/arch/arm/arch/64/mode/hardware.h
+++ b/include/arch/arm/arch/64/mode/hardware.h
@@ -210,6 +210,7 @@
 /* The log buffer is placed before the device region */
 #define KS_LOG_PPTR (KDEV_BASE - UL_CONST(0x200000))
 
+#ifndef __ASSEMBLER__
 /* All PPTR addresses must be canonical to be able to be stored in caps or objects.
    Check that all UTs that are created will have valid address in the PPTR space.
    For non-hyp, PPTR_BASE is in the top part of the address space and device untyped
@@ -218,7 +219,6 @@
    overflow without going into address ranges that are non-canonical.  These static
    asserts check that the kernel config won't lead to UTs being created that aren't
    representable. */
-#ifndef __ASSEMBLER__
 compile_assert(ut_max_less_than_cannonical, CONFIG_PADDR_USER_DEVICE_TOP <= BIT(47));
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
 compile_assert(ut_max_is_cannonical, (PPTR_BASE + CONFIG_PADDR_USER_DEVICE_TOP) <= BIT(48));

--- a/include/arch/riscv/arch/machine.h
+++ b/include/arch/riscv/arch/machine.h
@@ -16,6 +16,24 @@
 #include <arch/sbi.h>
 #include <mode/machine.h>
 
+/* PPTR_BASE must be smaller than KERNEL_ELF_BASE. */
+compile_assert(pptr_base_less_elf_base, PPTR_BASE < KERNEL_ELF_BASE_RAW);
+/* physBase must be aligned to a page for verification to succeed. */
+compile_assert(phys_base_page_aligned, IS_ALIGNED(PHYS_BASE_RAW, seL4_PageBits));
+
+/* The following compile time checks are verification artifacts. Not necessarily
+   all systems need to satisfy these, but proofs will need to be changed
+   manually if they are not satisfied. These particular checks also are not
+   necessarily sufficient for all real platforms, but they are good sanity
+   checks to have always on. */
+
+/* PPTR_BASE must be at least twice as far away from KERNEL_ELF_BASE as a LargePage. */
+compile_assert(pptr_base_distance, PPTR_BASE + BIT(seL4_LargePageBits + 1) < KERNEL_ELF_BASE_RAW);
+/* Kernel ELF window must have at least 64k space */
+compile_assert(kernel_elf_distance, KERNEL_ELF_BASE_RAW + BIT(16) < KDEV_BASE);
+/* End of kernel ELF window must not overflow as a word_t */
+compile_assert(kernel_elf_no_overflow, KERNEL_ELF_BASE_RAW < KERNEL_ELF_BASE_RAW + BIT(16));
+
 /* Bit flags in CSR MIP/SIP (interrupt pending). */
 /* Bit 0 was SIP_USIP, but the N extension will be dropped in v1.12 */
 #define SIP_SSIP   1 /* S-Mode software interrupt pending. */


### PR DESCRIPTION
Add compile time checks for conditions on physBase that are necessary for verification of multikernel builds to succeed -- if these fail, the proofs will fail.

If these succeed, and nothing else has changed compared to a verified kernel other than physBase, then the proofs will succeed. This does not mean that all platform requirements are validated, it just means that all requirements for the proofs to be consistent are met.

The conditions correspond to those in

    spec/machine/*/Arch_Kernel_Config_Lemmas.thy

in the verification repository. E.g. see [here for Aarch32](https://github.com/seL4/l4v/blob/master/spec/machine/ARM/Arch_Kernel_Config_Lemmas.thy).