### PR TITLE
make method names consistent

### DIFF
--- a/libsel4/arch_include/arm/interfaces/sel4arch.xml
+++ b/libsel4/arch_include/arm/interfaces/sel4arch.xml
@@ -669,7 +669,7 @@
     </interface>
    <interface name="seL4_IRQControl" manual_name="IRQ Control" cap_description="An IRQControl capability. This gives you the authority to make this call.">
 
-       <method id="ARMIRQIssueIRQHandlerTrigger" name="GetTrigger" manual_name="Get Trigger"
+       <method id="ARMIRQIssueIRQHandlerTrigger" name="GetTrigger" manual_name="Get IRQ Handler with Trigger Type"
            manual_label="irq_controlgettrigger">
             <brief>
                 Create an IRQ handler capability and specify the trigger method (edge or level).
@@ -718,7 +718,7 @@
             </error>
         </method>
 
-       <method id="ARMIRQIssueIRQHandlerTriggerCore" name="GetTriggerCore" manual_name="Get Trigger Core"
+       <method id="ARMIRQIssueIRQHandlerTriggerCore" name="GetTriggerCore" manual_name="Get IRQ Handler (SMP)"
            manual_label="irq_controlgettriggercore">
             <condition><config var="CONFIG_ENABLE_SMP_SUPPORT"/></condition>
             <brief>

--- a/libsel4/arch_include/arm/interfaces/sel4arch.xml
+++ b/libsel4/arch_include/arm/interfaces/sel4arch.xml
@@ -489,7 +489,7 @@
     <interface name="seL4_ARM_ASIDPool" manual_name="ASID Pool"
         cap_description="The ASID pool which is being assigned to. Must not be full. Each ASID pool can contain 1024 entries.">
         <method id="ARMASIDPoolAssign" name="Assign" manual_label="asidpool_assign"
-            manual_name="Asid Pool Assign">
+            manual_name="ASID Pool Assign">
             <brief>
                 Assign an ASID Pool.
             </brief>
@@ -669,7 +669,7 @@
     </interface>
    <interface name="seL4_IRQControl" manual_name="IRQ Control" cap_description="An IRQControl capability. This gives you the authority to make this call.">
 
-       <method id="ARMIRQIssueIRQHandlerTrigger" name="GetTrigger" manual_name="GetTrigger"
+       <method id="ARMIRQIssueIRQHandlerTrigger" name="GetTrigger" manual_name="Get Trigger"
            manual_label="irq_controlgettrigger">
             <brief>
                 Create an IRQ handler capability and specify the trigger method (edge or level).
@@ -718,7 +718,7 @@
             </error>
         </method>
 
-       <method id="ARMIRQIssueIRQHandlerTriggerCore" name="GetTriggerCore" manual_name="GetTriggerCore"
+       <method id="ARMIRQIssueIRQHandlerTriggerCore" name="GetTriggerCore" manual_name="Get Trigger Core"
            manual_label="irq_controlgettriggercore">
             <condition><config var="CONFIG_ENABLE_SMP_SUPPORT"/></condition>
             <brief>
@@ -774,7 +774,7 @@
         </method>
     </interface>
     <interface name="seL4_ARM_SIDControl" manual_name="SID Control" cap_description="A SIDControl capability. This gives you the authority to make this call.">
-       <method id="ARMSIDIssueSIDManager" name="GetSID" manual_name="GetSID" manual_label="sid_controlgetsid">
+       <method id="ARMSIDIssueSIDManager" name="GetSID" manual_name="Get SID" manual_label="sid_controlgetsid">
             <condition><config var="CONFIG_ARM_SMMU"/></condition>
             <brief>
                 Create a SID capability.
@@ -819,7 +819,7 @@
                 </description>
             </error>
         </method>
