### PR TITLE
macros: avoid breaking C subset

### DIFF
--- a/include/arch/arm/arch/machine/gic_v3.h
+++ b/include/arch/arm/arch/machine/gic_v3.h
@@ -175,8 +175,11 @@ struct gic_dist_map {
                                      * interrupt routing for SPI 32 */
 };
 
-compile_assert(0x6100 == SEL4_OFFSETOF(struct gic_dist_map, iroutern),
-               "Error in struct gic_dist_map");
+/* __builtin_offsetof is not in the verification C subset, so we can only check this in
+   non-verification builds. We specifically do not declare a macro for the builtin, because
+   we do not want break the verification subset by accident. */
+unverified_compile_assert(error_in_gic_dist_map,
+                          0x6100 == __builtin_offsetof(struct gic_dist_map, iroutern));
 
 /* Memory map for GIC Redistributor Registers for control and physical LPI's */
 struct gic_rdist_map {          /* Starting */

--- a/libsel4/include/sel4/macros.h
+++ b/libsel4/include/sel4/macros.h
@@ -19,7 +19,6 @@
 #define SEL4_PACKED             __attribute__((packed))
 #define SEL4_DEPRECATED(x)      __attribute__((deprecated(x)))
 #define SEL4_DEPRECATE_MACRO(x) _Pragma("deprecated") x
-#define SEL4_OFFSETOF(type, member) __builtin_offsetof(type, member)
 
 #define LIBSEL4_UNUSED          __attribute__((unused))
 #define LIBSEL4_WEAK            __attribute__((weak))


### PR DESCRIPTION
`__builtin_offsetof` is not part of the verification C subset -- avoid accidental use by not declaring a macro for it and filter out the single use by explicitly marking it as invisible to verification.

(I've checked that the macro is not used outside the kernel repo either)