### PR TITLE
manual: improve thread affinity description

### DIFF
--- a/manual/parts/threads.tex
+++ b/manual/parts/threads.tex
@@ -53,7 +53,7 @@ In non-MCS configurations of the kernel, this will result in the thread immediat
 the scheduler. On the MCS kernel, the thread will only begin running if it has a
 scheduling context object.
 
-In a SMP configuration of the kernel, the thread will resume on the core
+In a SMP configuration of the kernel, the thread will resume on the node
 corresponding to the affinity of the thread. For the non-MCS configurations of the kernel, this is set using
 \apifunc{seL4\_TCB\_SetAffinity}{tcb_setaffinity}, while on the MCS kernel the affinity is
 derived from the scheduling context object.

--- a/manual/parts/threads.tex
+++ b/manual/parts/threads.tex
@@ -54,9 +54,11 @@ the scheduler. On the MCS kernel, the thread will only begin running if it has a
 scheduling context object.
 
 In a SMP configuration of the kernel, the thread will resume on the node
-corresponding to the affinity of the thread. For the non-MCS configurations of the kernel, this is set using
-\apifunc{seL4\_TCB\_SetAffinity}{tcb_setaffinity}, while on the MCS kernel the affinity is
-derived from the scheduling context object.
+corresponding to the affinity of the thread. For non-MCS configurations, the
+default thread affinity is the node the thread's \obj{TCB} object was created
+on, and \apifunc{seL4\_TCB\_SetAffinity}{tcb_setaffinity} can be used to
+explicitly set the affinity. On MCS configurations, the affinity is derived
+from the scheduling context object (see \autoref{sec:sc_creation}).
 
 \subsection{Thread Deactivation}
 \label{sec:thread_deactivation}
@@ -71,6 +73,14 @@ reused or left suspended indefinitely if not needed. Threads will be
 automatically suspended when the last capability to their \obj{TCB} is
 deleted.
 % an example of which is demonstrated in \nameref{ex:second_thread}.
+
+\subsection{Affinity}
+\label{sec:thread_affinity}
+
+It is architecture and platform specific, how an affinity value maps to a
+specific node (core, hart) on a specific platform. There is no guarantee that
+affinity values are compatible across different platforms.
+
 
 \subsection{Scheduling}
 \label{sec:sched}

--- a/manual/parts/threads.tex
+++ b/manual/parts/threads.tex
@@ -49,12 +49,12 @@ pointer. The thread can then be activated either by setting the
 or by separately calling the \apifunc{seL4\_TCB\_Resume}{tcb_resume} method. Both of these methods
 place the thread in a runnable state.
 
-On the master kernel, this will result in the thread immediately being added to
+In non-MCS configurations of the kernel, this will result in the thread immediately being added to
 the scheduler. On the MCS kernel, the thread will only begin running if it has a
 scheduling context object.
 
 In a SMP configuration of the kernel, the thread will resume on the core
-corresponding to the affinity of the thread. For master, this is set using
+corresponding to the affinity of the thread. For the non-MCS configurations of the kernel, this is set using
 \apifunc{seL4\_TCB\_SetAffinity}{tcb_setaffinity}, while on the MCS kernel the affinity is
 derived from the scheduling context object.
 


### PR DESCRIPTION
The manual does not say much about the core affinity of a thread. Add some description.

- replace "master" by "non-MCS"
- improve thread affinity description