-       <method id="ARMSIDGetFault" name="GetFault" manual_name="GetFault" manual_label="sid_controlgetfault">
+       <method id="ARMSIDGetFault" name="GetFault" manual_name="Get Fault" manual_label="sid_controlgetfault">
             <condition><config var="CONFIG_ARM_SMMU"/></condition>
             <brief>
                 Get the fault status of the SMMU.
@@ -849,7 +849,7 @@
                 </description>
             </error>
         </method>
-        <method id="ARMSIDClearFault" name="ClearFault" manual_name="ClearFault" manual_label="sid_controlclearfault">
+        <method id="ARMSIDClearFault" name="ClearFault" manual_name="Clear Fault" manual_label="sid_controlclearfault">
             <condition><config var="CONFIG_ARM_SMMU"/></condition>
             <brief>
                 Clear the fault status of the SMMU.
@@ -870,7 +870,7 @@
         </method>
     </interface>
     <interface name="seL4_ARM_SID" manual_name="SID" cap_description="A SID capability. This gives you the authority to make this call.">
-       <method id="ARMSIDBindCB" name="BindCB" manual_name="BindCB" manual_label="sid_bindcb">
+       <method id="ARMSIDBindCB" name="BindCB" manual_name="Bind CB" manual_label="sid_bindcb">
             <condition><config var="CONFIG_ARM_SMMU"/></condition>
             <brief>
                 Binding a context bank to a stream ID.
@@ -897,7 +897,7 @@
                 </description>
             </error>
         </method>
-       <method id="ARMSIDUnbindCB" name="UnbindCB" manual_name="UnbindCB" manual_label="sid_unbindcb">
+       <method id="ARMSIDUnbindCB" name="UnbindCB" manual_name="Unbind CB" manual_label="sid_unbindcb">
             <condition><config var="CONFIG_ARM_SMMU"/></condition>
             <brief>
                 Unbinding a context bank from a stream ID.
@@ -919,7 +919,7 @@
         </method>
     </interface>
     <interface name="seL4_ARM_CBControl" manual_name="CB Control" cap_description="A CBControl capability. This gives you the authority to make this call.">
-       <method id="ARMCBIssueCBManager" name="GetCB" manual_name="GetCB" manual_label="cb_controlgetcb">
+       <method id="ARMCBIssueCBManager" name="GetCB" manual_name="Get CB" manual_label="cb_controlgetcb">
             <condition><config var="CONFIG_ARM_SMMU"/></condition>
             <brief>
                 Create a CB capability.
@@ -964,7 +964,7 @@
                 </description>
             </error>
         </method>
-        <method id="ARMCBTLBInvalidateAll" name="TLBInvalidateAll" manual_name="TLBInvalidateAll"
+        <method id="ARMCBTLBInvalidateAll" name="TLBInvalidateAll" manual_name="TLB Invalidate All"
            manual_label="cb_controltlbinvalidate">
             <condition><config var="CONFIG_ARM_SMMU"/></condition>
             <brief>
@@ -986,7 +986,7 @@
         </method>
     </interface>
     <interface name="seL4_ARM_CB" manual_name="CB" cap_description="A CB capability. This gives you the authority to make this call.">
-       <method id="ARMCBAssignVspace" name="AssignVspace" manual_name="AssignVspace" manual_label="cb_assignvspace">
+       <method id="ARMCBAssignVspace" name="AssignVspace" manual_name="Assign VSpace" manual_label="cb_assignvspace">
             <condition><config var="CONFIG_ARM_SMMU"/></condition>
             <brief>
                 Assigning a vspace to a context bank.
@@ -1013,7 +1013,7 @@
                 </description>
             </error>
         </method>
-        <method id="ARMCBUnassignVspace" name="UnassignVspace" manual_name="UnassignVspace" manual_label="cb_unassignvspace">
+        <method id="ARMCBUnassignVspace" name="UnassignVspace" manual_name="Unassign VSpace" manual_label="cb_unassignvspace">
             <condition><config var="CONFIG_ARM_SMMU"/></condition>
             <brief>
                 Unassigning a vspace to a context bank.
