### PR TITLE
AArch64: updates for verification compatibility

### DIFF
--- a/include/arch/arm/armv/armv8-a/64/armv/vcpu.h
+++ b/include/arch/arm/armv/armv8-a/64/armv/vcpu.h
@@ -487,61 +487,82 @@ static void vcpu_hw_write_reg(word_t reg_index, word_t reg)
 {
     switch (reg_index) {
     case seL4_VCPUReg_SCTLR:
-        return setSCTLR(reg);
+        setSCTLR(reg);
+        break;
     case seL4_VCPUReg_TTBR0:
-        return writeTTBR0(reg);
+        writeTTBR0(reg);
+        break;
     case seL4_VCPUReg_TTBR1:
-        return writeTTBR1(reg);
+        writeTTBR1(reg);
+        break;
     case seL4_VCPUReg_TCR:
-        return writeTCR(reg);
+        writeTCR(reg);
+        break;
     case seL4_VCPUReg_MAIR:
-        return writeMAIR(reg);
+        writeMAIR(reg);
+        break;
     case seL4_VCPUReg_AMAIR:
-        return writeAMAIR(reg);
+        writeAMAIR(reg);
+        break;
     case seL4_VCPUReg_CIDR:
-        return writeCIDR(reg);
+        writeCIDR(reg);
+        break;
     case seL4_VCPUReg_ACTLR:
-        return writeACTLR(reg);
+        writeACTLR(reg);
+        break;
     case seL4_VCPUReg_CPACR:
-        return writeCPACR_EL1(reg);
+        writeCPACR_EL1(reg);
+        break;
     case seL4_VCPUReg_AFSR0:
-        return writeAFSR0(reg);
+        writeAFSR0(reg);
+        break;
     case seL4_VCPUReg_AFSR1:
-        return writeAFSR1(reg);
+        writeAFSR1(reg);
+        break;
     case seL4_VCPUReg_ESR:
-        return writeESR(reg);
+        writeESR(reg);
+        break;
     case seL4_VCPUReg_FAR:
-        return writeFAR(reg);
+        writeFAR(reg);
+        break;
     case seL4_VCPUReg_ISR:
         /* ISR is read-only */
-        return;
+        break;
     case seL4_VCPUReg_VBAR:
-        return writeVBAR(reg);
+        writeVBAR(reg);
+        break;
     case seL4_VCPUReg_TPIDR_EL1:
-        return writeTPIDR_EL1(reg);
+        writeTPIDR_EL1(reg);
+        break;
     case seL4_VCPUReg_SP_EL1:
-        return writeSP_EL1(reg);
+        writeSP_EL1(reg);
+        break;
     case seL4_VCPUReg_ELR_EL1:
-        return writeELR_EL1(reg);
+        writeELR_EL1(reg);
+        break;
     case seL4_VCPUReg_SPSR_EL1:
-        return writeSPSR_EL1(reg);
+        writeSPSR_EL1(reg);
+        break;
     case seL4_VCPUReg_CNTV_CTL:
-        return writeCNTV_CTL_EL0(reg);
+        writeCNTV_CTL_EL0(reg);
+        break;
     case seL4_VCPUReg_CNTV_CVAL:
-        return writeCNTV_CVAL_EL0(reg);
+        writeCNTV_CVAL_EL0(reg);
+        break;
     case seL4_VCPUReg_CNTVOFF:
-        return writeCNTVOFF_EL2(reg);
+        writeCNTVOFF_EL2(reg);
+        break;
     case seL4_VCPUReg_CNTKCTL_EL1:
-        return writeCNTKCTL_EL1(reg);
+        writeCNTKCTL_EL1(reg);
+        break;
 #ifdef ENABLE_SMP_SUPPORT
     case seL4_VCPUReg_VMPIDR_EL2:
-        return writeVMPIDR_EL2(reg);
+        writeVMPIDR_EL2(reg);
+        break;
 #endif /* ENABLE_SMP_SUPPORT */
     default:
         fail("ARM/HYP: Invalid register index");
     }
-
-    return;
 }
 
 /** DONT_TRANSLATE */

--- a/include/arch/arm/armv/armv8-a/64/armv/vcpu.h
+++ b/include/arch/arm/armv/armv8-a/64/armv/vcpu.h
@@ -196,6 +196,7 @@ static inline void writeAMAIR(word_t reg)
     MSR(REG_AMAIR_EL1, reg);
 }
 
+/** DONT_TRANSLATE */
 static inline word_t readCIDR(void)
 {
     uint32_t reg;
@@ -203,6 +204,7 @@ static inline word_t readCIDR(void)
     return (word_t)reg;
 }
 
