### PR TITLE
Remove VMKernelReadOnly from AArch64 VM rights

### DIFF
--- a/include/arch/arm/arch/64/mode/object/structures.h
+++ b/include/arch/arm/arch/64/mode/object/structures.h
@@ -26,7 +26,6 @@ typedef struct arch_tcb {
 enum vm_rights {
     VMKernelOnly = 0,
     VMReadWrite = 1,
-    VMKernelReadOnly = 2,
     VMReadOnly = 3
 };
 typedef word_t vm_rights_t;

--- a/src/arch/arm/64/kernel/vspace.c
+++ b/src/arch/arm/64/kernel/vspace.c
@@ -149,14 +149,6 @@ static word_t CONST APFromVMRights(vm_rights_t vm_rights)
             return 1;
         }
 
-    case VMKernelReadOnly:
-        if (config_set(CONFIG_ARM_HYPERVISOR_SUPPORT)) {
-            /* no corresponding AP for S2AP, return None */
-            return 0;
-        } else {
-            return 2;
-        }
-
     case VMReadOnly:
         if (config_set(CONFIG_ARM_HYPERVISOR_SUPPORT)) {
             return 1;


### PR DESCRIPTION
From investigating https://github.com/seL4/seL4/issues/214 it looks like the VM right `VMKernelReadOnly` is not used at all. It was introduced in the initial AArch64 port of seL4, I do not know why it exists, perhaps there is a reason and I am missing something.