### PR TITLE
remove obsolete assert()

### DIFF
--- a/src/arch/x86/object/tcb.c
+++ b/src/arch/x86/object/tcb.c
@@ -84,10 +84,6 @@ exception_t decodeSetEPTRoot(cap_t cap)
 #ifdef ENABLE_SMP_SUPPORT
 void Arch_migrateTCB(tcb_t *thread)
 {
-#ifdef CONFIG_KERNEL_MCS
-    assert(thread->tcbSchedContext != NULL);
-#endif
-
     /* check if thread owns its current core FPU */
     if (nativeThreadUsingFPU(thread)) {
         switchFpuOwner(NULL, thread->tcbAffinity);


### PR DESCRIPTION
Commit f4c41f39 removed a check that dereferenced `tcbSchedContext`. It should have removed this assert() also then.

It's unclear to me what this is supposed to check here. If this is to be kept, then the assertion check should move to generic kernel function `migrateTCB()` and get some explanation also.