### PR TITLE
remove Arch_migrateTCB()

### DIFF
--- a/include/object/tcb.h
+++ b/include/object/tcb.h
@@ -223,10 +223,6 @@ word_t CONST Arch_decodeTransfer(word_t flags);
 exception_t CONST Arch_performTransfer(word_t arch, tcb_t *tcb_src,
                                        tcb_t *tcb_dest);
 
-#ifdef ENABLE_SMP_SUPPORT
-void Arch_migrateTCB(tcb_t *thread);
-#endif /* ENABLE_SMP_SUPPORT */
-
 #ifdef CONFIG_DEBUG_BUILD
 void setThreadName(tcb_t *thread, const char *name);
 #endif /* CONFIG_DEBUG_BUILD */

--- a/src/arch/arm/object/tcb.c
+++ b/src/arch/arm/object/tcb.c
@@ -21,15 +21,3 @@ exception_t CONST Arch_performTransfer(word_t arch, tcb_t *tcb_src, tcb_t *tcb_d
 {
     return EXCEPTION_NONE;
 }
-
-#ifdef ENABLE_SMP_SUPPORT
-void Arch_migrateTCB(tcb_t *thread)
-{
-#ifdef CONFIG_HAVE_FPU
-    /* check if thread owns its current core FPU */
-    if (nativeThreadUsingFPU(thread)) {
-        switchFpuOwner(NULL, thread->tcbAffinity);
-    }
-#endif /* CONFIG_HAVE_FPU */
-}
-#endif /* ENABLE_SMP_SUPPORT */

--- a/src/arch/riscv/object/tcb.c
+++ b/src/arch/riscv/object/tcb.c
@@ -21,14 +21,3 @@ exception_t CONST Arch_performTransfer(word_t arch, tcb_t *tcb_src, tcb_t *tcb_d
 {
     return EXCEPTION_NONE;
 }
-
-#ifdef ENABLE_SMP_SUPPORT
-void Arch_migrateTCB(tcb_t *thread)
-{
-#ifdef CONFIG_HAVE_FPU
-    if (nativeThreadUsingFPU(thread)) {
-        switchFpuOwner(NULL, thread->tcbAffinity);
-    }
-#endif
-}
-#endif

--- a/src/arch/x86/object/tcb.c
+++ b/src/arch/x86/object/tcb.c
@@ -80,13 +80,3 @@ exception_t decodeSetEPTRoot(cap_t cap)
     return performSetEPTRoot(TCB_PTR(cap_thread_cap_get_capTCBPtr(cap)), dc_ret.cap, rootSlot);
 }
 #endif
-
-#ifdef ENABLE_SMP_SUPPORT
-void Arch_migrateTCB(tcb_t *thread)
-{
-    /* check if thread owns its current core FPU */
-    if (nativeThreadUsingFPU(thread)) {
-        switchFpuOwner(NULL, thread->tcbAffinity);
-    }
-}
-#endif /* ENABLE_SMP_SUPPORT */

--- a/src/arch/x86/object/tcb.c
+++ b/src/arch/x86/object/tcb.c
@@ -84,10 +84,6 @@ exception_t decodeSetEPTRoot(cap_t cap)
 #ifdef ENABLE_SMP_SUPPORT
 void Arch_migrateTCB(tcb_t *thread)
 {
-#ifdef CONFIG_KERNEL_MCS
-    assert(thread->tcbSchedContext != NULL);
-#endif
-
     /* check if thread owns its current core FPU */
     if (nativeThreadUsingFPU(thread)) {
         switchFpuOwner(NULL, thread->tcbAffinity);

--- a/src/model/smp.c
+++ b/src/model/smp.c
@@ -15,7 +15,15 @@ void migrateTCB(tcb_t *tcb, word_t new_core)
 #ifdef CONFIG_DEBUG_BUILD
     tcbDebugRemove(tcb);
 #endif
-    Arch_migrateTCB(tcb);
+#ifdef CONFIG_HAVE_FPU
+    /* If the thread owns the FPU of the core it is currently running on (which
+     * is not necessarily the core, that we are now running on), then release
+     * this cores's FPU.
+     */
+    if (nativeThreadUsingFPU(thread)) {
+        switchFpuOwner(NULL, thread->tcbAffinity);
+    }
+#endif /* CONFIG_HAVE_FPU */
     tcb->tcbAffinity = new_core;
 #ifdef CONFIG_DEBUG_BUILD
     tcbDebugAppend(tcb);


### PR DESCRIPTION
Remove `Arch_migrateTCB()`, because nowadays It does the same on all architectures, so the contents can be moved into the generic code. Architectures that support `CONFIG_HAVE_FPU` must provide proper implementations for `nativeThreadUsingFPU()` and `switchFpuOwner()` anyway, as this is also used in other places in the generic kernel code.

I also have doubts that keeping `Arch_migrateTCB()` as empty function with the current signature has a value, as it lacks the destination core parameter. If there is more to do, introducing more specific function might be the better way. That is why it's removed completely.