### PR TITLE
github: upload kernel.elf build artifact

### DIFF
--- a/.github/workflows/sel4test-hw.yml
+++ b/.github/workflows/sel4test-hw.yml
@@ -50,6 +50,11 @@ jobs:
       with:
         name: images-${{ matrix.march }}-${{ matrix.compiler }}
         path: '*-images.tar.gz'
+    - name: Upload kernel.elf files
+      uses: actions/upload-artifact@v3
+      with:
+        name: kernel.elf-${{ matrix.march }}-${{ matrix.compiler }}
+        path: '*-kernel.elf'
 
   the_matrix:
     name: Matrix


### PR DESCRIPTION
The kernel.elf file is occasionally more useful for debugging than the final board image.

This will need seL4/ci-actions#292 to be merged first.