### PR TITLE
elfloader: Replace calls to reset_cntvoff

### DIFF
--- a/src/plat/bcm2711/overlay-rpi4.dts
+++ b/src/plat/bcm2711/overlay-rpi4.dts
@@ -9,7 +9,8 @@
 / {
 	chosen {
 		seL4,elfloader-devices =
-		    "serial1";
+		    "serial1",
+		    &{/timer};
 
 		seL4,kernel-devices =
 		    "serial1",

--- a/src/plat/bcm2837/overlay-rpi3.dts
+++ b/src/plat/bcm2837/overlay-rpi3.dts
@@ -7,7 +7,8 @@
 / {
 	chosen {
 		seL4,elfloader-devices =
-		    "serial1";
+		    "serial1",
+		    &{/timer};
 
 		seL4,kernel-devices =
 		    "serial1",

--- a/src/plat/exynos5/overlay-exynos5250.dts
+++ b/src/plat/exynos5/overlay-exynos5250.dts
@@ -9,7 +9,8 @@
 	chosen {
 		stdout-path = "serial2:115200n8";
 		seL4,elfloader-devices =
-		    "serial2";
+		    "serial2",
+		    &{/soc/timer};
 		seL4,kernel-devices =
 		    "serial2",
 		    &{/soc/interrupt-controller@10481000},

--- a/src/plat/exynos5/overlay-exynos5410.dts
+++ b/src/plat/exynos5/overlay-exynos5410.dts
@@ -9,7 +9,8 @@
 	chosen {
 		seL4,boot-cpu = <&{/cpus/cpu@0}>;
 		seL4,elfloader-devices =
-		    "serial2";
+		    "serial2",
+		    &{/timer};
 		seL4,kernel-devices =
 		    "serial2",
 		    &{/soc/interrupt-controller@10481000},

--- a/src/plat/exynos5/overlay-exynos5422.dts
+++ b/src/plat/exynos5/overlay-exynos5422.dts
@@ -15,7 +15,8 @@
 	chosen {
 		seL4,boot-cpu = <&{/cpus/cpu@100}>;
 		seL4,elfloader-devices =
-		    "serial2";
+		    "serial2",
+		    &{/timer};
 		seL4,kernel-devices =
 		    "serial2",
 		    &{/soc/interrupt-controller@10481000},

--- a/src/plat/fvp/overlay-fvp.dts
+++ b/src/plat/fvp/overlay-fvp.dts
@@ -8,7 +8,8 @@
 	chosen {
 		seL4,elfloader-devices =
 		    "serial0",
-		    &{/psci};
+		    &{/psci},
+		    &{/timer};
 
 		seL4,kernel-devices =
 		    "serial0",

--- a/src/plat/hikey/overlay-hikey.dts
+++ b/src/plat/hikey/overlay-hikey.dts
@@ -10,7 +10,8 @@
 
 		seL4,elfloader-devices =
 		    "serial0",
-		    &{/psci};
+		    &{/psci},
+		    &{/timer};
 
 		seL4,kernel-devices =
 		    "serial0",

--- a/src/plat/imx7/overlay-imx7sabre.dts
+++ b/src/plat/imx7/overlay-imx7sabre.dts
@@ -7,7 +7,8 @@
 / {
 	chosen {
 		seL4,elfloader-devices =
-		    "serial0";
+		    "serial0",
+		    &{/timer};
 		seL4,kernel-devices =
 		    "serial0",
 		    &{/soc/interrupt-controller@31001000},

--- a/src/plat/imx8m-evk/overlay-imx8mm-evk.dts
+++ b/src/plat/imx8m-evk/overlay-imx8mm-evk.dts
@@ -8,7 +8,8 @@
     chosen {
         seL4,elfloader-devices =
             "serial1",
-            &{/psci};
+            &{/psci},
+            &{/timer};
 
         seL4,kernel-devices =
             "serial1",

--- a/src/plat/imx8m-evk/overlay-imx8mq-evk.dts
+++ b/src/plat/imx8m-evk/overlay-imx8mq-evk.dts
@@ -8,7 +8,8 @@
 	chosen {
 		seL4,elfloader-devices =
 			"serial0",
-			&{/psci};
+			&{/psci},
+			&{/timer};
 
 		seL4,kernel-devices =
 			"serial0",

--- a/src/plat/maaxboard/overlay-maaxboard.dts
+++ b/src/plat/maaxboard/overlay-maaxboard.dts
@@ -9,7 +9,8 @@
 	chosen {
 		seL4,elfloader-devices =
 			"serial0",
-			&{/psci};
+			&{/psci},
+			&{/timer};
 
 		seL4,kernel-devices =
 			"serial0",

--- a/src/plat/odroidc2/overlay-odroidc2.dts
+++ b/src/plat/odroidc2/overlay-odroidc2.dts
@@ -8,7 +8,8 @@
 	chosen {
 		seL4,elfloader-devices =
 		    "serial0",
-		    &{/psci};
+		    &{/psci},
+		    &{/timer};
 
 		seL4,kernel-devices =
 		    "serial0",

--- a/src/plat/odroidc4/overlay-odroidc4.dts
+++ b/src/plat/odroidc4/overlay-odroidc4.dts
@@ -8,7 +8,8 @@
 	chosen {
 		seL4,elfloader-devices =
 		    "serial0",
-		    &{/psci};
+		    &{/psci},
+		    &{/timer};
 
 		seL4,kernel-devices =
 		    "serial0",

--- a/src/plat/qemu-arm-virt/overlay-qemu-arm-virt.dts
+++ b/src/plat/qemu-arm-virt/overlay-qemu-arm-virt.dts
@@ -8,7 +8,8 @@
 	chosen {
 		seL4,elfloader-devices =
 		    &{/pl011@9000000},
-		    &{/psci};
+		    &{/psci},
+		    &{/timer};
 		seL4,kernel-devices =
             &{/pl011@9000000},
 		    &{/intc@8000000},

--- a/src/plat/quartz64/overlay-quartz64.dts
+++ b/src/plat/quartz64/overlay-quartz64.dts
@@ -8,7 +8,8 @@
 	chosen {
 		seL4,elfloader-devices =
 		    "serial2",
-		    &{/psci};
+		    &{/psci},
+		    &{/timer};
 		seL4,kernel-devices =
 		    "serial2",
 		    &{/interrupt-controller@fd400000},

--- a/src/plat/rockpro64/overlay-rockpro64.dts
+++ b/src/plat/rockpro64/overlay-rockpro64.dts
@@ -8,7 +8,8 @@
 	chosen {
 		seL4,elfloader-devices =
 		    "serial2",
-		    &{/psci};
+		    &{/psci},
+		    &{/timer};
 		seL4,kernel-devices =
 		    "serial2",
 		    &{/interrupt-controller@fee00000},

--- a/src/plat/tk1/overlay-tk1.dts
+++ b/src/plat/tk1/overlay-tk1.dts
@@ -7,7 +7,9 @@
 / {
 	chosen {
 		seL4,elfloader-devices =
-		    "serial0";
+		    "serial0",
+		    &{/timer};
+
 		seL4,kernel-devices =
 		    "serial0",
 		    &{/interrupt-controller@50041000},

--- a/src/plat/tqma8xqp1gb/overlay-tqma8xqp1gb.dts
+++ b/src/plat/tqma8xqp1gb/overlay-tqma8xqp1gb.dts
@@ -8,7 +8,8 @@
 	chosen {
 		seL4,elfloader-devices =
 			"serial1",
-			&{/psci};
+			&{/psci},
+			&{/timer};
 
 		seL4,kernel-devices =
 			"serial1",

--- a/src/plat/tx1/overlay-tx1.dts
+++ b/src/plat/tx1/overlay-tx1.dts
@@ -8,7 +8,8 @@
 	chosen {
 		seL4,elfloader-devices =
 		    "serial0",
-		    &{/psci};
+		    &{/psci},
+		    &{/timer};
 
 		seL4,kernel-devices =
 		    "serial0",

--- a/src/plat/tx2/overlay-tx2.dts
+++ b/src/plat/tx2/overlay-tx2.dts
@@ -10,7 +10,8 @@
 		seL4,boot-cpu = <&{/cpus/cpu@2}>;
 		seL4,elfloader-devices =
 		    "serial0",
-		    &{/psci};
+		    &{/psci},
+		    &{/timer};
 		seL4,kernel-devices =
 		    "serial0",
 		    &{/interrupt-controller@3881000},

--- a/src/plat/zynqmp/overlay-zynqmp.dts
+++ b/src/plat/zynqmp/overlay-zynqmp.dts
@@ -29,7 +29,8 @@
     chosen {
 		seL4,elfloader-devices =
 		    "serial0",
-		    &{/psci};
+		    &{/psci},
+		    &{/timer};
 		seL4,kernel-devices =
 		    "serial0",
 		    &{/amba_apu@0/interrupt-controller@f9010000},


### PR DESCRIPTION
These calls can now be implemented via binding the /timer driver in the elfloader's device tree configuration.

Test with: seL4/seL4_tools#168