@@ -1033,7 +1033,7 @@
                 </description>
             </error>
         </method>
-        <method id="ARMCBTLBInvalidate" name="TLBInvalidate" manual_name="TLBInvalidate" manual_label="cb_tlbinvalidate">
+        <method id="ARMCBTLBInvalidate" name="TLBInvalidate" manual_name="TLB Invalidate" manual_label="cb_tlbinvalidate">
             <condition><config var="CONFIG_ARM_SMMU"/></condition>
             <brief>
                 Invalidating TLB entries used by the current ASID in this context bank.
@@ -1053,7 +1053,7 @@
                 </description>
             </error>
         </method>
-        <method id="ARMCBGetFault" name="CBGetFault" manual_name="CBGetFault"
+        <method id="ARMCBGetFault" name="CBGetFault" manual_name="CB Get Fault"
            manual_label="cb_getfault">
             <condition><config var="CONFIG_ARM_SMMU"/></condition>
             <brief>
@@ -1082,7 +1082,7 @@
                 </description>
             </error>
         </method>
-        <method id="ARMCBClearFault" name="CBClearFault" manual_name="CBClearFault" manual_label="cb_clearfault">
+        <method id="ARMCBClearFault" name="CBClearFault" manual_name="CB Clear Fault" manual_label="cb_clearfault">
             <condition><config var="CONFIG_ARM_SMMU"/></condition>
             <brief>
                  Clear the fault status of the context bank.

--- a/libsel4/arch_include/riscv/interfaces/sel4arch.xml
+++ b/libsel4/arch_include/riscv/interfaces/sel4arch.xml
@@ -199,7 +199,7 @@
                 </description>
             </error>
         </method>
-        <method id="RISCVPageGetAddress" name="GetAddress">
+        <method id="RISCVPageGetAddress" name="GetAddress" manual_name="Get Address">
             <brief>
                 Get the physical address of a page.
             </brief>
@@ -227,7 +227,7 @@
     </interface>
     <interface name="seL4_RISCV_ASIDControl" manual_name="ASID Control"
         cap_description="The master ASIDControl capability to invoke.">
-        <method id="RISCVASIDControlMakePool" name="MakePool">
+        <method id="RISCVASIDControlMakePool" name="MakePool" manual_name="Make Pool">
            <brief>
                 Create an ASID Pool.
             </brief>
@@ -317,7 +317,7 @@
     </interface>
     <interface name="seL4_IRQControl" manual_name="IRQ Control" cap_description="An IRQControl capability. This gives you the authority to make this call.">
 
-       <method id="RISCVIRQIssueIRQHandlerTrigger" name="GetTrigger" manual_name="GetTrigger"
+       <method id="RISCVIRQIssueIRQHandlerTrigger" name="GetTrigger" manual_name="Get Trigger"
            manual_label="irq_controlgettrigger">
             <brief>
                 Create an IRQ handler capability and specify the trigger method (edge or level).

--- a/libsel4/arch_include/riscv/interfaces/sel4arch.xml
+++ b/libsel4/arch_include/riscv/interfaces/sel4arch.xml
@@ -317,7 +317,7 @@
     </interface>
     <interface name="seL4_IRQControl" manual_name="IRQ Control" cap_description="An IRQControl capability. This gives you the authority to make this call.">
 
-       <method id="RISCVIRQIssueIRQHandlerTrigger" name="GetTrigger" manual_name="Get Trigger"
+       <method id="RISCVIRQIssueIRQHandlerTrigger" name="GetTrigger" manual_name="Get IRQ Handler with Trigger Type"
            manual_label="irq_controlgettrigger">
             <brief>
                 Create an IRQ handler capability and specify the trigger method (edge or level).

