### PR TITLE
MCS: preserve sc_sporadic invariant

### DIFF
--- a/include/kernel/sporadic.h
+++ b/include/kernel/sporadic.h
@@ -160,7 +160,10 @@ static inline bool_t sc_released(sched_context_t *sc)
  */
 static inline bool_t sc_sporadic(sched_context_t *sc)
 {
-    return sc != NULL && sc_active(sc) && sc->scSporadic;
+    /* asserting sc != NULL --> sc->scSporadic --> sc_active(sc). That means, when
+       this function returns true, we also know that sc_active(sc) is true */
+    assert(sc == NULL || !sc->scSporadic || sc_active(sc));
+    return sc != NULL && sc->scSporadic;
 }
 
 /*

--- a/src/object/objecttype.c
+++ b/src/object/objecttype.c
@@ -230,6 +230,7 @@ finaliseCap_ret_t finaliseCap(cap_t cap, bool_t final, bool_t exposed)
             }
             /* mark the sc as no longer valid */
             sc->scRefillMax = 0;
+            sc->scSporadic = false;
             fc_ret.remainder = cap_null_cap_new();
             fc_ret.cleanupInfo = cap_null_cap_new();
             return fc_ret;

--- a/src/object/schedcontrol.c
+++ b/src/object/schedcontrol.c
@@ -13,10 +13,6 @@
 static exception_t invokeSchedControl_ConfigureFlags(sched_context_t *target, word_t core, ticks_t budget,
                                                      ticks_t period, word_t max_refills, word_t badge, word_t flags)
 {
-
-    target->scBadge = badge;
-    target->scSporadic = (flags & seL4_SchedContext_Sporadic) != 0;
-
     /* don't modify parameters of tcb while it is in a sorted queue */
     if (target->scTcb) {
         /* possibly stall a remote core */
@@ -72,6 +68,9 @@ static exception_t invokeSchedControl_ConfigureFlags(sched_context_t *target, wo
             rescheduleRequired();
         }
     }
+
+    target->scBadge = badge;
+    target->scSporadic = (flags & seL4_SchedContext_Sporadic) != 0;
 
     return EXCEPTION_NONE;
 }


### PR DESCRIPTION
#498 stipulates that `sc_sporadic` should imply `sc_active`, but the code showed assertion failures for a corresponding check.

It turns out that the failing assertion was wrong in the sense that it checked a different condition. It also turns out that the invariant as stipulated there is true if `scSporadic` is reset in `finaliseCap`. Thanks to @michaelmcinerney for proving that.

This PR:
- fixes `finaliseCap` so that the expected invariant holds
- simplifies `sc_sporadic` again so that it does not have to check `sc_active`
- adds the correct corresponding assertion
- slightly tweaks code ordering in `invokeSchedControl_ConfigureFlags` to make verification easier