### PR TITLE
Remove obsolete guard value and only use guard size for CNodes

### DIFF
--- a/include/fastpath/fastpath.h
+++ b/include/fastpath/fastpath.h
@@ -89,7 +89,7 @@ static inline cap_t FORCE_INLINE lookup_fp(cap_t cap, cptr_t cptr)
     word_t cptr2;
     cte_t *slot;
     word_t guardBits, radixBits, bits;
-    word_t radix, capGuard;
+    word_t radix;
 
     bits = 0;
 
@@ -101,16 +101,6 @@ static inline cap_t FORCE_INLINE lookup_fp(cap_t cap, cptr_t cptr)
         guardBits = cap_cnode_cap_get_capCNodeGuardSize(cap);
         radixBits = cap_cnode_cap_get_capCNodeRadix(cap);
         cptr2 = cptr << bits;
-
-        capGuard = cap_cnode_cap_get_capCNodeGuard(cap);
-
-        /* Check the guard. Depth mismatch check is deferred.
-           The 32MinusGuardSize encoding contains an exception
-           when the guard is 0, when 32MinusGuardSize will be
-           reported as 0 also. In this case we skip the check */
-        if (likely(guardBits) && unlikely(cptr2 >> (wordBits - guardBits) != capGuard)) {
-            return cap_null_cap_new();
-        }
 
         radix = cptr2 << guardBits >> (wordBits - radixBits);
         slot = CTE_PTR(cap_cnode_cap_get_capCNodePtr(cap)) + radix;