--- a/libsel4/arch_include/x86/interfaces/sel4arch.xml
+++ b/libsel4/arch_include/x86/interfaces/sel4arch.xml
@@ -977,7 +977,7 @@ contain the mapping"/>
                 </description>
             </error>
         </method>
-        <method id="X86VCPUEnableIOPort" name="EnableIOPort" manual_name="Enable IO Port" manual_label="vcpu_enableioport">
+        <method id="X86VCPUEnableIOPort" name="EnableIOPort" manual_name="Enable I/O Port" manual_label="vcpu_enableioport">
             <condition><config var="CONFIG_VTX"/></condition>
             <brief>
                 Enable I/O port range in guest execution
@@ -1012,7 +1012,7 @@ contain the mapping"/>
                 </description>
             </error>
         </method>
-        <method id="X86VCPUDisableIOPort" name="DisableIOPort" manual_name="Disable IO Port">
+        <method id="X86VCPUDisableIOPort" name="DisableIOPort" manual_name="Disable I/O Port">
             <condition><config var="CONFIG_VTX"/></condition>
             <brief>
                 Disable I/O port range in privileged execution

--- a/libsel4/arch_include/x86/interfaces/sel4arch.xml
+++ b/libsel4/arch_include/x86/interfaces/sel4arch.xml
@@ -750,7 +750,7 @@ contain the mapping"/>
     </interface>
 
     <interface name="seL4_IRQControl" manual_name="IRQ Control" cap_description='An IRQControl capability. This gives you the authority to make this call.'>
-        <method id="X86IRQIssueIRQHandlerIOAPIC" name="GetIOAPIC" manual_name="Get I/O APIC">
+        <method id="X86IRQIssueIRQHandlerIOAPIC" name="GetIOAPIC" manual_name="Get I/O APIC Handler">
             <brief>
                 Create an IRQ handler capability for an interrupt from an IOAPIC.
             </brief>
@@ -807,7 +807,7 @@ contain the mapping"/>
                 </description>
             </error>
         </method>
-        <method id="X86IRQIssueIRQHandlerMSI" name="GetMSI" manual_name="Get MSI">
+        <method id="X86IRQIssueIRQHandlerMSI" name="GetMSI" manual_name="Get MSI Handler">
             <brief>
                 Create an IRQ handler capability for an interrupt from an MSI.
             </brief>

--- a/libsel4/include/interfaces/sel4.xml
+++ b/libsel4/include/interfaces/sel4.xml
@@ -9,7 +9,7 @@
 
     <interface name="seL4_Untyped" manual_name="Untyped" cap_description="CPtr to an untyped object.">
 
-        <method id="UntypedRetype" name="Retype" manual_name="Retype" manual_label="untyped_retype">
+        <method id="UntypedRetype" name="Retype" manual_label="untyped_retype">
             <brief>
                 Retype an untyped object
             </brief>
@@ -179,7 +179,7 @@
             </error>
         </method>
 
-        <method id="TCBConfigure" name="Configure" manual_name="Configure" manual_label="tcb_configure">
+        <method id="TCBConfigure" name="Configure" manual_label="tcb_configure">
             <condition><not><config var="CONFIG_KERNEL_MCS"/></not></condition>
             <brief>
                 Set the parameters of a TCB
@@ -525,7 +525,7 @@
             </error>
         </method>
 
-        <method id="TCBSuspend" name="Suspend" manual_name="Suspend" manual_label="tcb_suspend">
+        <method id="TCBSuspend" name="Suspend" manual_label="tcb_suspend">
             <brief>
                 Suspend a thread
             </brief>
@@ -544,7 +544,7 @@
             </error>
         </method>
 
-        <method id="TCBResume" name="Resume" manual_name="Resume" manual_label="tcb_resume">
+        <method id="TCBResume" name="Resume" manual_label="tcb_resume">
             <brief>
                 Resume a thread
             </brief>
@@ -828,7 +828,7 @@
     </interface>
 
     <interface name="seL4_CNode" manual_name="CNode">
