### PR TITLE
boot: strengthen distinctness check

### DIFF
--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -765,7 +765,7 @@ BOOT_CODE static bool_t check_available_memory(word_t n_available,
         }
 
         /* Regions must be ordered and must not overlap. */
-        if ((i > 0) && (r->start < available[i - 1].end)) {
+        if ((i > 0) && (r->start <= available[i - 1].end)) {
             printf("ERROR: memory region %d in wrong order\n", (int)i);
             return false;
         }
@@ -792,7 +792,7 @@ BOOT_CODE static bool_t check_reserved_memory(word_t n_reserved,
         }
 
         /* Regions must be ordered and must not overlap. */
-        if ((i > 0) && (r->start < reserved[i - 1].end)) {
+        if ((i > 0) && (r->start <= reserved[i - 1].end)) {
             printf("ERROR: reserved region %"SEL4_PRIu_word" in wrong order\n", i);
             return false;
         }


### PR DESCRIPTION
Strengthen the distinctness checks for memory regions in `check_available_memory` and `check_reserved_memory`.

We want the property `reg[i-1].end < reg[i].start`, because if these values are equal, `reg[i].start` is part of both regions. Directly adjacent regions have `reg[i].start == reg[i-1].end + 1`.

The negation of `reg[i-1].end < reg[i].start` is `reg[i].start >= reg[i-1].end`.

Caught this while looking at documenting the overflow issue (#1004).