### PR TITLE
Add support for other Raspberry Pi 4B variants

### DIFF
--- a/src/plat/bcm2711/config.cmake
+++ b/src/plat/bcm2711/config.cmake
@@ -26,6 +26,25 @@ if(KernelPlatformRpi4)
     list(APPEND KernelDTSList "src/plat/bcm2711/overlay-rpi4.dts")
     list(APPEND KernelDTSList "src/plat/bcm2711/overlay-rpi4-address-mapping.dts")
 
+    if(NOT DEFINED RPI4_MEMORY)
+        # By default we assume an RPi4B model with 8GB of RAM
+        set("${RPI4_MEMORY}" "8192")
+    endif()
+
+    if("${RPI4_MEMORY}" STREQUAL "1024")
+        list(APPEND KernelDTSList "src/plat/bcm2711/overlay-rpi4-1gb.dts")
+    elseif("${RPI4_MEMORY}" STREQUAL "2048")
+        list(APPEND KernelDTSList "src/plat/bcm2711/overlay-rpi4-2gb.dts")
+    elseif("${RPI4_MEMORY}" STREQUAL "4096")
+        list(APPEND KernelDTSList "src/plat/bcm2711/overlay-rpi4-4gb.dts")
+    elseif("${RPI4_MEMORY}" STREQUAL "8192")
+        list(APPEND KernelDTSList "src/plat/bcm2711/overlay-rpi4-8gb.dts")
+    else()
+        message(FATAL_ERROR "Unsupported memory size given ${RPI4_MEMORY},
+                            supported memory sizes (in megabytes) are 1024,
+                            2048, 4096, and 8192.")
+    endif()
+
     # - The clock frequency is 54 MHz as can be seen in bcm2711.dtsi in the
     # Linux Kernel under clk_osc, thus TIMER_FREQUENCY = 54000000.
     # - The GIC-400 offers 216 SPI IRQs (MAX_IRQ = 216) as can be seen in the

--- a/src/plat/bcm2711/overlay-rpi4-1gb.dts
+++ b/src/plat/bcm2711/overlay-rpi4-1gb.dts
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2023, UNSW
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+/ {
+    /delete-node/ memory;
+
+    /* Memory for the 1GB RAM variant of the RPi4B, see overlay-pi4.dts for an
+     * explanation of the memory ranges.
+     */
+    memory@0 {
+        device_type = "memory";
+        reg = < 0x00000000 0x00000000 0x3b400000 >;
+    };
+};

--- a/src/plat/bcm2711/overlay-rpi4-2gb.dts
+++ b/src/plat/bcm2711/overlay-rpi4-2gb.dts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2023, UNSW
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+/ {
+    /delete-node/ memory;
+
+    /* Memory for the 2GB RAM variant of the RPi4B, see overlay-pi4.dts for an
+     * explanation of the memory ranges.
+     */
+    memory@0 {
+        device_type = "memory";
+        reg = < 0x00000000 0x00000000 0x3b400000
+            0x00000000 0x40000000 0x40000000 >;
+    };
+};

--- a/src/plat/bcm2711/overlay-rpi4-4gb.dts
+++ b/src/plat/bcm2711/overlay-rpi4-4gb.dts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2023, UNSW
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+/ {
+    /delete-node/ memory;
+
+    /* Memory for the 4GB RAM variant of the RPi4B, see overlay-pi4.dts for an
+     * explanation of the memory ranges.
+     */
+    memory@0 {
+        device_type = "memory";
+        reg = < 0x00000000 0x00000000 0x3b400000
+            0x00000000 0x40000000 0xbc000000 >;
+    };
+};

--- a/src/plat/bcm2711/overlay-rpi4-8gb.dts
+++ b/src/plat/bcm2711/overlay-rpi4-8gb.dts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2023, UNSW
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+/ {
+    /delete-node/ memory;
+
+    /* Memory for the 8GB RAM variant of the RPi4B, see overlay-pi4.dts for an
+     * explanation of the memory ranges.
+     */
+    memory@0 {
+        device_type = "memory";
+        reg = < 0x00000000 0x00000000 0x3b400000
+            0x00000000 0x40000000 0xbc000000
+            0x00000001 0x00000000 0x80000000
+            0x00000001 0x80000000 0x80000000 >;
+    };
+};

--- a/src/plat/bcm2711/overlay-rpi4.dts
+++ b/src/plat/bcm2711/overlay-rpi4.dts
@@ -37,17 +37,15 @@
 	 * 0x01 0x00000000 0x80000000  2048MB
 	 * 0x01 0x80000000 0x80000000  2048MB
 	 *
+	 * In "low peripheral" mode there is a reserved region [0xfc000000, 0x100000000)
+	 * which is why the region starting at 0x40000000 has a size of 0xbc000000.
+	 *
+	 * There are multiple models of the RPi4B with different sizes of RAM.
+	 * The above outlines the memory ranges for the 8GB model, for models
+	 * with less than 4GB of RAM, the last two ranges are omitted. For the
+	 * 2GB model, the range starting at 0x40000000 is smaller in size.
+	 *
 	 */
-
-	/delete-node/ memory;
-
-	memory@0 {
-		device_type = "memory";
-		reg = < 0x00000000 0x00000000 0x3b400000
-			0x00000000 0x40000000 0xbc000000
-			0x00000001 0x00000000 0x80000000
-			0x00000001 0x80000000 0x80000000 >;
-	};
 
 	reserved-memory {
 		#address-cells = <0x02>;


### PR DESCRIPTION
There are multiple variants of the RPi4B SBC with different sizes of RAM. There exists 1GB, 2GB, 4GB, and 8GB models. This patch adds the `RPI4_MEMORY` CMake configuration option in order to be able to specify the RAM size when building the kernel. Based on the RAM size provided, an appropriate device tree overlay is selected.

The default memory size of 8GB remains the same as to not introduce breaking changes.

Closes https://github.com/seL4/seL4/issues/1044.