### PR TITLE
boot: remove redundant initialization

### DIFF
--- a/include/kernel/boot.h
+++ b/include/kernel/boot.h
@@ -136,6 +136,11 @@ static inline BOOT_CODE pptr_t it_alloc_paging(void)
 /* return the amount of paging structures required to cover v_reg */
 word_t arch_get_n_paging(v_region_t it_veg);
 
+bool_t finalize_init_kernel(void);
+#ifdef ENABLE_SMP_SUPPORT
+bool_t finalize_init_kernel_on_secondary_core(void);
+#endif
+
 #if defined(CONFIG_DEBUG_BUILD) && defined(ENABLE_SMP_SUPPORT) && defined(CONFIG_KERNEL_MCS)
 /* Test whether clocks are synchronised across nodes */
 #define ENABLE_SMP_CLOCK_SYNC_TEST_ON_BOOT

--- a/src/arch/arm/kernel/boot.c
+++ b/src/arch/arm/kernel/boot.c
@@ -272,14 +272,8 @@ BOOT_CODE static bool_t try_init_kernel_secondary_core(void)
     setIRQState(IRQReserved, CORE_IRQ_TO_IRQT(getCurrentCPUIndex(), INTERRUPT_VGIC_MAINTENANCE));
     setIRQState(IRQReserved, CORE_IRQ_TO_IRQT(getCurrentCPUIndex(), INTERRUPT_VTIMER_EVENT));
 #endif /* CONFIG_ARM_HYPERVISOR_SUPPORT */
-    NODE_LOCK_SYS;
 
-    clock_sync_test();
-    ksNumCPUs++;
-
-    init_core_state(SchedulerAction_ResumeCurrentThread);
-
-    return true;
+    return finalize_init_kernel();
 }
 
 BOOT_CODE static void release_secondary_cpus(void)
@@ -599,23 +593,7 @@ static BOOT_CODE bool_t try_init_kernel(
         invalidateHypTLB();
     }
 
-    ksNumCPUs = 1;
-
-    /* initialize BKL before booting up other cores */
-    SMP_COND_STATEMENT(clh_lock_init());
-    SMP_COND_STATEMENT(release_secondary_cpus());
-
-    /* All cores are up now, so there can be concurrency. The kernel booting is
-     * supposed to be finished before the secondary cores are released, all the
-     * primary has to do now is schedule the initial thread. Currently there is
-     * nothing that touches any global data structures, nevertheless we grab the
-     * BKL here to play safe. It is released when the kernel is left. */
-    NODE_LOCK_SYS;
-
-    printf("Booting all finished, dropped to user space\n");
-
-    /* kernel successfully initialized */
-    return true;
+    return finalize_init_kernel(true);
 }
 
 BOOT_CODE VISIBLE void init_kernel(
@@ -654,11 +632,4 @@ BOOT_CODE VISIBLE void init_kernel(
         fail("ERROR: kernel init failed");
         UNREACHABLE();
     }
-
-#ifdef CONFIG_KERNEL_MCS
-    NODE_STATE(ksCurTime) = getCurrentTime();
-    NODE_STATE(ksConsumed) = 0;
-#endif
-    schedule();
-    activateThread();
 }

--- a/src/arch/x86/kernel/boot_sys.c
+++ b/src/arch/x86/kernel/boot_sys.c
@@ -179,7 +179,7 @@ static BOOT_CODE bool_t try_boot_sys_node(cpu_id_t cpu_id)
             &boot_state.mem_p_regs,
             boot_state.ui_info,
             boot_mem_reuse_p_reg,
-            /* parameters below not modeled in abstract specification */
+            /* parameters below not modelled in abstract specification */
             boot_state.num_drhu,
             boot_state.drhu_list,
             &boot_state.rmrr_list,

--- a/src/arch/x86/kernel/boot_sys.c
+++ b/src/arch/x86/kernel/boot_sys.c
@@ -502,16 +502,7 @@ static BOOT_CODE bool_t try_boot_sys(void)
         ioapic_init(1, boot_state.cpus, boot_state.num_ioapic);
     }
 
-    /* initialize BKL before booting up APs */
-    SMP_COND_STATEMENT(clh_lock_init());
-    SMP_COND_STATEMENT(start_boot_aps());
-
-    /* grab BKL before leaving the kernel */
-    NODE_LOCK_SYS;
-
-    printf("Booting all finished, dropped to user space\n");
-
-    return true;
+    return finalize_init_kernel();
 }
 
 static BOOT_CODE bool_t try_boot_sys_mbi1(
@@ -729,16 +720,4 @@ BOOT_CODE VISIBLE void boot_sys(
     if (!result) {
         fail("boot_sys failed for some reason :(\n");
     }
-
-    ARCH_NODE_STATE(x86KScurInterrupt) = int_invalid;
-    ARCH_NODE_STATE(x86KSPendingInterrupt) = int_invalid;
-
-#ifdef CONFIG_KERNEL_MCS
-    NODE_STATE(ksCurTime) = getCurrentTime();
-    NODE_STATE(ksConsumed) = 0;
-#endif
-
-    schedule();
-    activateThread();
 }
-

--- a/src/arch/x86/kernel/smp_sys.c
+++ b/src/arch/x86/kernel/smp_sys.c
@@ -132,18 +132,11 @@ VISIBLE void boot_node(void)
         fail("boot_node failed for some reason :(\n");
     }
 
-    clock_sync_test();
     smp_aps_index++;
 
-    /* grab BKL before leaving the kernel */
-    NODE_LOCK_SYS;
-
-    init_core_state(SchedulerAction_ChooseNewThread);
-    ARCH_NODE_STATE(x86KScurInterrupt) = int_invalid;
-    ARCH_NODE_STATE(x86KSPendingInterrupt) = int_invalid;
-
-    schedule();
-    activateThread();
+    if (!finalize_init_kernel_on_secondary_core()) {
+        fail("finalize_init_kernel_on_secondary_core failed for some reason :(\n");
+    }
 }
 
 #endif /* ENABLE_SMP_SUPPORT */


### PR DESCRIPTION
The function `init_core_state()` does the initialization already.

I assume the actual goals is using most recent timestamp, even after getting the BKL and debug printing?