-        <method id="CNodeRevoke" name="Revoke" manual_name="Revoke" manual_label="cnode_revoke">
+        <method id="CNodeRevoke" name="Revoke" manual_label="cnode_revoke">
             <brief>
                 Delete all child capabilities of a capability
             </brief>
@@ -860,7 +860,7 @@
             </error>
         </method>
 
-        <method id="CNodeDelete" name="Delete" manual_name="Delete" manual_label="cnode_delete">
+        <method id="CNodeDelete" name="Delete" manual_label="cnode_delete">
             <brief>
                 Delete a capability
             </brief>
@@ -928,7 +928,7 @@
             </error>
         </method>
 
-        <method id="CNodeCopy" name="Copy" manual_name="Copy" manual_label="cnode_copy">
+        <method id="CNodeCopy" name="Copy" manual_label="cnode_copy">
             <brief>
                 Copy a capability, setting its access rights whilst doing so
             </brief>
@@ -977,7 +977,7 @@
             </error>
         </method>
 
-        <method id="CNodeMint" name="Mint" manual_name="Mint" manual_label="cnode_mint">
+        <method id="CNodeMint" name="Mint" manual_label="cnode_mint">
             <brief>
                 Copy a capability, setting its access rights and badge whilst doing so
             </brief>
@@ -1028,7 +1028,7 @@
             </error>
         </method>
 
-        <method id="CNodeMove" name="Move" manual_name="Move" manual_label="cnode_move">
+        <method id="CNodeMove" name="Move" manual_label="cnode_move">
             <brief>
                 Move a capability
             </brief>
@@ -1066,7 +1066,7 @@
             </error>
         </method>
 
-        <method id="CNodeMutate" name="Mutate" manual_name="Mutate" manual_label="cnode_mutate">
+        <method id="CNodeMutate" name="Mutate" manual_label="cnode_mutate">
             <brief>
                 Move a capability, setting its guard in the process. This
                 operation is mostly useful for setting the guard of a CNode
@@ -1110,7 +1110,7 @@
             </error>
         </method>
 
-        <method id="CNodeRotate" name="Rotate" manual_name="Rotate" manual_label="cnode_rotate">
+        <method id="CNodeRotate" name="Rotate" manual_label="cnode_rotate">
             <brief>
                 Given 3 capability slots - a destination, pivot and source - move the capability in the
                 pivot slot to the destination slot and the capability in the source slot to the pivot slot
@@ -1194,7 +1194,7 @@
 
     <interface name="seL4_IRQControl" manual_name="IRQ Control" cap_description="An IRQControl capability. This gives you the authority to make this call.">
 
-        <method id="IRQIssueIRQHandler" name="Get" manual_name="Get" manual_label="irq_controlget">
+        <method id="IRQIssueIRQHandler" name="Get" manual_label="irq_controlget">
             <brief>
                 Create an IRQ handler capability
             </brief>
@@ -1281,7 +1281,7 @@
             </error>
         </method>
 
-        <method id="IRQClearIRQHandler" name="Clear" manual_name="Clear" manual_label="irq_handlerclear">
+        <method id="IRQClearIRQHandler" name="Clear" manual_label="irq_handlerclear">
             <brief>
                 Clear the handler capability from the IRQ slot
             </brief>
@@ -1304,7 +1304,7 @@
 
     <interface name="seL4_DomainSet" manual_name="Domain Set" cap_description="Capability allowing domain configuration.">
 
-        <method id="DomainSetSet" name="Set" manual_name="Set" manual_label="domainset_set">
+        <method id="DomainSetSet" name="Set" manual_label="domainset_set">
             <brief>
                 Change the domain of a thread.
             </brief>
@@ -1334,7 +1334,7 @@
 
     <interface name="seL4_SchedControl" cap_description="Capability to a scheduling control object.">
 
