### PR TITLE
Output JSON for hardware configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -767,5 +767,8 @@ if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
     if(DEFINED platform_yaml)
         install(FILES ${platform_yaml} DESTINATION support)
     endif()
+    if(DEFINED platform_json)
+        install(FILES ${platform_json} DESTINATION support)
+    endif()
 
 endif()

--- a/config.cmake
+++ b/config.cmake
@@ -116,6 +116,10 @@ if(DEFINED KernelDTSList AND (NOT "${KernelDTSList}" STREQUAL ""))
         platform_yaml "${CMAKE_CURRENT_BINARY_DIR}/gen_headers/plat/machine/platform_gen.yaml"
         CACHE INTERNAL "Location of platform YAML description"
     )
+    set(
+        platform_json "${CMAKE_CURRENT_BINARY_DIR}/gen_headers/plat/machine/platform_gen.json"
+        CACHE INTERNAL "Location of platform JSON description"
+    )
     set(config_file "${CMAKE_CURRENT_SOURCE_DIR}/tools/hardware.yml")
     set(config_schema "${CMAKE_CURRENT_SOURCE_DIR}/tools/hardware_schema.yml")
     set(
@@ -202,7 +206,8 @@ if(DEFINED KernelDTSList AND (NOT "${KernelDTSList}" STREQUAL ""))
                 --compat-strings-out "${compatibility_outfile}" --c-header --header-out
                 "${device_dest}" --hardware-config "${config_file}" --hardware-schema
                 "${config_schema}" --yaml --yaml-out "${platform_yaml}" --sel4arch
-                "${KernelSel4Arch}" --addrspace-max "${KernelPaddrUserTop}"
+                "${KernelSel4Arch}" --addrspace-max "${KernelPaddrUserTop}" --json --json-out
+                "${platform_json}"
             RESULT_VARIABLE error
         )
         if(error)

--- a/tools/hardware/outputs/json.py
+++ b/tools/hardware/outputs/json.py
@@ -1,0 +1,64 @@
+#
+# Copyright 2023, UNSW
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+''' Generate a JSON file with memory region info from the device tree '''
+
+import argparse
+import json
+from typing import List
+import hardware
+from hardware.config import Config
+from hardware.fdt import FdtParser
+from hardware.utils.rule import HardwareYaml
+
+
+def make_json_list_of_regions(regions) -> List:
+    return [
+        {
+            'start': r.base,
+            'end':   r.base + r.size
+        }
+        for r in regions if r.size > 0
+    ]
+
+
+def create_json_file(dev_mem, phys_mem, output_stream):
+    json_obj = {
+        'devices': make_json_list_of_regions(dev_mem),
+        'memory':  make_json_list_of_regions(phys_mem)
+    }
+
+    with output_stream:
+        json.dump(json_obj, output_stream)
+
+
+def get_kernel_devices(tree: FdtParser, hw_yaml: HardwareYaml):
+    kernel_devices = tree.get_kernel_devices()
+
+    groups = []
+    for dev in kernel_devices:
+        rule = hw_yaml.get_rule(dev)
+        groups += rule.get_regions(dev)
+
+    return groups
+
+
+def run(tree: FdtParser, hw_yaml: HardwareYaml, config: Config,
+        args: argparse.Namespace):
+    if not args.json_out:
+        raise ValueError('you need to provide a json-out to use the JSON output method')
+
+    phys_mem, reserved, _ = hardware.utils.memory.get_physical_memory(tree, config)
+    kernel_devs = get_kernel_devices(tree, hw_yaml)
+    dev_mem = hardware.utils.memory.get_addrspace_exclude(
+        list(reserved) + phys_mem + kernel_devs, config)
+
+    create_json_file(dev_mem, phys_mem, args.json_out)
+
+
+def add_args(parser):
+    parser.add_argument('--json-out', help='output file for memory represented in JSON',
+                        type=argparse.FileType('w'))

--- a/tools/hardware_gen.py
+++ b/tools/hardware_gen.py
@@ -13,7 +13,7 @@ import yaml
 import hardware
 from hardware.config import Config
 from hardware.fdt import FdtParser
-from hardware.outputs import c_header, compat_strings, yaml as yaml_out, elfloader
+from hardware.outputs import c_header, compat_strings, yaml as yaml_out, json as json_out, elfloader
 from hardware.utils.rule import HardwareYaml
 
 
@@ -22,6 +22,7 @@ OUTPUTS = {
     'compat_strings': compat_strings,
     'elfloader': elfloader,
     'yaml': yaml_out,
+    'json': json_out,
 }
 
 


### PR DESCRIPTION
There is already existing YAML output for the hardware platform description, this adds JSON output as well.

My main motivation for this is that JSON is part of the standard library of Python and so doesn't need an external dependency to parse. Also, other generated config files such as `gen_config` have JSON and YAML versions so this is being consistent with that.

Example output:
```json
{
  "devices": [
    {
      "start": 0,
      "end": 16777216
    },
    {
      "start": 83886080,
      "end": 87031808
    },
    {
      "start": 268435456,
      "end": 270532608
    },
    {
      "start": 2147483648,
      "end": 3291484160
    },
    {
      "start": 3291492352,
      "end": 3291496448
    },
    {
      "start": 3291500544,
      "end": 1099511627776
    }
  ],
  "memory": [
    {
      "start": 16777216,
      "end": 83886080
    },
    {
      "start": 87031808,
      "end": 268435456
    },
    {
      "start": 270532608,
      "end": 2147483648
    }
  ]
}
```