### PR TITLE
github: bump Isabelle version on proof checks

### DIFF
--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -37,7 +37,7 @@ jobs:
       uses: seL4/ci-actions/aws-proofs@master
       with:
         L4V_ARCH: ${{ matrix.arch }}
-        isa_branch: ts-2022
+        isa_branch: ts-2023
         session: ${{ matrix.session }}
         manifest: default.xml
       env:


### PR DESCRIPTION
The proofs are now running on Isabelle2023