### PR TITLE
x86: missing x2apic.h header inclusion

### DIFF
--- a/include/arch/x86/arch/machine/timer.h
+++ b/include/arch/x86/arch/machine/timer.h
@@ -12,7 +12,7 @@
 
 #ifdef CONFIG_KERNEL_MCS
 #include <mode/util.h>
-#include <arch/kernel/xapic.h>
+#include <arch/kernel/apic.h>
 
 static inline CONST time_t getKernelWcetUs(void)
 {


### PR DESCRIPTION
This looks like a trivial omission. The header is required to build with `KernelLAPICMode=X2APIC`.