### PR TITLE
github: bump GitHub actions to node20

### DIFF
--- a/.github/workflows/compilation-checks.yml
+++ b/.github/workflows/compilation-checks.yml
@@ -23,7 +23,7 @@ jobs:
         arch: [ARM, ARM_HYP, AARCH64, RISCV64, X64]
         compiler: [gcc, llvm]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: seL4/ci-actions/standalone-kernel@master
       with:
         ARCH: ${{ matrix.arch }}

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: seL4/ci-actions/seL4-manual@master
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: PDF
         path: manual/manual.pdf

--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -50,13 +50,13 @@ jobs:
         AWS_SSH: ${{ secrets.AWS_SSH }}
         GH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
     - name: Upload kernel builds
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: kernel-builds
         path: artifacts/kernel-builds
         if-no-files-found: ignore
     - name: Upload logs
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: logs-${{ matrix.arch }}
         path: logs.tar.xz

--- a/.github/workflows/sel4bench-pr.yml
+++ b/.github/workflows/sel4bench-pr.yml
@@ -49,7 +49,7 @@ jobs:
         xml: ${{ needs.code.outputs.xml }}
         march: ${{ matrix.march }}
     - name: Upload images
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: images-${{ matrix.march }}
         path: '*-images.tar.gz'
@@ -80,7 +80,7 @@ jobs:
     concurrency: sel4bench-hw-pr-${{ github.event.number }}-${{ strategy.job-index }}
     steps:
       - name: Get machine queue
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: seL4/machine_queue
           path: machine_queue
@@ -91,7 +91,7 @@ jobs:
         with:
           platform: ${{ matrix.platform }}
       - name: Download image
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: images-${{ steps.plat.outputs.march }}
       - name: Run
@@ -103,7 +103,7 @@ jobs:
         env:
           HW_SSH: ${{ secrets.HW_SSH }}
       - name: Upload results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           # funky expression below is to work around lack of ternary operator
           name: sel4bench-results-${{ matrix.platform }}${{ matrix.req != '' && format('-{0}', matrix.req) || '' }}

--- a/.github/workflows/sel4test-deploy.yml
+++ b/.github/workflows/sel4test-deploy.yml
@@ -64,7 +64,7 @@ jobs:
         march: ${{ matrix.march }}
         compiler: ${{ matrix.compiler }}
     - name: Upload images
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: images-${{ matrix.march }}-${{ matrix.compiler }}
         path: '*-images.tar.gz'
@@ -91,13 +91,13 @@ jobs:
     concurrency: hw-run-${{ strategy.job-index }}
     steps:
       - name: Get machine queue
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: seL4/machine_queue
           path: machine_queue
           token: ${{ secrets.PRIV_REPO_TOKEN }}
       - name: Download image
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: images-${{ matrix.march }}-${{ matrix.compiler }}
       - name: Run

--- a/.github/workflows/sel4test-hw.yml
+++ b/.github/workflows/sel4test-hw.yml
@@ -44,12 +44,12 @@ jobs:
         compiler: ${{ matrix.compiler }}
         sha: ${{ github.event.pull_request.head.sha }}
     - name: Upload images
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: images-${{ matrix.march }}-${{ matrix.compiler }}
         path: '*-images.tar.gz'
     - name: Upload kernel.elf files
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: kernel.elf-${{ matrix.march }}-${{ matrix.compiler }}
         path: '*-kernel.elf'
@@ -81,13 +81,13 @@ jobs:
       matrix: ${{ fromJson(needs.the_matrix.outputs.matrix) }}
     steps:
       - name: Get machine queue
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: seL4/machine_queue
           path: machine_queue
           token: ${{ secrets.PRIV_REPO_TOKEN }}
       - name: Download image
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: images-${{ matrix.march }}-${{ matrix.compiler }}
       - name: Run

--- a/.github/workflows/xml_lint.yml
+++ b/.github/workflows/xml_lint.yml
@@ -31,7 +31,7 @@ jobs:
       run: sudo apt-get update
     - name: install xmllint
       run: sudo apt-get install libxml2-utils
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: run xmllint
       run: |
         find libsel4 -name "sel4*.xml" | \


### PR DESCRIPTION
GitHub has updated the LTS node.js version from 16 to 20 and is starting to show warnings for node16 actions.