### PR TITLE
riscv: place traps and fastpath code adjacently

### DIFF
--- a/include/arch/riscv/arch/kernel/traps.h
+++ b/include/arch/riscv/arch/kernel/traps.h
@@ -25,22 +25,22 @@ void c_handle_fastpath_reply_recv(word_t cptr, word_t msgInfo, word_t reply)
 #else
 void c_handle_fastpath_reply_recv(word_t cptr, word_t msgInfo)
 #endif
-VISIBLE NORETURN;
+VISIBLE NORETURN SECTION(".text.fastpath");
 
 void c_handle_fastpath_call(word_t cptr, word_t msgInfo)
-VISIBLE NORETURN;
+VISIBLE NORETURN SECTION(".text.fastpath");
 
 void c_handle_syscall(word_t cptr, word_t msgInfo, syscall_t syscall)
-VISIBLE NORETURN;
+VISIBLE NORETURN SECTION(".text.traps");
 
 void c_handle_interrupt(void)
-VISIBLE NORETURN;
+VISIBLE NORETURN SECTION(".text.traps");
 
 void c_handle_exception(void)
-VISIBLE NORETURN;
+VISIBLE NORETURN SECTION(".text.traps");
 
 void restore_user_context(void)
-VISIBLE NORETURN;
+VISIBLE NORETURN SECTION(".text.traps");
 
 void handle_exception(void);
 

--- a/src/arch/riscv/common_riscv.lds
+++ b/src/arch/riscv/common_riscv.lds
@@ -46,6 +46,9 @@ SECTIONS
     {
         . = ALIGN(4K);
 
+       /* Traps and fastpath */
+        *(.text.traps)
+        *(.text.fastpath)
 
         /* Standard kernel */
         *(.text)

--- a/src/arch/riscv/traps.S
+++ b/src/arch/riscv/traps.S
@@ -14,7 +14,7 @@
 
 #define REGBYTES (CONFIG_WORD_SIZE / 8)
 
-.section .text, "ax"
+.section .text.traps, "ax"
 
 .global trap_entry
 .extern c_handle_syscall


### PR DESCRIPTION
    riscv: place traps and fastpath code adjacently
    
    Follow Arm's code where it tries to place traps and vector
    code adjacently in a 4KiB page to optimise performance
    (through spatial cache locality).
    
    Closes #1091