### PR TITLE
SMP: only enter scheduler if node holds BKL

### DIFF
--- a/src/api/syscall.c
+++ b/src/api/syscall.c
@@ -55,14 +55,10 @@ exception_t handleInterruptEntry(void)
         handleSpuriousIRQ();
     }
 
-#ifdef CONFIG_KERNEL_MCS
     if (SMP_TERNARY(clh_is_self_in_queue(), 1)) {
-#endif
         schedule();
         activateThread();
-#ifdef CONFIG_KERNEL_MCS
     }
-#endif
 
     return EXCEPTION_NONE;
 }


### PR DESCRIPTION
In the IPI remote call paths where target nodes enter the kernel under the protection of the calling core's BKL, the scheduler may be invoked after handling the interrupt. The MCS kernel protects against this by doing a check, however, the commit that added this check did not do the same for the non-MCS kernel, so we remove the ifdef and check for both MCS and non-MCS.