### PR TITLE
libsel4: Make bootinfo consistent

### DIFF
--- a/libsel4/include/sel4/bootinfo_types.h
+++ b/libsel4/include/sel4/bootinfo_types.h
@@ -23,14 +23,10 @@ enum {
     seL4_CapBootInfoFrame       =  9, /* bootinfo frame cap */
     seL4_CapInitThreadIPCBuffer = 10, /* initial thread's IPC buffer frame cap */
     seL4_CapDomain              = 11, /* global domain controller cap */
-    seL4_CapSMMUSIDControl      = 12,  /*global SMMU SID controller cap, null cap if not supported*/
-    seL4_CapSMMUCBControl       = 13,  /*global SMMU CB controller cap, null cap if not supported*/
-#ifdef CONFIG_KERNEL_MCS
-    seL4_CapInitThreadSC        = 14, /* initial thread's scheduling context cap */
+    seL4_CapSMMUSIDControl      = 12, /* global SMMU SID controller cap, null cap if not supported */
+    seL4_CapSMMUCBControl       = 13, /* global SMMU CB controller cap, null cap if not supported */
+    seL4_CapInitThreadSC        = 14, /* initial thread's scheduling context cap, null cap if not supported */
     seL4_NumInitialCaps         = 15
-#else
-    seL4_NumInitialCaps         = 14
-#endif /* !CONFIG_KERNEL_MCS */
 };
 
 /* Legacy code will have assumptions on the vspace root being a Page Directory


### PR DESCRIPTION
Some slot positions in the rootnode would depend on configuration. However that makes it difficult to add new root caps, especially if multiple caps only exist based on configuration. Make all caps always there, but null if not configured.