### PR TITLE
additional verification configs

### DIFF
--- a/configs/ARM_HYP_exynos5_verified.cmake
+++ b/configs/ARM_HYP_exynos5_verified.cmake
@@ -1,0 +1,27 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+# If this file is executed then build the kernel.elf and kernel_all_pp.c file
+include(${CMAKE_CURRENT_LIST_DIR}/../tools/helpers.cmake)
+cmake_script_build_kernel()
+
+set(KernelPlatform "exynos5" CACHE STRING "")
+set(KernelARMPlatform "exynos5422" CACHE STRING "")
+set(KernelSel4Arch "arm_hyp" CACHE STRING "")
+set(KernelAArch32FPUEnableContextSwitch OFF CACHE BOOL "")
+set(KernelVerificationBuild ON CACHE BOOL "")
+set(KernelIPCBufferLocation "threadID_register" CACHE STRING "")
+set(KernelMaxNumNodes "1" CACHE STRING "")
+set(KernelOptimisation "-O2" CACHE STRING "")
+set(KernelRetypeFanOutLimit "256" CACHE STRING "")
+set(KernelBenchmarks "none" CACHE STRING "")
+set(KernelDangerousCodeInjection OFF CACHE BOOL "")
+set(KernelFastpath ON CACHE BOOL "")
+set(KernelPrinting OFF CACHE BOOL "")
+set(KernelNumDomains 16 CACHE STRING "")
+set(KernelRootCNodeSizeBits 19 CACHE STRING "")
+set(KernelMaxNumBootinfoUntypedCaps 50 CACHE STRING "")

--- a/configs/ARM_HYP_verified.cmake
+++ b/configs/ARM_HYP_verified.cmake
@@ -11,6 +11,7 @@ cmake_script_build_kernel()
 
 set(KernelPlatform "tk1" CACHE STRING "")
 set(KernelSel4Arch "arm_hyp" CACHE STRING "")
+set(KernelAArch32FPUEnableContextSwitch OFF CACHE BOOL "")
 set(KernelVerificationBuild ON CACHE BOOL "")
 set(KernelIPCBufferLocation "threadID_register" CACHE STRING "")
 set(KernelMaxNumNodes "1" CACHE STRING "")

--- a/configs/ARM_MCS_verified.cmake
+++ b/configs/ARM_MCS_verified.cmake
@@ -10,6 +10,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/../tools/helpers.cmake)
 cmake_script_build_kernel()
 
 set(KernelPlatform "imx6" CACHE STRING "")
+set(KernelAArch32FPUEnableContextSwitch OFF CACHE BOOL "")
 set(KernelVerificationBuild ON CACHE BOOL "")
 set(KernelBinaryVerificationBuild ON CACHE BOOL "")
 set(KernelOptimisationCloneFunctions OFF CACHE BOOL "")

--- a/configs/ARM_imx8mm_verified.cmake
+++ b/configs/ARM_imx8mm_verified.cmake
@@ -1,0 +1,26 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+# If this file is executed then build the kernel.elf and kernel_all_pp.c file
+include(${CMAKE_CURRENT_LIST_DIR}/../tools/helpers.cmake)
+cmake_script_build_kernel()
+
+set(KernelPlatform "imx8mm-evk" CACHE STRING "")
+set(KernelSel4Arch "aarch32" CACHE STRING "")
+set(KernelAArch32FPUEnableContextSwitch ON CACHE BOOL "")
+set(KernelVerificationBuild ON CACHE BOOL "")
+set(KernelBinaryVerificationBuild ON CACHE BOOL "")
+set(KernelOptimisationCloneFunctions OFF CACHE BOOL "")
+set(KernelIPCBufferLocation "threadID_register" CACHE STRING "")
+set(KernelMaxNumNodes "1" CACHE STRING "")
+set(KernelOptimisation "-O2" CACHE STRING "")
+set(KernelRetypeFanOutLimit "256" CACHE STRING "")
+set(KernelBenchmarks "none" CACHE STRING "")
+set(KernelDangerousCodeInjection OFF CACHE BOOL "")
+set(KernelFastpath ON CACHE BOOL "")
+set(KernelPrinting OFF CACHE BOOL "")
+set(KernelNumDomains 16 CACHE STRING "")

--- a/configs/ARM_verified.cmake
+++ b/configs/ARM_verified.cmake
@@ -10,6 +10,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/../tools/helpers.cmake)
 cmake_script_build_kernel()
 
 set(KernelPlatform "imx6" CACHE STRING "")
+set(KernelAArch32FPUEnableContextSwitch OFF CACHE BOOL "")
 set(KernelVerificationBuild ON CACHE BOOL "")
 set(KernelBinaryVerificationBuild ON CACHE BOOL "")
 set(KernelOptimisationCloneFunctions OFF CACHE BOOL "")

--- a/src/arch/arm/config.cmake
+++ b/src/arch/arm/config.cmake
@@ -185,7 +185,7 @@ config_option(
         operations in a multithreading environment, instead of relying on \
         software emulation of FPU/VFP from the C library (e.g. mfloat-abi=soft)."
     DEFAULT ON
-    DEPENDS "KernelSel4ArchAarch32;NOT KernelVerificationBuild"
+    DEPENDS "KernelSel4ArchAarch32"
     DEFAULT_DISABLED OFF
 )
 


### PR DESCRIPTION
- make AArch32 FPU possible for verification builds (cherry-pick 453ad135e2bea30f3)
- switch FPU off explicitly in current verification builds
- cherry-pick imx8mm FPU config for verification from branch imx8-fpu-ver as `ARM_imx8mm_verified.cmake`
- cherry-pick exynos5 hyp config for verification from branch exynos5-ver as `ARM_HYP_exynos5_verified.cmake`

These are designed to work together with https://github.com/seL4/l4v/pull/639 so that multiple verification platforms can be present for a particilar L4V_ARCH settings.