### PR TITLE
CMake: show DTS name in error message

### DIFF
--- a/config.cmake
+++ b/config.cmake
@@ -164,7 +164,7 @@ if(DEFINED KernelDTSList AND (NOT "${KernelDTSList}" STREQUAL ""))
             RESULT_VARIABLE error
         )
         if(error)
-            message(FATAL_ERROR "Failed to compile DTS to DTB: ${KernelDTBPath}")
+            message(FATAL_ERROR "Failed to compile DTS to DTB: ${KernelDTSIntermediate}")
         endif()
         # The macOS and GNU coreutils `stat` utilities have different interfaces.
         # Check if we're using the macOS version, otherwise assume GNU coreutils.


### PR DESCRIPTION
Printing the input DTS file name makes more sense than printing the output DTB name on error. The output likely does not exists and thus this does not help.