--- a/include/object/structures_32.bf
+++ b/include/object/structures_32.bf
@@ -74,10 +74,9 @@ block reply_cap(capReplyCanGrant, capReplyMaster, capTCBPtr, capType) {
 -- The user-visible format of the data word is defined by cnode_capdata, below.
 block cnode_cap(capCNodeRadix, capCNodeGuardSize, capCNodeGuard,
                 capCNodePtr, capType) {
-    padding 4
+    padding 22
     field capCNodeGuardSize 5
     field capCNodeRadix 5
-    field capCNodeGuard 18
 
     field_high capCNodePtr 27
     padding 1
@@ -257,8 +256,7 @@ block depth_mismatch {
 }
 
 block guard_mismatch {
-    field guardFound 32
-    padding 18
+    padding 50
     field bitsLeft 6
     field bitsFound 6
     field lufType 2

--- a/include/object/structures_64.bf
+++ b/include/object/structures_64.bf
@@ -107,9 +107,8 @@ block reply_cap(capReplyCanGrant, capReplyMaster, capTCBPtr, capType) {
 #endif
 
 -- The user-visible format of the data word is defined by cnode_capdata, below.
-block cnode_cap(capCNodeRadix, capCNodeGuardSize, capCNodeGuard,
-                capCNodePtr, capType) {
-    field capCNodeGuard 64
+block cnode_cap(capCNodeRadix, capCNodeGuardSize, capCNodePtr, capType) {
+    padding 64
 
     field capType 5
     field capCNodeGuardSize 6
@@ -353,7 +352,7 @@ block depth_mismatch {
 }
 
 block guard_mismatch {
-    field guardFound 64
+    padding 64
 
     padding 48
     field bitsLeft 7

--- a/libsel4/include/sel4/deprecated.h
+++ b/libsel4/include/sel4/deprecated.h
@@ -118,13 +118,15 @@ seL4_IsArchExceptionFrom(seL4_MessageInfo_t tag)
 
 typedef seL4_Word seL4_CapData_t SEL4_DEPRECATED("Badge and guard data are just seL4_Word type");
 
+typedef seL4_Word seL4_CNode_CapData_t SEL4_DEPRECATED("CNode CapData is just a seL4_Word type");
+
 static inline SEL4_DEPRECATED("Badges do not need to be constructed") seL4_Word seL4_CapData_Badge_new(seL4_Word badge)
 {
     return badge;
 }
 
-static inline SEL4_DEPRECATED("Use seL4_CNode_CapData_new().words[0]") seL4_Word seL4_CapData_Guard_new(seL4_Word guard,
+static inline SEL4_DEPRECATED("Guards do not need to be constructed") seL4_Word seL4_CNode_CapData_new(seL4_Word guard,
                                                                                                         seL4_Word bits)
 {
-    return seL4_CNode_CapData_new(guard, bits).words[0];
+    return bits;
 }

--- a/libsel4/include/sel4/faults.h
+++ b/libsel4/include/sel4/faults.h
@@ -20,8 +20,7 @@ LIBSEL4_INLINE_FUNC seL4_Fault_t seL4_getFault(seL4_MessageInfo_t tag)
                                        seL4_GetMR(seL4_CapFault_InRecvPhase),
                                        seL4_GetMR(seL4_CapFault_LookupFailureType),
                                        seL4_GetMR(seL4_CapFault_BitsLeft),
-                                       seL4_GetMR(seL4_CapFault_GuardMismatch_GuardFound),
-                                       seL4_GetMR(seL4_CapFault_GuardMismatch_BitsFound));
+                                       seL4_GetMR(seL4_CapFault_BitsFound));
 #ifdef CONFIG_HARDWARE_DEBUG_API
     case seL4_Fault_DebugException:
         return seL4_Fault_DebugException_new(seL4_GetMR(seL4_DebugException_FaultIP),

--- a/libsel4/include/sel4/shared_types.h
+++ b/libsel4/include/sel4/shared_types.h
@@ -24,9 +24,7 @@ typedef enum {
     seL4_CapFault_InRecvPhase,
     seL4_CapFault_LookupFailureType,
     seL4_CapFault_BitsLeft,
-    seL4_CapFault_DepthMismatch_BitsFound,
-    seL4_CapFault_GuardMismatch_GuardFound = seL4_CapFault_DepthMismatch_BitsFound,
-    seL4_CapFault_GuardMismatch_BitsFound,
+    seL4_CapFault_BitsFound,
     SEL4_FORCE_LONG_ENUM(seL4_CapFault_Msg),
 } seL4_CapFault_Msg;
 

--- a/libsel4/mode_include/32/sel4/shared_types.bf
+++ b/libsel4/mode_include/32/sel4/shared_types.bf
@@ -23,11 +23,3 @@ block seL4_CapRights {
     field capAllowRead 1
     field capAllowWrite 1
 }
-
--- CNode cap data
-block seL4_CNode_CapData {
-    padding 6
-    field guard 18
-    field guardSize 5
-    padding 3
-}

--- a/libsel4/mode_include/64/sel4/shared_types.bf
+++ b/libsel4/mode_include/64/sel4/shared_types.bf
@@ -24,9 +24,3 @@ block seL4_CapRights {
     field capAllowRead 1
     field capAllowWrite 1
 }
-
--- CNode cap data
-block seL4_CNode_CapData {
-    field guard 58
-    field guardSize 6
-}

--- a/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/types.bf
+++ b/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/types.bf
@@ -33,8 +33,7 @@ block CapFault {
    -- these vary according to LookupFailureType
    field MR4 32
    field MR5 32
-   field MR6 32
-   padding 28
+   padding 60
    field seL4_FaultType 4
 }
 

--- a/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/types.bf
+++ b/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/types.bf
@@ -33,8 +33,7 @@ block CapFault {
     -- these vary according to LookupFailureType
     field MR4 64
     field MR5 64
-    field MR6 64
-    padding 60
+    padding 124
     field seL4_FaultType 4
 }
 

--- a/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/types.bf
+++ b/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/types.bf
@@ -33,8 +33,7 @@ block CapFault {
    -- these vary according to LookupFailureType
    field MR4 32
    field MR5 32
-   field MR6 32
-   padding 28
+   padding 60
    field seL4_FaultType 4
 }
 

--- a/libsel4/sel4_arch_include/riscv32/sel4/sel4_arch/types.bf
+++ b/libsel4/sel4_arch_include/riscv32/sel4/sel4_arch/types.bf
@@ -43,8 +43,7 @@ block CapFault {
    -- these vary according to LookupFailureType
    field MR4 32
    field MR5 32
-   field MR6 32
-   padding 28
+   padding 60
    field seL4_FaultType 4
 }
 

--- a/libsel4/sel4_arch_include/riscv64/sel4/sel4_arch/types.bf
+++ b/libsel4/sel4_arch_include/riscv64/sel4/sel4_arch/types.bf
@@ -45,8 +45,7 @@ block CapFault {
    -- these vary according to LookupFailureType
    field MR4 64
    field MR5 64
-   field MR6 64
-   padding 60
+   padding 124
    field seL4_FaultType 4
 }
 

--- a/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/types.bf
+++ b/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/types.bf
@@ -33,8 +33,7 @@ block CapFault {
    -- these vary according to LookupFailureType
    field MR4 64
    field MR5 64
-   field MR6 64
-   padding 60
+   padding 124
    field seL4_FaultType 4
 }
 

--- a/src/api/faults.c
+++ b/src/api/faults.c
@@ -37,9 +37,7 @@ setMRs_lookup_failure(tcb_t *receiver, word_t *receiveIPCBuffer,
     /* check constants match libsel4 */
     if (offset == seL4_CapFault_LookupFailureType) {
         assert(offset + 1 == seL4_CapFault_BitsLeft);
-        assert(offset + 2 == seL4_CapFault_DepthMismatch_BitsFound);
-        assert(offset + 2 == seL4_CapFault_GuardMismatch_GuardFound);
-        assert(offset + 3 == seL4_CapFault_GuardMismatch_BitsFound);
+        assert(offset + 2 == seL4_CapFault_BitsFound);
     } else {
         assert(offset == 1);
     }
@@ -61,9 +59,7 @@ setMRs_lookup_failure(tcb_t *receiver, word_t *receiveIPCBuffer,
     case lookup_fault_guard_mismatch:
         setMR(receiver, receiveIPCBuffer, offset + 1,
               lookup_fault_guard_mismatch_get_bitsLeft(luf));
-        setMR(receiver, receiveIPCBuffer, offset + 2,
-              lookup_fault_guard_mismatch_get_guardFound(luf));
-        return setMR(receiver, receiveIPCBuffer, offset + 3,
+        return setMR(receiver, receiveIPCBuffer, offset + 2,
                      lookup_fault_guard_mismatch_get_bitsFound(luf));
 
     default:

--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -256,7 +256,6 @@ create_root_cnode(void)
     cap_t cap = cap_cnode_cap_new(
                     CONFIG_ROOT_CNODE_SIZE_BITS, /* radix */
                     wordBits - CONFIG_ROOT_CNODE_SIZE_BITS, /* guard size */
-                    0, /* guard */
                     rootserver.cnode); /* pptr */
 
     /* write the root CNode cap into the root CNode */

--- a/src/kernel/cspace.c
+++ b/src/kernel/cspace.c
@@ -126,8 +126,8 @@ lookupSlot_ret_t lookupPivotSlot(cap_t root, cptr_t capptr, word_t depth)
 resolveAddressBits_ret_t resolveAddressBits(cap_t nodeCap, cptr_t capptr, word_t n_bits)
 {
     resolveAddressBits_ret_t ret;
-    word_t radixBits, guardBits, levelBits, guard;
-    word_t capGuard, offset;
+    word_t radixBits, guardBits, levelBits;
+    word_t offset;
     cte_t *slot;
 
     ret.bitsRemaining = n_bits;
@@ -147,16 +147,9 @@ resolveAddressBits_ret_t resolveAddressBits(cap_t nodeCap, cptr_t capptr, word_t
         /* Haskell error: "All CNodes must resolve bits" */
         assert(levelBits != 0);
 
-        capGuard = cap_cnode_cap_get_capCNodeGuard(nodeCap);
-
-        /* The MASK(wordRadix) here is to avoid the case where
-         * n_bits = wordBits (=2^wordRadix) and guardBits = 0, as it violates
-         * the C spec to shift right by more than wordBits-1.
-         */
-        guard = (capptr >> ((n_bits - guardBits) & MASK(wordRadix))) & MASK(guardBits);
-        if (unlikely(guardBits > n_bits || guard != capGuard)) {
+        if (unlikely(guardBits > n_bits)) {
             current_lookup_fault =
-                lookup_fault_guard_mismatch_new(capGuard, n_bits, guardBits);
+                lookup_fault_guard_mismatch_new(n_bits, guardBits);
             ret.status = EXCEPTION_LOOKUP_FAULT;
             return ret;
         }

--- a/src/machine/capdl.c
+++ b/src/machine/capdl.c
@@ -194,9 +194,8 @@ void obj_tcb_print_cnodes(cap_t cnode, tcb_t *tcb)
 
 void cap_cnode_print_attrs(cap_t cnode)
 {
-    printf("(guard: %lu, guard_size: %lu)\n",
-           (long unsigned int)cap_cnode_cap_get_capCNodeGuard(cnode),
-           (long unsigned int)cap_cnode_cap_get_capCNodeGuardSize(cnode));
+    printf("(guard_size: %lu)\n",
+    (long unsigned int)cap_cnode_cap_get_capCNodeGuardSize(cnode));
 }
 
 void cap_ep_print_attrs(cap_t ep)

--- a/src/object/objecttype.c
+++ b/src/object/objecttype.c
@@ -416,22 +416,11 @@ cap_t CONST updateCapData(bool_t preserve, word_t newData, cap_t cap)
         }
 
     case cap_cnode_cap: {
-        word_t guard, guardSize;
-        seL4_CNode_CapData_t w = { .words = { newData } };
-
-        guardSize = seL4_CNode_CapData_get_guardSize(w);
-
-        if (guardSize + cap_cnode_cap_get_capCNodeRadix(cap) > wordBits) {
+        /* newData being passed in is the guard size */
+        if (newData + cap_cnode_cap_get_capCNodeRadix(cap) > wordBits) {
             return cap_null_cap_new();
         } else {
-            cap_t new_cap;
-
-            guard = seL4_CNode_CapData_get_guard(w) & MASK(guardSize);
-            new_cap = cap_cnode_cap_set_capCNodeGuard(cap, guard);
-            new_cap = cap_cnode_cap_set_capCNodeGuardSize(new_cap,
-                                                          guardSize);
-
-            return new_cap;
+            return cap_cnode_cap_set_capCNodeGuardSize(cap, newData);
         }
     }
 
@@ -562,7 +551,7 @@ cap_t createObject(object_t t, void *regionBase, word_t userSize, bool_t deviceM
         /** GHOSTUPD: "(True, gs_new_cnodes (unat \<acute>userSize)
                                 (ptr_val \<acute>regionBase)
                                 (4 + unat \<acute>userSize))" */
-        return cap_cnode_cap_new(userSize, 0, 0, CTE_REF(regionBase));
+        return cap_cnode_cap_new(userSize, 0, CTE_REF(regionBase));
 
     case seL4_UntypedObject:
         /*


### PR DESCRIPTION
CNode guards are currently configured with 2 values:
1. guard values
2. guard sizes

In practice, guard values are not used and only the guard size is actually used. This commit removes the guard value from the kernel in an attempt to simplify the API. I'd like to simplify the process to create CSpaces as well as simplify the manual so that beginners to seL4 have an easier time grasping CNodes and how to configure CSpaces.

Questions:
- What is the proof impact?
- How much of the API should we deprecate. For example, `api_make_guard_skip_word()` in `seL4_libs/libsel4utils` is a helper function that is often used to generate an `seL4_CNode_CapData` type with an empty guard value. Should this function be kept for backwards compatibility or completely deprecated? (the CapData type will be removed in favor of an seL4_Word type)

If people are happy with this change, the manual changes will follow. Also see: https://sel4.discourse.group/t/why-do-cnodes-have-guard-bits/49/3