### PR TITLE
manual: group invocations by MCS/non-MCS

### DIFF
--- a/libsel4/include/interfaces/sel4.xml
+++ b/libsel4/include/interfaces/sel4.xml
@@ -487,7 +487,7 @@
             </error>
         </method>
 
-        <method id="TCBSetSpace" name="SetSpace" manual_name="Set Space" manual_label="tcb_setspace_mcs">
+        <method id="TCBSetSpace" name="SetSpace" manual_name="Set Space (MCS)" manual_label="tcb_setspace_mcs">
             <condition><config var="CONFIG_KERNEL_MCS"/></condition>
             <brief>
                 Set the fault endpoint, CSpace and VSpace of a thread

--- a/manual/Doxyfile
+++ b/manual/Doxyfile
@@ -1146,15 +1146,6 @@ HTML_COLORSTYLE_SAT    = 100
 
 HTML_COLORSTYLE_GAMMA  = 80
 
-# If the HTML_TIMESTAMP tag is set to YES then the footer of each generated HTML
-# page will contain the date and time when the page was generated. Setting this
-# to YES can help to show when doxygen was last run and thus if the
-# documentation is up to date.
-# The default value is: NO.
-# This tag requires that the tag GENERATE_HTML is set to YES.
-
-HTML_TIMESTAMP         = NO
-
 # If the HTML_DYNAMIC_SECTIONS tag is set to YES then the generated HTML
 # documentation will contain sections that can be hidden and shown after the
 # page has loaded.
@@ -1710,14 +1701,6 @@ LATEX_HIDE_INDICES     = NO
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
 LATEX_BIB_STYLE        = plain
-
-# If the LATEX_TIMESTAMP tag is set to YES then the footer of each generated
-# page will contain the date and time when the page was generated. Setting this
-# to NO can help when comparing the output of multiple runs.
-# The default value is: NO.
-# This tag requires that the tag GENERATE_LATEX is set to YES.
-
-LATEX_TIMESTAMP        = NO
 
 #---------------------------------------------------------------------------
 # Configuration options related to the RTF output


### PR DESCRIPTION
(this PR is on top of #1123)

Put MCS-only invocations into their own groups and files. This solves the problem that doxygen gets confused by duplicate function names with the same parameters.

MCS/non-MCS is distinguished by evaluating the `<condition>` field in the API XML definition. If the condition evaluates to true when `CONFIG_KERNEL_MCS` is set, it is an MCS-only method, otherwise it is assumed to be non-MCS or present in both configs.

The longest part of all of this is parsing the condition field, but it's still relatively short and I don't think it warrants use of a full-blown parser generator or library.

Fixes https://github.com/seL4/seL4/issues/558

Also:
- distinguish SetSpace (MCS) by name in the manual to avoid confusion for the reader
- remove obsolete doxygen settings to avoid warnings in more recent versions