### PR TITLE
clarify names to reflect the exact content

### DIFF
--- a/include/arch/arm/arch/machine/timer.h
+++ b/include/arch/arm/arch/machine/timer.h
@@ -59,9 +59,9 @@ static inline CONST ticks_t getTimerPrecision(void)
 #include <plat/machine/hardware.h>
 
 /* but multiply by timer tick ms */
-#define TIMER_RELOAD    (TICKS_PER_MS * CONFIG_TIMER_TICK_MS)
+#define TIMER_RELOAD_TICKS    (TICKS_PER_MS * CONFIG_TIMER_TICK_MS)
 
-#if (TIMER_RELOAD >= UINTPTR_MAX)
+#if (TIMER_RELOAD_TICKS >= UINTPTR_MAX)
 #error "Timer reload too high"
 #endif
 

--- a/include/drivers/timer/arm_generic.h
+++ b/include/drivers/timer/arm_generic.h
@@ -41,7 +41,7 @@ static inline void ackDeadlineIRQ(void)
 #include <arch/machine/timer.h>
 static inline void resetTimer(void)
 {
-    SYSTEM_WRITE_WORD(CNT_TVAL, TIMER_RELOAD);
+    SYSTEM_WRITE_WORD(CNT_TVAL, TIMER_RELOAD_TICKS);
     /* Ensure that the timer deasserts the IRQ before GIC EOIR/DIR.
      * This is sufficient to remove the pending state from the GICR
      * and avoid the interrupt happening twice because of the level

--- a/include/kernel/sporadic.h
+++ b/include/kernel/sporadic.h
@@ -32,7 +32,7 @@
 /* To do an operation in the kernel, the thread must have
  * at least this much budget - see comment on refill_sufficient */
 #define MIN_BUDGET_US (2u * getKernelWcetUs() * CONFIG_KERNEL_WCET_SCALE)
-#define MIN_BUDGET    (2u * getKernelWcetTicks() * CONFIG_KERNEL_WCET_SCALE)
+#define MIN_BUDGET_TICKS (2u * getKernelWcetTicks() * CONFIG_KERNEL_WCET_SCALE)
 #if (CONFIG_KERNEL_STATIC_MAX_PERIOD_US) != 0
 #define MAX_PERIOD_US (CONFIG_KERNEL_STATIC_MAX_PERIOD_US)
 #else
@@ -46,7 +46,7 @@
  * than 2^62. */
 #define MAX_PERIOD_US (getMaxUsToTicks() / 8)
 #endif /* CONFIG_KERNEL_STATIC_MAX_PERIOD_US != 0 */
-#define MAX_RELEASE_TIME (UINT64_MAX - 5 * usToTicks(MAX_PERIOD_US))
+#define MAX_RELEASE_TICKS (UINT64_MAX - 5 * usToTicks(MAX_PERIOD_US))
 
 /* Short hand for accessing refill queue items */
 static inline refill_t *refill_index(sched_context_t *sc, word_t index)
@@ -115,7 +115,7 @@ static inline ticks_t refill_capacity(sched_context_t *sc, ticks_t usage)
  */
 static inline bool_t refill_sufficient(sched_context_t *sc, ticks_t usage)
 {
-    return refill_capacity(sc, usage) >= MIN_BUDGET;
+    return refill_capacity(sc, usage) >= MIN_BUDGET_TICKS;
 }
 
 /*
@@ -145,7 +145,7 @@ static inline bool_t sc_active(sched_context_t *sc)
 static inline bool_t sc_released(sched_context_t *sc)
 {
     if (sc_active(sc)) {
-        /* All refills must all be greater than MIN_BUDGET so this
+        /* All refills must all be greater than MIN_BUDGET_TICKS so this
          * should be true for all active SCs */
         assert(refill_sufficient(sc, 0));
         return refill_ready(sc);

--- a/include/kernel/thread.h
+++ b/include/kernel/thread.h
@@ -232,11 +232,11 @@ static inline void updateTimestamp(void)
 {
     ticks_t prev = NODE_STATE(ksCurTime);
     NODE_STATE(ksCurTime) = getCurrentTime();
-    assert(NODE_STATE(ksCurTime) < MAX_RELEASE_TIME);
+    assert(NODE_STATE(ksCurTime) < MAX_RELEASE_TICKS);
     ticks_t consumed = (NODE_STATE(ksCurTime) - prev);
     NODE_STATE(ksConsumed) += consumed;
     if (numDomains > 1) {
-        if ((consumed + MIN_BUDGET) >= ksDomainTime) {
+        if ((consumed + MIN_BUDGET_TICKS) >= ksDomainTime) {
             ksDomainTime = 0;
         } else {
             ksDomainTime -= consumed;

--- a/src/drivers/timer/am335x-timer.c
+++ b/src/drivers/timer/am335x-timer.c
@@ -150,13 +150,13 @@ BOOT_CODE void initTimer(void)
     maskInterrupt(/*disable*/ true, KERNEL_TIMER_IRQ);
 
     /* Set the reload value */
-    timer->tldr = 0xFFFFFFFFUL - TIMER_RELOAD;
+    timer->tldr = 0xFFFFFFFFUL - TIMER_RELOAD_TICKS;
 
     /* Enables interrupt on overflow */
     timer->tier = TIER_OVERFLOW_ENABLE;
 
     /* Clear the read register */
-    timer->tcrr = 0xFFFFFFFFUL - TIMER_RELOAD;
+    timer->tcrr = 0xFFFFFFFFUL - TIMER_RELOAD_TICKS;
 
     /* Set autoreload and start the timer */
     timer->tclr = TCLR_AUTORELOAD | TCLR_STARTTIMER;

--- a/src/drivers/timer/exynos4412-mct.c
+++ b/src/drivers/timer/exynos4412-mct.c
@@ -37,10 +37,10 @@ BOOT_CODE void initTimer(void)
     mct_clear_write_status();
 
     /* Configure the comparator */
-    mct->global.comp0_add_inc = TIMER_RELOAD;
+    mct->global.comp0_add_inc = TIMER_RELOAD_TICKS;
 
     uint64_t  comparator_value = ((((uint64_t) mct->global.cnth) << 32llu)
-                                  | mct->global.cntl) + TIMER_RELOAD;
+                                  | mct->global.cntl) + TIMER_RELOAD_TICKS;
     mct->global.comp0h = (uint32_t)(comparator_value >> 32u);
     mct->global.comp0l = (uint32_t) comparator_value;
     /* Enable interrupts */

--- a/src/drivers/timer/kpss-timer.c
+++ b/src/drivers/timer/kpss-timer.c
@@ -32,7 +32,7 @@ timer_t *dgt_tmr = (timer_t *) DGT_TIMER_PPTR;
 #define PRESCALER          DGTTMR_CLK_CTRL_DIV1
 #define PRESCALE_VAL       1
 
-#define TIMER_MATCH_VAL  (TIMER_RELOAD / PRESCALE_VAL)
+#define TIMER_MATCH_VAL  (TIMER_RELOAD_TICKS / PRESCALE_VAL)
 
 BOOT_CODE void initTimer(void)
 {

--- a/src/drivers/timer/omap3430-timer.c
+++ b/src/drivers/timer/omap3430-timer.c
@@ -65,13 +65,13 @@ BOOT_CODE void initTimer(void)
     maskInterrupt(/*disable*/ true, KERNEL_TIMER_IRQ);
 
     /* Set the reload value */
-    timer->tldr = 0xFFFFFFFFUL - TIMER_RELOAD;
+    timer->tldr = 0xFFFFFFFFUL - TIMER_RELOAD_TICKS;
 
     /* Enables interrupt on overflow */
     timer->tier = TIER_OVERFLOWENABLE;
 
     /* Clear the read register */
-    timer->tcrr = 0xFFFFFFFFUL - TIMER_RELOAD;
+    timer->tcrr = 0xFFFFFFFFUL - TIMER_RELOAD_TICKS;
 
     /* Set autoreload and start the timer */
     timer->tclr = TCLR_AUTORELOAD | TCLR_STARTTIMER;

--- a/src/drivers/timer/priv_timer.c
+++ b/src/drivers/timer/priv_timer.c
@@ -19,8 +19,8 @@ timer_t *const priv_timer = (timer_t *) ARM_MP_PRIV_TIMER_PPTR;
 #define TIMER_INTERVAL_MS    (CONFIG_TIMER_TICK_MS)
 #define TIMER_COUNT_BITS 32
 
-#define PRESCALE ((TIMER_RELOAD) >> TIMER_COUNT_BITS)
-#define TMR_LOAD ((TIMER_RELOAD) / (PRESCALE + 1))
+#define PRESCALE ((TIMER_RELOAD_TICKS) >> TIMER_COUNT_BITS)
+#define TMR_LOAD ((TIMER_RELOAD_TICKS) / (PRESCALE + 1))
 
 BOOT_CODE void initTimer(void)
 {

--- a/src/kernel/sporadic.c
+++ b/src/kernel/sporadic.c
@@ -161,7 +161,7 @@ void refill_new(sched_context_t *sc, word_t max_refills, ticks_t budget, ticks_t
     sc->scRefillHead = 0;
     sc->scRefillTail = 0;
     sc->scRefillMax = max_refills;
-    assert(budget >= MIN_BUDGET);
+    assert(budget >= MIN_BUDGET_TICKS);
     /* full budget available */
     refill_head(sc)->rAmount = budget;
     /* budget can be used from now */
@@ -263,7 +263,7 @@ void refill_budget_check(ticks_t usage)
      * that assertion we ensure that we never delate a refill past this
      * point in the future.
      */
-    while (refill_head(sc)->rAmount <= usage && refill_head(sc)->rTime < MAX_RELEASE_TIME) {
+    while (refill_head(sc)->rAmount <= usage && refill_head(sc)->rTime < MAX_RELEASE_TICKS) {
         usage -= refill_head(sc)->rAmount;
 
         if (refill_single(sc)) {
@@ -279,7 +279,7 @@ void refill_budget_check(ticks_t usage)
      * If the head time is still sufficiently far from the point of
      * integer overflow then the usage must be smaller than the head.
      */
-    if (usage > 0 && refill_head(sc)->rTime < MAX_RELEASE_TIME) {
+    if (usage > 0 && refill_head(sc)->rTime < MAX_RELEASE_TICKS) {
         assert(refill_head(sc)->rAmount > usage);
         refill_t used = (refill_t) {
             .rAmount = usage,
@@ -302,7 +302,7 @@ void refill_budget_check(ticks_t usage)
     }
 
     /* Ensure the head refill has the minimum budget */
-    while (refill_head(sc)->rAmount < MIN_BUDGET) {
+    while (refill_head(sc)->rAmount < MIN_BUDGET_TICKS) {
         refill_t head = refill_pop_head(sc);
         refill_head(sc)->rAmount += head.rAmount;
         /* Delay head to ensure the subsequent refill doesn't end any

--- a/src/kernel/thread.c
+++ b/src/kernel/thread.c
@@ -606,7 +606,7 @@ void chargeBudget(ticks_t consumed, bool_t canTimeoutFault)
             refill_budget_check(consumed);
         }
 
-        assert(refill_head(NODE_STATE(ksCurSC))->rAmount >= MIN_BUDGET);
+        assert(refill_head(NODE_STATE(ksCurSC))->rAmount >= MIN_BUDGET_TICKS);
         NODE_STATE(ksCurSC)->scConsumed += consumed;
     }
     NODE_STATE(ksConsumed) = 0;

--- a/src/object/schedcontrol.c
+++ b/src/object/schedcontrol.c
@@ -105,7 +105,7 @@ static exception_t decodeSchedControl_ConfigureFlags(word_t length, cap_t cap, w
         return EXCEPTION_SYSCALL_ERROR;
     }
 
-    if (budget_us > MAX_PERIOD_US || budget_ticks < MIN_BUDGET) {
+    if (budget_us > MAX_PERIOD_US || budget_ticks < MIN_BUDGET_TICKS) {
         userError("SchedControl_ConfigureFlags: budget out of range.");
         current_syscall_error.type = seL4_RangeError;
         current_syscall_error.rangeErrorMin = MIN_BUDGET_US;
@@ -113,7 +113,7 @@ static exception_t decodeSchedControl_ConfigureFlags(word_t length, cap_t cap, w
         return EXCEPTION_SYSCALL_ERROR;
     }
 
-    if (period_us > MAX_PERIOD_US || period_ticks < MIN_BUDGET) {
+    if (period_us > MAX_PERIOD_US || period_ticks < MIN_BUDGET_TICKS) {
         userError("SchedControl_ConfigureFlags: period out of range.");
         current_syscall_error.type = seL4_RangeError;
         current_syscall_error.rangeErrorMin = MIN_BUDGET_US;


### PR DESCRIPTION
Follow-up from https://github.com/seL4/seL4/pull/922. In the code we are sometimes dealing with us/ms and sometimes with ticks. Give the constants a clear name to indicate when they hold ticks, so there is less chance to confuse this.