### PR TITLE
gic_v3: mark gicv3_do_wait_for_rwp dont-translate

### DIFF
--- a/src/arch/arm/machine/gic_v3.c
+++ b/src/arch/arm/machine/gic_v3.c
@@ -75,6 +75,7 @@ static inline uint64_t mpidr_to_gic_affinity(void)
 }
 
 /* Wait for completion of a distributor change */
+/** DONT_TRANSLATE */
 static uint32_t gicv3_do_wait_for_rwp(volatile uint32_t *ctlr_addr)
 {
     uint32_t val;


### PR DESCRIPTION
The verification C parser is failing to translate this function, but it does not actually need to since this is behind the machine interface anyway. Mark the function as dont-translate to avoid the problem.