### PR TITLE
aarch64/vspace: fix error reporting in decode

### DIFF
--- a/src/arch/arm/64/kernel/vspace.c
+++ b/src/arch/arm/64/kernel/vspace.c
@@ -1521,7 +1521,7 @@ static exception_t decodeARMFrameInvocation(word_t invLabel, word_t length,
             if (frame_asid != asid) {
                 userError("ARMPageMap: Attempting to remap a frame that does not belong to the passed address space");
                 current_syscall_error.type = seL4_InvalidCapability;
-                current_syscall_error.invalidArgumentNumber = 1;
+                current_syscall_error.invalidCapNumber = 1;
                 return EXCEPTION_SYSCALL_ERROR;
 
             } else if (cap_frame_cap_get_capFMappedAddress(cap) != vaddr) {


### PR DESCRIPTION
Fixing up a small detail in error reporting: `seL4_InvalidCapability` expects `invalidCapNumber` to be set (currently has `invalidArgumentNumber`, might have been a copy/paste error).