### PR TITLE
aarch64: Add option for user cache maintenance 

### DIFF
--- a/include/arch/arm/arch/64/mode/machine/hardware.h
+++ b/include/arch/arm/arch/64/mode/machine/hardware.h
@@ -18,8 +18,11 @@
 #define CONTROL_SA0       4  /* Stack Alignment Check Enable for EL0 */
 #define CONTROL_SA        3  /* Stack Alignment Check for EL1 */
 #define CONTROL_I         12 /* Instruction access Cacheability control */
+#define CONTROL_UCT       15 /* Enable EL0 access to CTR_EL0   */
 #define CONTROL_E0E       24 /* Endianness of data accesses at EL0 */
 #define CONTROL_EE        25 /* Endianness of data accesses at EL1 */
+#define CONTROL_UCI       26 /* Trap EL0 execution of cache maintenance
+                                instructions to EL1 (aarch64 only) */
 
 #ifndef __ASSEMBLER__
 

--- a/include/arch/arm/armv/armv8-a/64/armv/vcpu.h
+++ b/include/arch/arm/armv/armv8-a/64/armv/vcpu.h
@@ -32,14 +32,14 @@
 #define SCTLR_EL1_C         BIT(2)      /* Enable data and unified caches */
 #define SCTLR_EL1_I         BIT(12)     /* Enable instruction cache       */
 #define SCTLR_EL1_CP15BEN   BIT(5)      /* AArch32 CP15 barrier enable    */
-#define SCTLR_EL1_UTC       BIT(15)     /* Enable EL0 access to CTR_EL0   */
+#define SCTLR_EL1_UCT       BIT(15)     /* Enable EL0 access to CTR_EL0   */
 #define SCTLR_EL1_NTWI      BIT(16)     /* WFI executed as normal         */
 #define SCTLR_EL1_NTWE      BIT(18)     /* WFE executed as normal         */
 
 /* Disable MMU, SP alignment check, and alignment check */
 /* A57 default value */
 #define SCTLR_EL1_RES      0x30d00800   /* Reserved value */
-#define SCTLR_EL1          ( SCTLR_EL1_RES | SCTLR_EL1_CP15BEN | SCTLR_EL1_UTC \
+#define SCTLR_EL1          ( SCTLR_EL1_RES | SCTLR_EL1_CP15BEN | SCTLR_EL1_UCT \
                            | SCTLR_EL1_NTWI | SCTLR_EL1_NTWE )
 #define SCTLR_EL1_NATIVE   (SCTLR_EL1 | SCTLR_EL1_C | SCTLR_EL1_I | SCTLR_EL1_UCI)
 #define SCTLR_EL1_VM       (SCTLR_EL1 | SCTLR_EL1_UCI)

--- a/include/arch/arm/armv/armv8-a/64/armv/vcpu.h
+++ b/include/arch/arm/armv/armv8-a/64/armv/vcpu.h
@@ -36,13 +36,19 @@
 #define SCTLR_EL1_NTWI      BIT(16)     /* WFI executed as normal         */
 #define SCTLR_EL1_NTWE      BIT(18)     /* WFE executed as normal         */
 
+#ifdef CONFIG_AARCH64_USER_CACHE_ENABLE
+#define SCTLR_NATIVE_USER_CACHE_OPS (SCTLR_EL1_UCI | SCTLR_EL1_UCT)
+#else
+#define SCTLR_NATIVE_USER_CACHE_OPS
+#endif
+
 /* Disable MMU, SP alignment check, and alignment check */
 /* A57 default value */
 #define SCTLR_EL1_RES      0x30d00800   /* Reserved value */
