### PR TITLE
gic_v3: _Static_assert is not supported

### DIFF
--- a/include/arch/arm/arch/machine/gic_v3.h
+++ b/include/arch/arm/arch/machine/gic_v3.h
@@ -175,7 +175,7 @@ struct gic_dist_map {
                                      * interrupt routing for SPI 32 */
 };
 
-_Static_assert(0x6100 == SEL4_OFFSETOF(struct gic_dist_map, iroutern),
+compile_assert(0x6100 == SEL4_OFFSETOF(struct gic_dist_map, iroutern),
                "Error in struct gic_dist_map");
 
 /* Memory map for GIC Redistributor Registers for control and physical LPI's */


### PR DESCRIPTION
Prefer compile_assert over _Static_assert. The latter is only available in C11, and the verification demands C99.

(The offending instance was introduced in #387)