### PR TITLE
riscv: drop unused PLIC_IRQ_OFFSET

### DIFF
--- a/src/arch/riscv/platform_gen.h.in
+++ b/src/arch/riscv/platform_gen.h.in
@@ -27,8 +27,7 @@
  * field name.
  */
 enum IRQConstants {
-    PLIC_IRQ_OFFSET = 0,
-    PLIC_MAX_IRQ = PLIC_IRQ_OFFSET + (@CONFIGURE_MAX_IRQ@),
+    PLIC_MAX_IRQ = @CONFIGURE_MAX_IRQ@,
 #ifdef ENABLE_SMP_SUPPORT
     INTERRUPT_IPI_0,
     INTERRUPT_IPI_1,


### PR DESCRIPTION
I can't find a good reason why `PLIC_IRQ_OFFSET` is needed today, so let's remove this to avoid confusion. It was added in with 9a552d84b6f4f77ccf2b5e0e73d14b91ee7ed3d2 but I'm not sure why it was needed there, and then 375a98c8b36cea2dc3a9c8e94545a582f5c23548 moved it to this file.