### PR TITLE
aarch64/vspace: adjust type for verification

### DIFF
--- a/src/arch/arm/64/kernel/vspace.c
+++ b/src/arch/arm/64/kernel/vspace.c
@@ -1649,7 +1649,7 @@ exception_t decodeARMMMUInvocation(word_t invLabel, word_t length, cptr_t cptr,
         return decodeARMFrameInvocation(invLabel, length, cte, cap, call, buffer);
 
     case cap_asid_control_cap: {
-        unsigned int i;
+        word_t i;
         asid_t asid_base;
         word_t index, depth;
         cap_t untyped, root;


### PR DESCRIPTION
Bring the type of `i` into line with what the other architectures do in `decode...MMUInvocation` for `ASIDControl`. This makes it easier to re-use those proofs.