### PR TITLE
Fix setting of CMake variable in BCM2711 config

### DIFF
--- a/src/plat/bcm2711/config.cmake
+++ b/src/plat/bcm2711/config.cmake
@@ -28,7 +28,7 @@ if(KernelPlatformRpi4)
 
     if(NOT DEFINED RPI4_MEMORY)
         # By default we assume an RPi4B model with 8GB of RAM
-        set("${RPI4_MEMORY}" "8192")
+        set(RPI4_MEMORY "8192")
     endif()
 
     if("${RPI4_MEMORY}" STREQUAL "1024")


### PR DESCRIPTION
Apologies, I had made an error in my previous commit which causes a compile error when trying to build the kernel without passing `-DRPI4_MEMORY`.