### PR TITLE
gcc.cmake: add more known ARM cross compilers

### DIFF
--- a/gcc.cmake
+++ b/gcc.cmake
@@ -62,7 +62,13 @@ if("${CROSS_COMPILER_PREFIX}" STREQUAL "")
                 "arm-none-eabi-"
             )
         elseif(${sel4_arch} STREQUAL "aarch64")
-            FindPrefixedGCC(CROSS_COMPILER_PREFIX "aarch64-linux-gnu-" "aarch64-unknown-linux-gnu-")
+            FindPrefixedGCC(
+                CROSS_COMPILER_PREFIX
+                "aarch64-linux-gnu-"
+                "aarch64-unknown-linux-gnu-"
+                "aarch64-none-linux-gnu-"
+                "aarch64-none-elf-"
+            )
         elseif(${arch} STREQUAL "riscv")
             FindPrefixedGCC(
                 CROSS_COMPILER_PREFIX
@@ -86,7 +92,13 @@ if("${CROSS_COMPILER_PREFIX}" STREQUAL "")
                 message("ARM flag is deprecated, please use AARCH32")
             endif()
         elseif(AARCH64)
-            FindPrefixedGCC(CROSS_COMPILER_PREFIX "aarch64-linux-gnu-" "aarch64-unknown-linux-gnu-")
+            FindPrefixedGCC(
+                CROSS_COMPILER_PREFIX
+                "aarch64-linux-gnu-"
+                "aarch64-unknown-linux-gnu-"
+                "aarch64-none-linux-gnu-"
+                "aarch64-none-elf-"
+            )
         elseif(RISCV32 OR RISCV64)
             FindPrefixedGCC(
                 CROSS_COMPILER_PREFIX


### PR DESCRIPTION
These are the prefixes used by the official Arm GNU Toolchain [1] It would be convenient if seL4 would recognise it out of the box.

[1] https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads