### PR TITLE
Add missing ifdefs around printing functions

### DIFF
--- a/src/arch/arm/32/machine/capdl.c
+++ b/src/arch/arm/32/machine/capdl.c
@@ -506,7 +506,9 @@ void debug_capDL(void)
 {
     printf("arch aarch32\n");
     printf("objects {\n");
+#ifdef CONFIG_PRINTING
     print_objects();
+#endif
     printf("}\n");
 
     printf("caps {\n");

--- a/src/arch/arm/64/machine/capdl.c
+++ b/src/arch/arm/64/machine/capdl.c
@@ -543,7 +543,9 @@ void debug_capDL(void)
 {
     printf("arch aarch64\n");
     printf("objects {\n");
+#ifdef CONFIG_PRINTING
     print_objects();
+#endif
     printf("}\n");
 
     printf("caps {\n");

--- a/src/arch/riscv/machine/capdl.c
+++ b/src/arch/riscv/machine/capdl.c
@@ -229,7 +229,9 @@ void debug_capDL(void)
 {
     printf("arch riscv\n");
     printf("objects {\n");
+#ifdef CONFIG_PRINTING
     print_objects();
+#endif
     printf("}\n");
 
     printf("caps {\n");

--- a/src/arch/x86/64/machine/capdl.c
+++ b/src/arch/x86/64/machine/capdl.c
@@ -483,7 +483,9 @@ void debug_capDL(void)
 {
     printf("arch x86_64\n");
     printf("objects {\n");
+#ifdef CONFIG_PRINTING
     print_objects();
+#endif
     printf("}\n");
 
     printf("caps {\n");

--- a/src/kernel/sporadic.c
+++ b/src/kernel/sporadic.c
@@ -73,7 +73,9 @@ static UNUSED bool_t refill_ordered(sched_context_t *sc)
 
     while (current != sc->scRefillTail) {
         if (!(refill_index(sc, current)->rTime + refill_index(sc, current)->rAmount <= refill_index(sc, next)->rTime)) {
+#ifdef CONFIG_PRINTING
             refill_print(sc);
+#endif
             return false;
         }
         current = next;


### PR DESCRIPTION
These are only called when CONFIG_DEBUG_BUILD is on, which *usually* means that CONIFG_PRINTING is also enabled, but, it's not necessarily the case.