### PR TITLE
exynos4: remove explicit setting of TIMER_PRECISION

### DIFF
--- a/src/plat/exynos4/config.cmake
+++ b/src/plat/exynos4/config.cmake
@@ -25,7 +25,6 @@ if(KernelPlatformExynos4)
         KERNEL_WCET 10u
         CLK_MAGIC 2863311531llu
         CLK_SHIFT 36u
-        TIMER_PRECISION 0u
     )
 endif()
 


### PR DESCRIPTION
The default value is zero anyway.