-        <method id="SchedControlConfigureFlags" name="ConfigureFlags" manual_name="ConfigureFlags" manual_label="schedcontrol_configureflags">
+        <method id="SchedControlConfigureFlags" name="ConfigureFlags" manual_name="Configure Flags" manual_label="schedcontrol_configureflags">
             <condition><config var="CONFIG_KERNEL_MCS"/></condition>
             <brief>
                 Set the parameters of a scheduling context by invoking the scheduling control capability. If the scheduling context is bound to a currently running thread, the parameters will take effect immediately: that is the current budget will be increased or reduced by the difference between the new and previous budget and the replenishment time will be updated according to any difference in the period. This can result in active threads being post-poned or released depending on the nature of the parameter change and the state of the thread. Additionally, if the scheduling context was previously empty (no budget) but bound to a runnable thread, this can result in a thread running for the first time since it now has access to CPU time. This call will return seL4 Invalid Argument if the parameters are too small (smaller than the kernel WCET for this platform) or too large (will overflow the timer).
@@ -1377,8 +1377,7 @@
 
     <interface name="seL4_SchedContext" cap_description="Capability to the scheduling context which is being operated on.">
 
-        <method id="SchedContextBind" name="Bind"
-            manual_name="Bind" manual_label="schedcontext_bind">
+        <method id="SchedContextBind" name="Bind" manual_label="schedcontext_bind">
             <condition><config var="CONFIG_KERNEL_MCS"/></condition>
             <brief>
                 Bind an object to a scheduling context. The object can be a notification object or a
@@ -1415,8 +1414,7 @@
             </error>
         </method>
 
-        <method id="SchedContextUnbind" name="Unbind"
-            manual_name="Unbind" manual_label="schedcontext_unbind">
+        <method id="SchedContextUnbind" name="Unbind" manual_label="schedcontext_unbind">
             <condition><config var="CONFIG_KERNEL_MCS"/></condition>
             <brief>
                 Unbind any objects (threads or notification objects) from a scheduling context. This
@@ -1440,7 +1438,7 @@
         </method>
 
         <method id="SchedContextUnbindObject" name="UnbindObject"
-            manual_name="UnbindObject" manual_label="schedcontext_unbindobject">
+            manual_name="Unbind Object" manual_label="schedcontext_unbindobject">
             <condition><config var="CONFIG_KERNEL_MCS"/></condition>
             <brief>
                 Unbind an object from a scheduling context. The object can be either a thread or a
@@ -1472,7 +1470,7 @@
                 </description>
             </error>
         </method>
-        <method id="SchedContextConsumed" name="Consumed" manual_name="Consumed" manual_label="schedcontext_consumed">
+        <method id="SchedContextConsumed" name="Consumed" manual_label="schedcontext_consumed">
             <condition><config var="CONFIG_KERNEL_MCS"/></condition>
             <brief>
                 Return the amount of time used by this scheduling context since this function was last called or a timeout exception triggered.
@@ -1494,7 +1492,7 @@
                 </description>
             </error>
        </method>
-       <method id="SchedContextYieldTo" name="YieldTo" manual_name="YieldTo" manual_label="schedcontext_yieldto">
+       <method id="SchedContextYieldTo" name="YieldTo" manual_name="Yield To" manual_label="schedcontext_yieldto">
           <condition><config var="CONFIG_KERNEL_MCS"/></condition>
           <brief>
               If a thread is currently runnable and running on this scheduling context and the scheduling context has available budget, place it at the head of the scheduling queue.

--- a/libsel4/include/interfaces/sel4.xml
+++ b/libsel4/include/interfaces/sel4.xml
@@ -1194,7 +1194,7 @@
 
     <interface name="seL4_IRQControl" manual_name="IRQ Control" cap_description="An IRQControl capability. This gives you the authority to make this call.">
 
