### PR TITLE
Mark CLINT as reserved device on RISC-V platforms

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -49,6 +49,9 @@ Upcoming release: BREAKING
 * Changed how `gen_config.h` files are generated. Previously, they were generated at CMake configure time. Now, they
   are generated at build time as a dependency of the `${prefix}_Gen` target. To manually build the kernel
   `gen_config.h` file after running `cmake`, run `ninja gen_config/kernel/gen_config.h`.
+* Remove the ability for user-space on RISC-V platforms to access the core-local interrupt controller (CLINT). The
+  CLINT contains memory-mapped registers that the kernel depends on for timer interrupts and hence should not be
+  accessible by user-space.
 
 ## Upgrade Notes
 

--- a/src/plat/ariane/overlay-ariane.dts
+++ b/src/plat/ariane/overlay-ariane.dts
@@ -7,6 +7,19 @@
 / {
 	chosen {
 		seL4,kernel-devices =
+            &{/soc/clint@2000000},
 		    &{/soc/interrupt-controller@c000000};
 	};
+
+    /*
+     * The size and address of the CLINT is from the memory map listed in the
+     * CVA6 documentation. It can be found here:
+     * https://docs.openhwgroup.org/projects/cva6-user-manual/05_cva6_apu/cva6_apu.html#memory-map
+     */
+    soc {
+        clint@2000000 {
+            compatible = "riscv,cpu-intc";
+            reg = <0x00000000 0x2000000 0x00000000 0x0000c0000>;
+        };
+    };
 };

--- a/src/plat/polarfire/overlay-polarfire.dts
+++ b/src/plat/polarfire/overlay-polarfire.dts
@@ -7,6 +7,18 @@
 / {
 	chosen {
 		seL4,kernel-devices =
+            &{/soc/clint@2000000},
 		    &{/soc/interrupt-controller@c000000};
 	};
+
+    /*
+     * According to the "PolarFire SoC MSS Technical Reference Manual"
+     * (revision H), the CLINT is mapped from 0x0200_0000 to 0x0200_FFFF.
+     */
+    soc {
+        clint@2000000 {
+            compatible = "riscv,cpu-intc";
+            reg = <0x00000000 0x2000000 0x00000000 0x000010000>;
+        };
+    };
 };

--- a/src/plat/qemu-riscv-virt/overlay-qemu-riscv-virt.dts
+++ b/src/plat/qemu-riscv-virt/overlay-qemu-riscv-virt.dts
@@ -15,6 +15,15 @@
          *
          */
         seL4,kernel-devices =
+            &{/soc/clint@2000000},
             &{/soc/plic@c000000};
+    };
+
+    /* The size and address of the CLINT is derived from QEMU source code. */
+    soc {
+        clint@2000000 {
+            compatible = "riscv,cpu-intc";
+            reg = <0x00000000 0x2000000 0x00000000 0x000010000>;
+        };
     };
 };

--- a/src/plat/rocketchip/config.cmake
+++ b/src/plat/rocketchip/config.cmake
@@ -50,6 +50,7 @@ if(KernelPlatformRocketchip)
             INTERRUPT_CONTROLLER drivers/irq/riscv_plic0.h
         )
     else()
+        list(APPEND KernelDTSList "src/plat/rocketchip/overlay-rocketchip-base.dts")
         config_set(KernelOpenSBIPlatform OPENSBI_PLATFORM "generic")
         # This is an experimental platform that supports accessing peripherals, but
         # the status of support for external interrupts via a PLIC is unclear and

--- a/src/plat/rocketchip/overlay-rocketchip-base.dts
+++ b/src/plat/rocketchip/overlay-rocketchip-base.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ * Copyright 2023, UNSW
  *
  * SPDX-License-Identifier: GPL-2.0-only
  */
@@ -11,14 +11,11 @@
             &{/soc/interrupt-controller@c000000};
     };
 
-    /*
-     * According to the SiFive "FU540-C000 Manual" (version v1p4)
-     * the CLINT is mapped from 0x0200_0000 to 0x0200_FFFF.
-     */
+    /* The size and address of the CLINT is derived from the Rocketchip source code. */
     soc {
         clint@2000000 {
             compatible = "riscv,cpu-intc";
-            reg = <0x00000000 0x2000000 0x00000000 0x000010000>;
+            reg = <0x2000000 0x10000>;
         };
     };
 };

