### PR TITLE
gic_v3: AP1R for group 1 IRQs

### DIFF
--- a/include/arch/arm/arch/machine/gic_v3.h
+++ b/include/arch/arm/arch/machine/gic_v3.h
@@ -386,13 +386,13 @@ static inline void set_gic_vcpu_ctrl_vmcr(uint32_t vmcr)
 static inline uint32_t get_gic_vcpu_ctrl_apr(void)
 {
     uint32_t reg;
-    MRS(ICH_AP0R0_EL2, reg);
+    MRS(ICH_AP1R0_EL2, reg);
     return reg;
 }
 
 static inline void set_gic_vcpu_ctrl_apr(uint32_t apr)
 {
-    MSR(ICH_AP0R0_EL2, apr);
+    MSR(ICH_AP1R0_EL2, apr);
 }
 
 static inline uint32_t get_gic_vcpu_ctrl_vtr(void)


### PR DESCRIPTION
- In non-secure world, group 1 IRQs are used instead of group 0.
- APR for GICv2 is 32-bit while for GICv3 is 64-bit wide.