-        <method id="IRQIssueIRQHandler" name="GetIRQHandler" manual_name="Get IRQ Handler" manual_label="irq_controlget">
+        <method id="IRQIssueIRQHandler" name="Get" manual_name="Get IRQ Handler" manual_label="irq_controlget">
             <brief>
                 Create an IRQ handler capability
             </brief>

--- a/libsel4/include/interfaces/sel4.xml
+++ b/libsel4/include/interfaces/sel4.xml
@@ -1194,7 +1194,7 @@
 
     <interface name="seL4_IRQControl" manual_name="IRQ Control" cap_description="An IRQControl capability. This gives you the authority to make this call.">
 
-        <method id="IRQIssueIRQHandler" name="Get IRQ Handler" manual_label="irq_controlget">
+        <method id="IRQIssueIRQHandler" name="GetIRQHandler" manual_name="Get IRQ Handler" manual_label="irq_controlget">
             <brief>
                 Create an IRQ handler capability
             </brief>

--- a/libsel4/include/interfaces/sel4.xml
+++ b/libsel4/include/interfaces/sel4.xml
@@ -1194,7 +1194,7 @@
 
     <interface name="seL4_IRQControl" manual_name="IRQ Control" cap_description="An IRQControl capability. This gives you the authority to make this call.">
 
-        <method id="IRQIssueIRQHandler" name="Get" manual_label="irq_controlget">
+        <method id="IRQIssueIRQHandler" name="Get IRQ Handler" manual_label="irq_controlget">
             <brief>
                 Create an IRQ handler capability
             </brief>

