### PR TITLE
sanity checks for memory regions

### DIFF
--- a/include/basic_types.h
+++ b/include/basic_types.h
@@ -46,16 +46,19 @@ enum _bool {
 };
 typedef word_t bool_t;
 
+/** A region of kernel virtual memory. Empty if start == end. Must satisfy start <= end. */
 typedef struct region {
     pptr_t start;
     pptr_t end;
 } region_t;
 
+/** A region of physical addresses. Empty if start == end. Must satisfy start <= end. */
 typedef struct p_region {
     paddr_t start;
     paddr_t end;
 } p_region_t;
 
+/** A region of user virtual addresses. Empty if start == end. Must satisfy start <= end. */
 typedef struct v_region {
     vptr_t start;
     vptr_t end;
@@ -63,6 +66,7 @@ typedef struct v_region {
 
 #define REG_EMPTY (region_t){ .start = 0, .end = 0 }
 #define P_REG_EMPTY (p_region_t){ .start = 0, .end = 0 }
+#define REG_VALID(reg) ((reg).start <= (reg).end)
 
 /* equivalent to a word_t except that we tell the compiler that we may alias with
  * any other type (similar to a char pointer) */

--- a/include/machine.h
+++ b/include/machine.h
@@ -39,16 +39,43 @@ static inline paddr_t CONST addrFromKPPtr(const void *pptr)
 #define pptr_to_paddr(x)   addrFromPPtr(x)
 #define kpptr_to_paddr(x)  addrFromKPPtr(x)
 
+/**
+ * Convert a physical address region to a kernel virtual address region in the
+ * physical memory window.
+ *
+ * Inverse of pptr_to_paddr_reg(). The returned region may not be valid if
+ * address translation overflows only one address, but not the other. It is the
+ * caller's repsonsibility to know or check that this is not the case. It is Ok
+ * for both values to overflow if the values still satisfy platform invariants
+ * (e.g. are canonical) or if they are used in device untypeds only (i.e. never
+ * dereferenced).
+ *
+ * @param p_reg Physical address region.
+ * @return Kernel virtual address region.
+ */
 static inline region_t CONST paddr_to_pptr_reg(const p_region_t p_reg)
 {
+    assert(p_reg.start <= p_reg.end);
     return (region_t) {
         .start = (paddr_t)paddr_to_pptr(p_reg.start),
         .end   = (paddr_t)paddr_to_pptr(p_reg.end)
     };
 }
 
+/**
+ * Convert a kernel virtual address region to a phyiscal address region.
+ *
+ * Inverse of paddr_to_pptr_reg(). The returned region may not be valid if
+ * address translation overflows only one address, but not the other. It is the
+ * caller's repsonsibility to know or check this is not the case. It is Ok for
+ * both values to overflow.
+ *
+ * @param reg Kernel virtual address region.
+ * @return Physical address region.
+ */
 static inline p_region_t CONST pptr_to_paddr_reg(const region_t reg)
 {
+    assert(reg.start <= reg.end);
     return (p_region_t) {
         .start = pptr_to_paddr((const void *)reg.start),
         .end   = pptr_to_paddr((const void *)reg.end),

--- a/src/arch/arm/kernel/boot.c
+++ b/src/arch/arm/kernel/boot.c
@@ -68,6 +68,7 @@ BOOT_CODE static bool_t arch_init_freemem(p_region_t ui_p_reg,
     }
     if (ui_p_reg.start < PADDR_TOP) {
         region_t ui_reg = paddr_to_pptr_reg(ui_p_reg);
+        assert(REG_VALID(ui_reg));
         if (MODE_RESERVED == 1) {
             if (index + 1 >= ARRAY_SIZE(reserved)) {
                 printf("ERROR: no slot to add the user image and the "
@@ -332,6 +333,7 @@ static BOOT_CODE bool_t try_init_kernel(
         ui_p_reg_start, ui_p_reg_end
     };
     region_t ui_reg = paddr_to_pptr_reg(ui_p_reg);
+    assert(REG_VALID(ui_reg));
     word_t extra_bi_size = 0;
     pptr_t extra_bi_offset = 0;
     vptr_t extra_bi_frame_vptr;

--- a/src/arch/riscv/kernel/boot.c
+++ b/src/arch/riscv/kernel/boot.c
@@ -62,6 +62,7 @@ BOOT_CODE static bool_t arch_init_freemem(region_t ui_reg,
      */
     res_reg[0].start = (pptr_t)paddr_to_pptr(kpptr_to_paddr((void *)KERNEL_ELF_BASE));
     res_reg[0].end = (pptr_t)paddr_to_pptr(kpptr_to_paddr((void *)ki_end));
+    assert(REG_VALID(res_reg[0]));
 
     int index = 1;
 
@@ -72,6 +73,7 @@ BOOT_CODE static bool_t arch_init_freemem(region_t ui_reg,
             return false;
         }
         res_reg[index] = paddr_to_pptr_reg(dtb_p_reg);
+        assert(REG_VALID(res_reg[index]));
         index += 1;
     }
 
@@ -199,9 +201,11 @@ static BOOT_CODE bool_t try_init_kernel(
         kpptr_to_paddr((void *)KERNEL_ELF_BASE), kpptr_to_paddr(ki_boot_end)
     });
     region_t boot_mem_reuse_reg = paddr_to_pptr_reg(boot_mem_reuse_p_reg);
+    assert(REG_VALID(boot_mem_reuse_reg));
     region_t ui_reg = paddr_to_pptr_reg((p_region_t) {
         ui_p_reg_start, ui_p_reg_end
     });
+    assert(REG_VALID(ui_reg));
     word_t extra_bi_size = 0;
     pptr_t extra_bi_offset = 0;
     vptr_t extra_bi_frame_vptr;

--- a/src/arch/x86/kernel/boot.c
+++ b/src/arch/x86/kernel/boot.c
@@ -77,6 +77,7 @@ BOOT_CODE static bool_t arch_init_freemem(p_region_t ui_p_reg,
     // in the x86 linker script.
     ui_p_reg.start = KERNEL_ELF_PADDR_BASE;
     reserved[0] = paddr_to_pptr_reg(ui_p_reg);
+    assert(REG_VALID(reserved[0]));
     return init_freemem(mem_p_regs->count, mem_p_regs->list, MAX_RESERVED,
                         reserved, it_v_reg, extra_bi_size_bits);
 }
@@ -114,6 +115,9 @@ BOOT_CODE bool_t init_sys_state(
     /* convert from physical addresses to kernel pptrs */
     region_t ui_reg             = paddr_to_pptr_reg(ui_info.p_reg);
     region_t boot_mem_reuse_reg = paddr_to_pptr_reg(boot_mem_reuse_p_reg);
+
+    assert(REG_VALID(ui_reg));
+    assert(REG_VALID(boot_mem_reuse_reg));
 
     /* convert from physical addresses to userland vptrs */
     v_region_t ui_v_reg;

--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -624,6 +624,14 @@ BOOT_CODE static bool_t create_untypeds_for_region(
     seL4_SlotPos first_untyped_slot
 )
 {
+    /* Sanity check for overflow -- it is Ok for device untypeds to contain
+     * invalid kernel pointers, because they will never be accessed, but we
+     * still need start <= end for the code below to work correctly.
+     */
+    if (reg.end < reg.start) {
+        return false;
+    }
+
     while (!is_reg_empty(reg)) {
 
         /* Calculate the bit size of the region. */
@@ -830,6 +838,7 @@ BOOT_CODE bool_t init_freemem(word_t n_available, const p_region_t *available,
         avail_reg[i] = paddr_to_pptr_reg(available[i]);
         avail_reg[i].end = ceiling_kernel_window(avail_reg[i].end);
         avail_reg[i].start = ceiling_kernel_window(avail_reg[i].start);
+        assert(REG_VALID(avail_reg[i]));
     }
 
     word_t a = 0;


### PR DESCRIPTION
Systematically add assertions for validity (`start <= end`) of `paddr_to_pptr_reg` return values in boot code.

Memory regions `region_t`, `p_region_t`, and `v_region_t` are generally assumed to satisfy `start <= end`. This condition can be violated after address translation.

The correct response may be to fail or to split the region into `[start .. -1`], `[0 .. end]`. While overflow and even invalid kernel pointers are fine for device untyped where these are never dereferenced, the code still assumes `start <= end`, so doing nothing in cases where this is violated is incorrect.