--- a/src/plat/rocketchip/overlay-rocketchip-zcu102.dts
+++ b/src/plat/rocketchip/overlay-rocketchip-zcu102.dts
@@ -5,10 +5,19 @@
  */
 
 / {
-	chosen {
-		seL4,kernel-devices =
-		    &{/soc/interrupt-controller@c000000};
-	};
+    chosen {
+        seL4,kernel-devices =
+            &{/soc/clint@2000000},
+            &{/soc/interrupt-controller@c000000};
+    };
+
+    /* The size and address of the CLINT is derived from the Rocketchip source code. */
+    soc {
+        clint@2000000 {
+            compatible = "riscv,cpu-intc";
+            reg = <0x2000000 0x10000>;
+        };
+    };
 
 	/delete-node/ memory@80000000;
 

--- a/src/plat/spike/config.cmake
+++ b/src/plat/spike/config.cmake
@@ -26,6 +26,7 @@ if(KernelPlatformSpike)
     else()
         list(APPEND KernelDTSList "tools/dts/spike.dts")
     endif()
+    list(APPEND KernelDTSList "src/plat/spike/overlay-spike.dts")
     declare_default_headers(
         TIMER_FREQUENCY 10000000 PLIC_MAX_NUM_INT 0
         INTERRUPT_CONTROLLER drivers/irq/riscv_plic_dummy.h

--- a/src/plat/spike/overlay-spike.dts
+++ b/src/plat/spike/overlay-spike.dts
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023, UNSW
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+/ {
+    chosen {
+        seL4,kernel-devices =
+            &{/soc/clint@2000000};
+    };
+
+    /*
+     * The size and address of the CLINT is derived from the source code
+     * of QEMU (which supports the Spike as a platform) and the Spike RISC-V
+     * ISA simulator. At the time of writing the two simulators do not agree
+     * on the size of the CLINT. We take the larger of the two sizes (0xc0000)
+     * in order to be safe.
+     */
+    soc {
+        clint@2000000 {
+            compatible = "riscv,cpu-intc";
+            reg = <0x00000000 0x2000000 0x00000000 0x0000c0000>;
+        };
+    };
+};

--- a/tools/hardware.yml
+++ b/tools/hardware.yml
@@ -208,6 +208,17 @@ devices:
         kernel: PLIC_PPTR
         kernel_size: 0x04000000
 
+  # SiFive CLINT (HiFive, Polarfire, Ariane, QEMU RISC-V virt, Spike)
+  # Note that not all CLINTs with this compatible string are of the same size.
+  # However, omitting the kernel_size field works as each kernel device frame
+  # is of size 0x200000, which is currently larger than the CLINT's of all
+  # supported platforms.
+  - compatible:
+      - riscv,cpu-intc
+    regions:
+      - index: 0
+        kernel: CLINT_PPTR
+
   # elfloader rules
   - compatible:
       - arm,psci-0.2


### PR DESCRIPTION
Without this patch, user-level programs have the ability to map in the core-local interrupt controller on RISC-V platforms which contains the memory-mapped registers for the core-local timer the kernel uses. This is a level of privilege that user-level programs should not have. Writing to the `mtime` register is possible which can then affect the timer interrupts that are delivered to the kernel.

An example of the CLINT memory map can be found in Chapter 9.5 of the SiFive U54-MC manual (which is what the HiFive Unleashed uses). While seL4 does not directly use `mtime`, I believe the emulated `rdtime` instruction uses this register.

I have a patch to sel4test to reproduce my claims here: https://github.com/Ivan-Velickovic/sel4test/commit/289201d6f2cc75aad4702dc9d62a6b71135919ff. Running this test shows that the CLINT and hence the `mtime` register is accessible. Producing an MCS kernel shows an assertion fire immediately after messing with the `mtime` register. This kernel patch at least fixes the issue on the HiFive Unleashed.

Another thing to note is that I failed to write to any other registers in the CLINT such as `msip` or `mtimecmp`, this results in a write-fault. It is not clear to me why this occurs. All testing was performed on a HiFive Unleashed.

This is marked as a draft as I cannot see an agreement across platforms for the size of the CLINT.

On the HiFive Unleashed it is `0x10000`. On the Spike it is `0x10000`. This [page for the Ariane](https://www.cl.cam.ac.uk/~jrrk2/docs/memory-map/) has the size as `0xc0000`.