--- a/libsel4/include/sel4/syscalls.h
+++ b/libsel4/include/sel4/syscalls.h
@@ -44,7 +44,7 @@ LIBSEL4_INLINE_FUNC void
 seL4_DebugPutChar(char c);
 
 /**
- * @xmlonly <manual name="Dump scheduler" label="sel4_dumpscheduler"/> @endxmlonly
+ * @xmlonly <manual name="Dump Scheduler" label="sel4_dumpscheduler"/> @endxmlonly
  * @brief Output the contents of the kernel scheduler.
  *
  * Dump the state of the all TCB objects to kernel serial output. This system call
@@ -317,7 +317,7 @@ seL4_BenchmarkResetAllThreadsUtilisation(void);
 
 #ifdef CONFIG_VTX
 /**
- * @xmlonly <manual name="VMEnter" label="sel4_vmenter"/> @endxmlonly
+ * @xmlonly <manual name="VM Enter" label="sel4_vmenter"/> @endxmlonly
  * @brief Change current thread to execute from its bound VCPU
  *
  * Changes the execution mode of the current thread from normal TCB execution, to
@@ -374,7 +374,7 @@ seL4_VMEnter(seL4_Word *sender);
 
 #ifdef CONFIG_SET_TLS_BASE_SELF
 /**
- * @xmlonly <manual name="SetTLSBase" label="sel4_settlsbase"/> @endxmlonly
+ * @xmlonly <manual name="Set TLS Base" label="sel4_settlsbase"/> @endxmlonly
  * @brief Set the TLS base address and register of the currently executing thread.
  *
  * This stores the base address of the TLS region in the register

--- a/libsel4/include/sel4/syscalls_master.h
+++ b/libsel4/include/sel4/syscalls_master.h
@@ -125,7 +125,7 @@ LIBSEL4_INLINE_FUNC seL4_MessageInfo_t
 seL4_ReplyRecv(seL4_CPtr dest, seL4_MessageInfo_t msgInfo, seL4_Word *sender);
 
 /**
- * @xmlonly <manual name="NBRecv" label="sel4_nbrecv"/> @endxmlonly
+ * @xmlonly <manual name="Non-Blocking Recv" label="sel4_nbrecv"/> @endxmlonly
  * @brief Receive a message from an endpoint but do not block
  *        in the case that no messages are pending
  *

--- a/libsel4/include/sel4/syscalls_mcs.h
+++ b/libsel4/include/sel4/syscalls_mcs.h
@@ -114,7 +114,7 @@ LIBSEL4_INLINE_FUNC seL4_MessageInfo_t
 seL4_ReplyRecv(seL4_CPtr src, seL4_MessageInfo_t msgInfo, seL4_Word *sender, seL4_CPtr reply);
 
 /**
- * @xmlonly <manual name="NBRecv" label="sel4_mcs_nbrecv"/> @endxmlonly
+ * @xmlonly <manual name="Non-Blocking Recv" label="sel4_mcs_nbrecv"/> @endxmlonly
  * @brief Receive a message from an endpoint but do not block
  *        in the case that no messages are pending
  *
@@ -140,7 +140,7 @@ LIBSEL4_INLINE_FUNC seL4_MessageInfo_t
 seL4_NBRecv(seL4_CPtr src, seL4_Word *sender, seL4_CPtr reply);
 
 /**
- * @xmlonly <manual name="NBSend Recv" label="sel4_nbsendrecv"/> @endxmlonly
+ * @xmlonly <manual name="Non-Blocking Send Recv" label="sel4_nbsendrecv"/> @endxmlonly
  * @brief Non-blocking send on one capability, and a blocking recieve on another in a single
  *        system call.
  *
@@ -168,7 +168,7 @@ LIBSEL4_INLINE_FUNC seL4_MessageInfo_t
 seL4_NBSendRecv(seL4_CPtr dest, seL4_MessageInfo_t msgInfo, seL4_CPtr src, seL4_Word *sender, seL4_CPtr reply);
 
 /**
- * @xmlonly <manual name="NBSend Wait" label="sel4_nbsendwait"/> @endxmlonly
+ * @xmlonly <manual name="Non-Blocking Send Wait" label="sel4_nbsendwait"/> @endxmlonly
  * @brief Non-blocking invoke of a capability and wait on another in one system call
  *
  * @xmlonly
@@ -233,7 +233,7 @@ LIBSEL4_INLINE_FUNC seL4_MessageInfo_t
 seL4_Wait(seL4_CPtr src, seL4_Word *sender);
 
 /**
- * @xmlonly <manual name="NBWait" label="sel4_nbwait"/> @endxmlonly
+ * @xmlonly <manual name="Non-Blocking Wait" label="sel4_nbwait"/> @endxmlonly
  * @brief Perform a polling wait on an endpoint or notification object
  *
  * Poll a notification or endpoint waiting for a message. No reply object is

--- a/libsel4/sel4_arch_include/x86_64/interfaces/sel4arch.xml
+++ b/libsel4/sel4_arch_include/x86_64/interfaces/sel4arch.xml
@@ -97,7 +97,7 @@
         </method>
     </interface>
     <interface name="seL4_X86_VCPU" manual_name="VCPU" cap_description='VCPU object to operate on'>
-      <method id="X86VCPUReadMSR" name="ReadMSR">
+      <method id="X86VCPUReadMSR" name="ReadMSR" manual_name="Read MSR">
         <condition><config var="CONFIG_X86_64_VTX_64BIT_GUESTS"/></condition>
         <brief>
           Read 64-bit specific MSR field from the hardware
@@ -119,7 +119,7 @@
         <param dir="out" name="value" type="seL4_Word"
                description='Value returned by `rdmsr` instruction'/>
       </method>
-      <method id="X86VCPUWriteMSR" name="WriteMSR">
+      <method id="X86VCPUWriteMSR" name="WriteMSR" manual_name="Write MSR">
         <condition><config var="CONFIG_X86_64_VTX_64BIT_GUESTS"/></condition>
         <brief>
           Write 64-bit specific MSR field to the hardware


### PR DESCRIPTION
@Indanz @lsf37 
A first conservative go at addressing https://github.com/seL4/seL4/issues/565
- made method names consistent
- deleted duplicates for manual_name and name

There many other acronyms in manual headings, e.g. Recv, but renaming these is probably unnecessary.