-#define SCTLR_EL1          ( SCTLR_EL1_RES | SCTLR_EL1_CP15BEN | SCTLR_EL1_UCT \
-                           | SCTLR_EL1_NTWI | SCTLR_EL1_NTWE )
-#define SCTLR_EL1_NATIVE   (SCTLR_EL1 | SCTLR_EL1_C | SCTLR_EL1_I | SCTLR_EL1_UCI)
-#define SCTLR_EL1_VM       (SCTLR_EL1 | SCTLR_EL1_UCI)
+#define SCTLR_EL1          ( SCTLR_EL1_RES | SCTLR_EL1_CP15BEN | \
+                             SCTLR_EL1_NTWI | SCTLR_EL1_NTWE )
+#define SCTLR_EL1_NATIVE   (SCTLR_EL1 | SCTLR_EL1_C | SCTLR_EL1_I | SCTLR_NATIVE_USER_CACHE_OPS)
+#define SCTLR_EL1_VM       (SCTLR_EL1 | SCTLR_EL1_UCT | SCTLR_EL1_UCI)
 #define SCTLR_DEFAULT      SCTLR_EL1_NATIVE
 
 #define UNKNOWN_FAULT       0x2000000

--- a/src/arch/arm/64/head.S
+++ b/src/arch/arm/64/head.S
@@ -23,6 +23,14 @@
 #define CR_ALIGN_CLEAR   0
 #endif
 
+#if defined(CONFIG_ARM_HYPERVISOR_SUPPORT) && defined(CONFIG_AARCH64_USER_CACHE_ENABLE)
+#define CR_USER_CACHE_OPS_SET (BIT(CONTROL_UCT) | BIT(CONTROL_UCI))
+#define CR_USER_CACHE_OPS_CLEAR 0
+#else
+#define CR_USER_CACHE_OPS_SET 0
+#define CR_USER_CACHE_OPS_CLEAR (BIT(CONTROL_UCT) | BIT(CONTROL_UCI))
+#endif
+
 #ifndef CONFIG_DEBUG_DISABLE_L1_ICACHE
     #define CR_L1_ICACHE_SET   BIT(CONTROL_I)
     #define CR_L1_ICACHE_CLEAR 0
@@ -42,11 +50,13 @@
 #define CR_BITS_SET    (CR_ALIGN_SET | \
                         CR_L1_ICACHE_SET | \
                         CR_L1_DCACHE_SET | \
+                        CR_USER_CACHE_OPS_SET | \
                         BIT(CONTROL_M))
 
 #define CR_BITS_CLEAR  (CR_ALIGN_CLEAR | \
                         CR_L1_ICACHE_CLEAR | \
                         CR_L1_DCACHE_CLEAR | \
+                        CR_USER_CACHE_OPS_CLEAR | \
                         BIT(CONTROL_SA0) | \
                         BIT(CONTROL_EE) | \
                         BIT(CONTROL_E0E))

--- a/src/arch/arm/config.cmake
+++ b/src/arch/arm/config.cmake
@@ -190,6 +190,15 @@ config_option(
 )
 
 config_option(
+    KernelAArch64UserCacheEnable AARCH64_USER_CACHE_ENABLE
+    "Enable any attempt to execute a DC CVAU, DC CIVAC, DC CVAC, or IC IVAU \
+    instruction or access to CTR_EL0 at EL0 using AArch64. \
+    When disabled, these operations will be trapped."
+    DEFAULT ON
+    DEPENDS "KernelSel4ArchAarch64"
+)
+
+config_option(
     KernelAArch64SErrorIgnore AARCH64_SERROR_IGNORE
     "By default any SError interrupt will halt the kernel. SErrors may \
     be caused by e.g. writes to read-only device registers or ECC errors. \


### PR DESCRIPTION
Add a config option, KernelAArch64UserCacheEnable, that enables user
level access to DC CVAU, DC CIVAC, DC CVAC, and IC IVAU which are cache
maintenance operations for the data caches and instruction caches
underlying Normal memory and also access to the read-only cache-type
register CTR_EL0 that provides cache type information. The ArmV8-A
architecture allows access from EL0 as fast cache maintenance operations
improves DMA performance in user-level device drivers.

These instructions are a subset of the available cache maintenance
instructions as they can only address lines by virtual address (VA).
They also require that the VA provided referrs to a valid mapping
with at least read permissions. This corresponds to lines that the
EL0 could already affect via regular operation and so it's not expected
to break any cache-partitioning scheme.

The config option allows this policy to be selected for a particular
kernel configuration, but it is default enabled as this has been the
existing behavior for current aarch64,hyp configurations and have not
been explicitly disabled in non-hyp configurations.