### PR TITLE
aarch64: makeUserPage rework and some verification MODIFIES annotations

### DIFF
--- a/include/arch/arm/armv/armv8-a/64/armv/vcpu.h
+++ b/include/arch/arm/armv/armv8-a/64/armv/vcpu.h
@@ -196,6 +196,7 @@ static inline void writeAMAIR(word_t reg)
     MSR(REG_AMAIR_EL1, reg);
 }
 
+/** MODIFIES: */
 /** DONT_TRANSLATE */
 static inline word_t readCIDR(void)
 {
@@ -204,6 +205,7 @@ static inline word_t readCIDR(void)
     return (word_t)reg;
 }
 
+/** MODIFIES: phantom_machine_state */
 /** DONT_TRANSLATE */
 static inline void writeCIDR(word_t reg)
 {
@@ -222,6 +224,7 @@ static inline void writeACTLR(word_t reg)
     MSR(REG_ACTLR_EL1, reg);
 }
 
+/** MODIFIES: */
 /** DONT_TRANSLATE */
 static inline word_t readAFSR0(void)
 {
@@ -230,12 +233,14 @@ static inline word_t readAFSR0(void)
     return (word_t)reg;
 }
 
+/** MODIFIES: phantom_machine_state */
 /** DONT_TRANSLATE */
 static inline void writeAFSR0(word_t reg)
 {
     MSR(REG_AFSR0_EL1, (uint32_t)reg);
 }
 
+/** MODIFIES: */
 /** DONT_TRANSLATE */
 static inline word_t readAFSR1(void)
 {
@@ -244,12 +249,14 @@ static inline word_t readAFSR1(void)
     return (word_t)reg;
 }
 
+/** MODIFIES: phantom_machine_state */
 /** DONT_TRANSLATE */
 static inline void writeAFSR1(word_t reg)
 {
     MSR(REG_AFSR1_EL1, (uint32_t)reg);
 }
 
+/** MODIFIES: */
 /** DONT_TRANSLATE */
 static inline word_t readESR(void)
 {
@@ -258,6 +265,7 @@ static inline word_t readESR(void)
     return (word_t)reg;
 }
 
+/** MODIFIES: phantom_machine_state */
 /** DONT_TRANSLATE */
 static inline void writeESR(word_t reg)
 {
@@ -277,6 +285,7 @@ static inline void writeFAR(word_t reg)
 }
 
 /* ISR is read-only */
+/** MODIFIES: */
 /** DONT_TRANSLATE */
 static inline word_t readISR(void)
 {

--- a/src/arch/arm/64/kernel/vspace.c
+++ b/src/arch/arm/64/kernel/vspace.c
@@ -652,7 +652,7 @@ static lookupPTSlot_ret_t lookupPTSlot(vspace_root_t *vspace, vptr_t vptr)
 /* Note that if the hypervisor support is enabled, the user page tables use
  * stage-2 translation format. Otherwise, they follow the stage-1 translation format.
  */
-static pte_t makeUserPage(paddr_t paddr, vm_rights_t vm_rights, vm_attributes_t attributes, vm_page_size_t page_size)
+static pte_t makeUserPagePTE(paddr_t paddr, vm_rights_t vm_rights, vm_attributes_t attributes, vm_page_size_t page_size)
 {
     bool_t nonexecutable = vm_attributes_get_armExecuteNever(attributes);
     word_t cacheable = vm_attributes_get_armPageCacheable(attributes);
@@ -1525,7 +1525,7 @@ static exception_t decodeARMFrameInvocation(word_t invLabel, unsigned int length
 
         setThreadState(NODE_STATE(ksCurThread), ThreadState_Restart);
         return performPageInvocationMap(asid, cap, cte,
-                                        makeUserPage(base, vmRights, attributes, frameSize), lu_ret.ptSlot);
+                                        makeUserPagePTE(base, vmRights, attributes, frameSize), lu_ret.ptSlot);
     }
 
     case ARMPageUnmap:


### PR DESCRIPTION
This overhauls `makeUserPage` to take care of the bit 58 and bitfield gen issues outlined in #1110 
I threw in a verification MODIFIES annotation commit to do less PR littering, it doesn't have any impact on the code.