### PR TITLE
cmake: define KERNEL_ROOT_DIR

### DIFF
--- a/configs/seL4Config.cmake
+++ b/configs/seL4Config.cmake
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
+set(KERNEL_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/..")
+
 #
 # Architecture selection
 #
@@ -13,8 +15,8 @@ set(asm_sources "")
 set(bf_declarations "")
 set(KernelDTSList "")
 
-include(${CMAKE_CURRENT_LIST_DIR}/../tools/internal.cmake)
-include(${CMAKE_CURRENT_LIST_DIR}/../tools/helpers.cmake)
+include(${KERNEL_ROOT_DIR}/tools/internal.cmake)
+include(${KERNEL_ROOT_DIR}/tools/helpers.cmake)
 
 # Create and set all of the Kernel config options that can be derived from the
 # seL4 arch which is one of the following:
@@ -158,7 +160,7 @@ unset(KernelArmArmV CACHE)
 # Blacklist platforms without MCS support
 set(KernelPlatformSupportsMCS ON)
 
-file(GLOB result ${CMAKE_CURRENT_LIST_DIR}/../src/plat/*/config.cmake)
+file(GLOB result ${KERNEL_ROOT_DIR}/src/plat/*/config.cmake)
 list(SORT result)
 
 foreach(file ${result})
@@ -241,9 +243,7 @@ if(
         set(cross_prefix $CACHE{CROSS_COMPILER_PREFIX})
     endif()
 
-    configure_file(
-        "${CMAKE_CURRENT_LIST_DIR}/../${toolchain_file}" "${toolchain_outputfile}.temp" @ONLY
-    )
+    configure_file("${KERNEL_ROOT_DIR}/${toolchain_file}" "${toolchain_outputfile}.temp" @ONLY)
     if(EXISTS "${toolchain_outputfile}")
         file(READ "${toolchain_outputfile}.temp" filea)
         file(READ "${toolchain_outputfile}" fileb)


### PR DESCRIPTION
Define the (relative) location of the kernel project in one place only.