### PR TITLE
VM fault fastpath: missing rename of vspace cap ASID function

### DIFF
--- a/src/fastpath/fastpath.c
+++ b/src/fastpath/fastpath.c
@@ -779,7 +779,7 @@ void NORETURN fastpath_vm_fault(vm_fault_type_t type)
 
 #ifdef CONFIG_ARCH_AARCH64
     /* Need to test that the ASID is still valid */
-    asid_t asid = cap_vtable_root_get_mappedASID(newVTable);
+    asid_t asid = cap_vspace_cap_get_capMappedASID(newVTable);
     asid_map_t asid_map = findMapForASID(asid);
     if (unlikely(asid_map_get_type(asid_map) != asid_map_asid_map_vspace ||
                  VSPACE_PTR(asid_map_asid_map_vspace_get_vspace_root(asid_map)) != cap_pd)) {


### PR DESCRIPTION
This change was missing from commit dc808b3d76fc09741e91ccc53e2738d052c08f0a. Renames `cap_vtable_root_get_mappedASID` to `cap_vspace_cap_get_capMappedASID`, allowing builds with the exception fastpath enabled to build.