### PR TITLE
CI: build and test kernel for RISCV64 with LLVM

### DIFF
--- a/.github/workflows/compilation-checks.yml
+++ b/.github/workflows/compilation-checks.yml
@@ -19,12 +19,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # RISCV32 and IA32 are left out, as they have no verified config
         arch: [ARM, ARM_HYP, AARCH64, RISCV64, X64]
         compiler: [gcc, llvm]
-        exclude:
-          # llvm RISCV64 compilation is not currently supported
-          - arch: RISCV64
-            compiler: llvm
     steps:
     - uses: actions/checkout@v3
     - uses: seL4/ci-actions/standalone-kernel@master

--- a/.github/workflows/sel4test-deploy.yml
+++ b/.github/workflows/sel4test-deploy.yml
@@ -58,11 +58,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        march: [armv7a, armv8a, nehalem]
+        # There is no "rv32imac" hardware yet.
+        march: [armv7a, armv8a, nehalem, rv64imac]
         compiler: [gcc, clang]
-        include:
-          - march: rv64imac
-            compiler: gcc
     steps:
     - name: Build
       uses: seL4/ci-actions/sel4test-hw@master

--- a/.github/workflows/sel4test-hw.yml
+++ b/.github/workflows/sel4test-hw.yml
@@ -33,11 +33,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        march: [armv7a, armv8a, nehalem]
+        # There is no "rv32imac" hardware yet.
+        march: [armv7a, armv8a, nehalem, rv64imac]
         compiler: [gcc, clang]
-        include:
-          - march: rv64imac
-            compiler: gcc
     steps:
     - name: Build
       uses: seL4/ci-actions/sel4test-hw@master

--- a/.github/workflows/sel4test-sim.yml
+++ b/.github/workflows/sel4test-sim.yml
@@ -23,11 +23,6 @@ jobs:
       matrix:
         march: [armv7a, armv8a, nehalem, rv32imac, rv64imac]
         compiler: [gcc, clang]
-        exclude:
-          - march: rv32imac
-            compiler: clang
-          - march: rv64imac
-            compiler: clang
     steps:
     - uses: seL4/ci-actions/sel4test-sim@master
       with:


### PR DESCRIPTION
Changes
- CI: build standalone kernel for RISCV64 with LLVM
- CI: run sim and HW build with LLVM for RISCV

To be me merged one these docker containers have been updated, so the workflows use them
- https://hub.docker.com/r/sel4/sel4test-hw
- https://hub.docker.com/r/sel4/sel4test-sim

related CI-Actions PR
- https://github.com/seL4/ci-actions/pull/295
- https://github.com/seL4/ci-actions/pull/299