+/** DONT_TRANSLATE */
 static inline void writeCIDR(word_t reg)
 {
     MSR(REG_CONTEXTIDR_EL1, (uint32_t)reg);
@@ -220,6 +222,7 @@ static inline void writeACTLR(word_t reg)
     MSR(REG_ACTLR_EL1, reg);
 }
 
+/** DONT_TRANSLATE */
 static inline word_t readAFSR0(void)
 {
     uint32_t reg;
@@ -227,11 +230,13 @@ static inline word_t readAFSR0(void)
     return (word_t)reg;
 }
 
+/** DONT_TRANSLATE */
 static inline void writeAFSR0(word_t reg)
 {
     MSR(REG_AFSR0_EL1, (uint32_t)reg);
 }
 
+/** DONT_TRANSLATE */
 static inline word_t readAFSR1(void)
 {
     uint32_t reg;
@@ -239,11 +244,13 @@ static inline word_t readAFSR1(void)
     return (word_t)reg;
 }
 
+/** DONT_TRANSLATE */
 static inline void writeAFSR1(word_t reg)
 {
     MSR(REG_AFSR1_EL1, (uint32_t)reg);
 }
 
+/** DONT_TRANSLATE */
 static inline word_t readESR(void)
 {
     uint32_t reg;
@@ -251,6 +258,7 @@ static inline word_t readESR(void)
     return (word_t)reg;
 }
 
+/** DONT_TRANSLATE */
 static inline void writeESR(word_t reg)
 {
     MSR(REG_ESR_EL1, (uint32_t)reg);
@@ -269,6 +277,7 @@ static inline void writeFAR(word_t reg)
 }
 
 /* ISR is read-only */
+/** DONT_TRANSLATE */
 static inline word_t readISR(void)
 {
     uint32_t reg;
@@ -535,6 +544,7 @@ static void vcpu_hw_write_reg(word_t reg_index, word_t reg)
     return;
 }
 
+/** DONT_TRANSLATE */
 static inline void vcpu_init_vtcr(void)
 {
 

--- a/src/arch/arm/64/kernel/vspace.c
+++ b/src/arch/arm/64/kernel/vspace.c
@@ -1448,9 +1448,9 @@ static exception_t decodeARMPageTableInvocation(word_t invLabel, unsigned int le
 
     pte = pte_pte_table_new(pptr_to_paddr(PTE_PTR(cap_page_table_cap_get_capPTBasePtr(cap))));
 
-    cap_page_table_cap_ptr_set_capPTIsMapped(&cap, 1);
-    cap_page_table_cap_ptr_set_capPTMappedASID(&cap, asid);
-    cap_page_table_cap_ptr_set_capPTMappedAddress(&cap, (vaddr & ~MASK(ptSlot.ptBitsLeft)));
+    cap = cap_page_table_cap_set_capPTIsMapped(cap, 1);
+    cap = cap_page_table_cap_set_capPTMappedASID(cap, asid);
+    cap = cap_page_table_cap_set_capPTMappedAddress(cap, (vaddr & ~MASK(ptSlot.ptBitsLeft)));
 
     setThreadState(NODE_STATE(ksCurThread), ThreadState_Restart);
     return performPageTableInvocationMap(cap, cte, pte, ptSlot.ptSlot);
@@ -1512,7 +1512,7 @@ static exception_t decodeARMFrameInvocation(word_t invLabel, unsigned int length
         }
 
         /* In the case of remap, the cap should have a valid asid */
-        frame_asid = cap_frame_cap_ptr_get_capFMappedASID(&cap);
+        frame_asid = cap_frame_cap_get_capFMappedASID(cap);
 
         if (frame_asid != asidInvalid) {
             if (frame_asid != asid) {

--- a/src/arch/arm/config.cmake
+++ b/src/arch/arm/config.cmake
@@ -6,7 +6,7 @@
 
 cmake_minimum_required(VERSION 3.7.2)
 
-if(KernelArchARM)
+if(KernelSel4ArchAarch32)
     set_property(TARGET kernel_config_target APPEND PROPERTY TOPLEVELTYPES pde_C)
 endif()
 


### PR DESCRIPTION
These are the changes I needed to introduce to get the C kernel parsed and imported into Isabelle:
- aarch64: avoid void-return statements
- aarch64: DONT_TRANSLATE 32-bit __asm__
- aarch64: don't take address of local vars
- arm: pde_C type is only available on aarch32

I was a bit surprised by the `&cap` where `cap` is local. Well-known limitation of the verification infrastructure.
The 32-bit `__asm__` is a bit disappointing on the verification side (the limitation is irritating, but tracking down the error is terrible), maybe we should think of what we can do about it next time binary verification comes up.