### PR TITLE
aarch64: (verification) performPageInvocationUnmap, performASIDPoolInvocation, checkVPAlignment

### DIFF
--- a/include/arch/arm/arch/machine/hardware.h
+++ b/include/arch/arm/arch/machine/hardware.h
@@ -18,7 +18,6 @@ typedef word_t vm_fault_type_t;
 
 #define PAGE_BASE(_p, _s)        ((_p) & ~MASK(pageBitsForSize((_s))))
 #define PAGE_OFFSET(_p, _s)      ((_p) & MASK(pageBitsForSize((_s))))
-#define IS_PAGE_ALIGNED(_p, _s)  (((_p) & MASK(pageBitsForSize((_s)))) == 0)
 
 #define IPI_MEM_BARRIER \
   do { \

--- a/src/arch/arm/64/kernel/vspace.c
+++ b/src/arch/arm/64/kernel/vspace.c
@@ -1435,6 +1435,11 @@ static exception_t decodeARMPageTableInvocation(word_t invLabel, unsigned int le
     return performPageTableInvocationMap(cap, cte, pte, ptSlot.ptSlot);
 }
 
+static inline bool_t CONST checkVPAlignment(vm_page_size_t sz, word_t w)
+{
+    return (w & MASK(pageBitsForSize(sz))) == 0;
+}
+
 static exception_t decodeARMFrameInvocation(word_t invLabel, unsigned int length,
                                             cte_t *cte, cap_t cap, bool_t call, word_t *buffer)
 {
@@ -1485,7 +1490,7 @@ static exception_t decodeARMFrameInvocation(word_t invLabel, unsigned int length
             return EXCEPTION_SYSCALL_ERROR;
         }
 
-        if (unlikely(!IS_PAGE_ALIGNED(vaddr, frameSize))) {
+        if (unlikely(!checkVPAlignment(frameSize, vaddr))) {
             current_syscall_error.type = seL4_AlignmentError;
             return EXCEPTION_SYSCALL_ERROR;
         }

--- a/src/arch/arm/64/kernel/vspace.c
+++ b/src/arch/arm/64/kernel/vspace.c
@@ -1172,8 +1172,12 @@ static exception_t performPageInvocationUnmap(cap_t cap, cte_t *ctSlot)
                   cap_frame_cap_get_capFBasePtr(cap));
     }
 
-    cap_frame_cap_ptr_set_capFMappedASID(&ctSlot->cap, asidInvalid);
-    cap_frame_cap_ptr_set_capFMappedAddress(&ctSlot->cap, 0);
+    cap_t slotCap = ctSlot->cap;
+    slotCap = cap_frame_cap_set_capFMappedAddress(slotCap, 0);
+    slotCap = cap_frame_cap_set_capFMappedASID(slotCap, asidInvalid);
+    ctSlot->cap = slotCap;
+
+
     return EXCEPTION_NONE;
 }
 


### PR DESCRIPTION
This is a bunch of tweaks that make it easier for verification to deal with cap updates, and also to make some things more like what's on the other platforms.

TLDR: a single update using a `_ptr_set_` generated function is fine, but if multiple updates are needed, best fetch the thing, do updates to a local var, and then post back.