### PR TITLE
libsel4: Add __ASSEMBLER__ guards in .h files

### DIFF
--- a/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/deprecated.h
+++ b/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/deprecated.h
@@ -9,6 +9,7 @@
 #include <sel4/config.h>
 #include <sel4/macros.h>
 
+#ifndef __ASSEMBLER__
 typedef seL4_Word seL4_ExceptIPCRegister SEL4_DEPRECATED("use seL4_UnknownSyscall_Msg");
 
 #define EXCEPT_IPC_SYS_MR_R0 SEL4_DEPRECATE_MACRO(seL4_UnknownSyscall_R0)
@@ -26,3 +27,4 @@ typedef seL4_Word seL4_ExceptIPCRegister SEL4_DEPRECATED("use seL4_UnknownSyscal
 #define EXCEPT_IPC_SYS_MR_SYSCALL SEL4_DEPRECATE_MACRO(seL4_UnknownSyscall_Syscall)
 #define EXCEPT_IPC_LENGTH SEL4_DEPRECATE_MACRO(seL4_UnknownSyscall_Length)
 
+#endif /*__ASSEMBLER__*/

--- a/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/deprecated.h
+++ b/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/deprecated.h
@@ -9,6 +9,8 @@
 #include <sel4/config.h>
 #include <sel4/macros.h>
 
+#ifndef __ASSEMBLER__
+
 #define EXCEPT_IPC_LENGTH SEL4_DEPRECATE_MACRO(seL4_UnknownSyscall_Length)
 
 typedef seL4_Word seL4_UserExceptIPCRegister SEL4_DEPRECATED("use seL4_UserException_Msg");
@@ -84,3 +86,4 @@ static inline SEL4_DEPRECATED("") seL4_Bool seL4_Fault_isNonPresentFault(seL4_Wo
     return !(FaultStatusRegister & 0x1);
 }
 
+#endif /*__ASSEMBLER__*/


### PR DESCRIPTION
Additional header files may now be included in non-C contexts and so we need to guard some C definitions with the __ASSEMBLER__ guards convention.