### PR TITLE
Generate configuration headers at configure-time

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -46,9 +46,6 @@ Upcoming release: BREAKING
 * aarch32 VM fault messages now deliver original (untranslated) faulting IP in a hypervisor context, matching
   aarch64 behaviour.
 * Correct the minimum size of a scheduling context. This changes the value of `seL4_MinSchedContextBits`.
-* Changed how `gen_config.h` files are generated. Previously, they were generated at CMake configure time. Now, they
-  are generated at build time as a dependency of the `${prefix}_Gen` target. To manually build the kernel
-  `gen_config.h` file after running `cmake`, run `ninja gen_config/kernel/gen_config.h`.
 * Remove the ability for user-space on RISC-V platforms to access the core-local interrupt controller (CLINT). The
   CLINT contains memory-mapped registers that the kernel depends on for timer interrupts and hence should not be
   accessible by user-space.


### PR DESCRIPTION
https://github.com/seL4/seL4/pull/975, which added JSON configuration output, caused the configuration headers to be generated at build-time instead of configure-time.  This broke CAmkES build systems which depend on configuration headers in CAmkES files at configure-time.

This PR makes the configuration headers available at configure-time.