### PR TITLE
cmake: propagate `CROSS_COMPILER_PREFIX`

### DIFF
--- a/gcc.cmake
+++ b/gcc.cmake
@@ -145,6 +145,8 @@ set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
 
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 
+set(CMAKE_TRY_COMPILE_PLATFORM_VARIABLES CROSS_COMPILER_PREFIX)
+
 mark_as_advanced(FORCE CMAKE_TOOLCHAIN_FILE)
 
 # Invoke compiler via ccache. This has no effect if ccache cannot be found.


### PR DESCRIPTION
Mark `CROSS_COMPILER_PREFIX` as meaningful to `gcc.cmake`, so that it is propagated for all cases where `gcc.cmake` used.

`gcc.cmake` may be evaluated multiple times by CMake during configuration. Without this patch, `gcc.cmake` may be evaluated without `CROSS_COMPILER_PREFIX` set in some cases, even if `-DCROSS_COMPILER_PREFIX=<...>` was specified in the CMake command line.

[Documentation for CMAKE_TRY_COMPILE_PLATFORM_VARIABLES](https://cmake.org/cmake/help/latest/variable/CMAKE_TRY_COMPILE_PLATFORM_VARIABLES.html).
