### PR TITLE
Arm 64-bit: do not use unsigned int for arg length

### DIFF
--- a/include/arch/arm/arch/machine/gic_v2.h
+++ b/include/arch/arm/arch/machine/gic_v2.h
@@ -216,7 +216,7 @@ struct gich_vcpu_ctrl_map {
 };
 
 extern volatile struct gich_vcpu_ctrl_map *gic_vcpu_ctrl;
-extern unsigned int gic_vcpu_num_list_regs;
+extern word_t gic_vcpu_num_list_regs;
 
 static inline uint32_t get_gic_vcpu_ctrl_hcr(void)
 {

--- a/include/arch/arm/arch/machine/gic_v3.h
+++ b/include/arch/arm/arch/machine/gic_v3.h
@@ -320,7 +320,7 @@ static inline void ackInterrupt(irq_t irq)
 
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
 
-extern unsigned int gic_vcpu_num_list_regs;
+extern word_t gic_vcpu_num_list_regs;
 
 static inline uint32_t get_gic_vcpu_ctrl_hcr(void)
 {

--- a/include/arch/arm/arch/object/smc.h
+++ b/include/arch/arm/arch/object/smc.h
@@ -8,5 +8,5 @@
 
 #define NUM_SMC_REGS 8
 
-exception_t decodeARMSMCInvocation(word_t label, unsigned int length, cptr_t cptr,
+exception_t decodeARMSMCInvocation(word_t label, word_t length, cptr_t cptr,
                                    cte_t *srcSlot, cap_t cap, bool_t call, word_t *buffer);

--- a/include/arch/arm/arch/object/smmu.h
+++ b/include/arch/arm/arch/object/smmu.h
@@ -14,18 +14,18 @@
 #define ASID_INVALID     nASIDs
 
 
-exception_t decodeARMSIDControlInvocation(word_t label, unsigned int length, cptr_t cptr,
+exception_t decodeARMSIDControlInvocation(word_t label, word_t length, cptr_t cptr,
                                           cte_t *srcSlot, cap_t cap,
                                           bool_t call, word_t *buffer);
 
-exception_t decodeARMSIDInvocation(word_t label, unsigned int length, cptr_t cptr,
+exception_t decodeARMSIDInvocation(word_t label, word_t length, cptr_t cptr,
                                    cte_t *srcSlot, cap_t cap, bool_t call, word_t *buffer);
 
-exception_t decodeARMCBControlInvocation(word_t label, unsigned int length, cptr_t cptr,
+exception_t decodeARMCBControlInvocation(word_t label, word_t length, cptr_t cptr,
                                          cte_t *srcSlot, cap_t cap,
                                          bool_t call, word_t *buffer);
 
-exception_t decodeARMCBInvocation(word_t label, unsigned int length, cptr_t cptr,
+exception_t decodeARMCBInvocation(word_t label, word_t length, cptr_t cptr,
                                   cte_t *srcSlot, cap_t cap, bool_t call, word_t *buffer);
 exception_t smmu_delete_cb(cap_t cap);
 exception_t smmu_delete_sid(cap_t cap);

--- a/include/arch/arm/arch/object/vcpu.h
+++ b/include/arch/arm/arch/object/vcpu.h
@@ -107,7 +107,7 @@ void dissociateVCPUTCB(vcpu_t *vcpu, tcb_t *tcb);
 
 exception_t decodeARMVCPUInvocation(
     word_t label,
-    unsigned int length,
+    word_t length,
     cptr_t cptr,
     cte_t *slot,
     cap_t cap,
@@ -121,11 +121,11 @@ void vcpu_switch(vcpu_t *cpu);
 void handleVCPUInjectInterruptIPI(vcpu_t *vcpu, unsigned long index, virq_t virq);
 #endif /* ENABLE_SMP_SUPPORT */
 
-exception_t decodeVCPUWriteReg(cap_t cap, unsigned int length, word_t *buffer);
-exception_t decodeVCPUReadReg(cap_t cap, unsigned int length, bool_t call, word_t *buffer);
-exception_t decodeVCPUInjectIRQ(cap_t cap, unsigned int length, word_t *buffer);
+exception_t decodeVCPUWriteReg(cap_t cap, word_t length, word_t *buffer);
+exception_t decodeVCPUReadReg(cap_t cap, word_t length, bool_t call, word_t *buffer);
+exception_t decodeVCPUInjectIRQ(cap_t cap, word_t length, word_t *buffer);
 exception_t decodeVCPUSetTCB(cap_t cap);
-exception_t decodeVCPUAckVPPI(cap_t cap, unsigned int length, word_t *buffer);
+exception_t decodeVCPUAckVPPI(cap_t cap, word_t length, word_t *buffer);
 
 exception_t invokeVCPUWriteReg(vcpu_t *vcpu, word_t field, word_t value);
 exception_t invokeVCPUReadReg(vcpu_t *vcpu, word_t field, bool_t call);

--- a/src/arch/arm/64/kernel/vspace.c
+++ b/src/arch/arm/64/kernel/vspace.c
@@ -1247,7 +1247,7 @@ static exception_t performASIDControlInvocation(void *frame, cte_t *slot,
     return EXCEPTION_NONE;
 }
 
-static exception_t decodeARMVSpaceRootInvocation(word_t invLabel, unsigned int length,
+static exception_t decodeARMVSpaceRootInvocation(word_t invLabel, word_t length,
                                                  cte_t *cte, cap_t cap, word_t *buffer)
 {
     vptr_t start, end;
@@ -1350,7 +1350,7 @@ static exception_t decodeARMVSpaceRootInvocation(word_t invLabel, unsigned int l
 }
 
 
-static exception_t decodeARMPageTableInvocation(word_t invLabel, unsigned int length,
+static exception_t decodeARMPageTableInvocation(word_t invLabel, word_t length,
                                                 cte_t *cte, cap_t cap, word_t *buffer)
 {
     cap_t vspaceRootCap;
@@ -1440,7 +1440,7 @@ static inline bool_t CONST checkVPAlignment(vm_page_size_t sz, word_t w)
     return (w & MASK(pageBitsForSize(sz))) == 0;
 }
 
-static exception_t decodeARMFrameInvocation(word_t invLabel, unsigned int length,
+static exception_t decodeARMFrameInvocation(word_t invLabel, word_t length,
                                             cte_t *cte, cap_t cap, bool_t call, word_t *buffer)
 {
     switch (invLabel) {

--- a/src/arch/arm/machine/gic_v2.c
+++ b/src/arch/arm/machine/gic_v2.c
@@ -228,6 +228,6 @@ volatile struct gich_vcpu_ctrl_map *gic_vcpu_ctrl =
     (volatile struct gich_vcpu_ctrl_map *)(GIC_V2_VCPUCTRL_PPTR);
 #endif /* GIC_PL400_GICVCPUCTRL_PPTR */
 
-unsigned int gic_vcpu_num_list_regs;
+word_t gic_vcpu_num_list_regs;
 
 #endif /* End of CONFIG_ARM_HYPERVISOR_SUPPORT */

--- a/src/arch/arm/machine/gic_v3.c
+++ b/src/arch/arm/machine/gic_v3.c
@@ -389,6 +389,6 @@ void setIRQTarget(irq_t irq, seL4_Word target)
 
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
 
-unsigned int gic_vcpu_num_list_regs;
+word_t gic_vcpu_num_list_regs;
 
 #endif /* End of CONFIG_ARM_HYPERVISOR_SUPPORT */

--- a/src/arch/arm/object/smc.c
+++ b/src/arch/arm/object/smc.c
@@ -63,7 +63,7 @@ static exception_t invokeSMCCall(word_t *buffer, bool_t call)
     return EXCEPTION_NONE;
 }
 
-exception_t decodeARMSMCInvocation(word_t label, unsigned int length, cptr_t cptr,
+exception_t decodeARMSMCInvocation(word_t label, word_t length, cptr_t cptr,
                                    cte_t *srcSlot, cap_t cap, bool_t call, word_t *buffer)
 {
     if (label != ARMSMCCall) {

--- a/src/arch/arm/object/smmu.c
+++ b/src/arch/arm/object/smmu.c
@@ -18,7 +18,7 @@ static exception_t checkARMCBVspace(cap_t cap)
     return EXCEPTION_NONE;
 }
 
-exception_t decodeARMSIDControlInvocation(word_t label, unsigned int length, cptr_t cptr,
+exception_t decodeARMSIDControlInvocation(word_t label, word_t length, cptr_t cptr,
                                           cte_t *srcSlot, cap_t cap, bool_t call, word_t *buffer)
 {
 
@@ -99,7 +99,7 @@ exception_t decodeARMSIDControlInvocation(word_t label, unsigned int length, cpt
     return EXCEPTION_NONE;
 }
 
-exception_t decodeARMSIDInvocation(word_t label, unsigned int length, cptr_t cptr,
+exception_t decodeARMSIDInvocation(word_t label, word_t length, cptr_t cptr,
                                    cte_t *srcSlot, cap_t cap, bool_t call, word_t *buffer)
 {
     cap_t cbCap;
@@ -185,7 +185,7 @@ exception_t smmu_delete_sid(cap_t cap)
     return status;
 }
 
-exception_t decodeARMCBControlInvocation(word_t label, unsigned int length, cptr_t cptr,
+exception_t decodeARMCBControlInvocation(word_t label, word_t length, cptr_t cptr,
                                          cte_t *srcSlot, cap_t cap, bool_t call, word_t *buffer)
 {
 
@@ -249,7 +249,7 @@ exception_t decodeARMCBControlInvocation(word_t label, unsigned int length, cptr
     return EXCEPTION_NONE;
 }
 
-exception_t decodeARMCBInvocation(word_t label, unsigned int length, cptr_t cptr,
+exception_t decodeARMCBInvocation(word_t label, word_t length, cptr_t cptr,
                                   cte_t *srcSlot, cap_t cap, bool_t call, word_t *buffer)
 {
 

--- a/src/arch/arm/object/vcpu.c
+++ b/src/arch/arm/object/vcpu.c
@@ -32,7 +32,7 @@ BOOT_CODE void vcpu_boot_init(void)
 static void vcpu_save(vcpu_t *vcpu, bool_t active)
 {
     word_t i;
-    unsigned int lr_num;
+    word_t lr_num;
 
     assert(vcpu);
     dsb();
@@ -85,7 +85,7 @@ void vcpu_restore(vcpu_t *vcpu)
 {
     assert(vcpu);
     word_t i;
-    unsigned int lr_num;
+    word_t lr_num;
     /* Turn off the VGIC */
     set_gic_vcpu_ctrl_hcr(0);
     isb();

--- a/src/arch/arm/object/vcpu.c
+++ b/src/arch/arm/object/vcpu.c
@@ -314,7 +314,7 @@ exception_t invokeVCPUWriteReg(vcpu_t *vcpu, word_t field, word_t value)
     return EXCEPTION_NONE;
 }
 
-exception_t decodeVCPUWriteReg(cap_t cap, unsigned int length, word_t *buffer)
+exception_t decodeVCPUWriteReg(cap_t cap, word_t length, word_t *buffer)
 {
     word_t field;
     word_t value;
@@ -351,7 +351,7 @@ exception_t invokeVCPUReadReg(vcpu_t *vcpu, word_t field, bool_t call)
     return EXCEPTION_NONE;
 }
 
-exception_t decodeVCPUReadReg(cap_t cap, unsigned int length, bool_t call, word_t *buffer)
+exception_t decodeVCPUReadReg(cap_t cap, word_t length, bool_t call, word_t *buffer)
 {
     word_t field;
     if (length < 1) {
@@ -388,7 +388,7 @@ exception_t invokeVCPUInjectIRQ(vcpu_t *vcpu, unsigned long index, virq_t virq)
     return EXCEPTION_NONE;
 }
 
-exception_t decodeVCPUInjectIRQ(cap_t cap, unsigned int length, word_t *buffer)
+exception_t decodeVCPUInjectIRQ(cap_t cap, word_t length, word_t *buffer)
 {
     word_t vid, priority, group, index;
     vcpu_t *vcpu;
@@ -473,7 +473,7 @@ exception_t decodeVCPUInjectIRQ(cap_t cap, unsigned int length, word_t *buffer)
 
 exception_t decodeARMVCPUInvocation(
     word_t label,
-    unsigned int length,
+    word_t length,
     cptr_t cptr,
     cte_t *slot,
     cap_t cap,
@@ -499,7 +499,7 @@ exception_t decodeARMVCPUInvocation(
     }
 }
 
-exception_t decodeVCPUAckVPPI(cap_t cap, unsigned int length, word_t *buffer)
+exception_t decodeVCPUAckVPPI(cap_t cap, word_t length, word_t *buffer)
 {
     vcpu_t *vcpu = VCPU_PTR(cap_vcpu_cap_get_capVCPUPtr(cap));
 


### PR DESCRIPTION
Arch_decodeInvocation takes a word_t length and then passes it to functions that take an unsigned int length. This was OK on 32-bit where these types are the same, but on 64-bit this is a downcast without a range check. It isn't clear why this doesn't trip a compiler warning.