### PR TITLE
mcs: more uniformly handle ready and release queue updates

### DIFF
--- a/include/model/statedata.h
+++ b/include/model/statedata.h
@@ -64,7 +64,7 @@ NODE_STATE_DECLARE(tcb_t, *ksIdleThread);
 NODE_STATE_DECLARE(tcb_t, *ksSchedulerAction);
 
 #ifdef CONFIG_KERNEL_MCS
-NODE_STATE_DECLARE(tcb_t, *ksReleaseHead);
+NODE_STATE_DECLARE(tcb_queue_t, ksReleaseQueue);
 NODE_STATE_DECLARE(ticks_t, ksConsumed);
 NODE_STATE_DECLARE(ticks_t, ksCurTime);
 NODE_STATE_DECLARE(bool_t, ksReprogram);

--- a/include/object/tcb.h
+++ b/include/object/tcb.h
@@ -44,6 +44,57 @@ static inline unsigned int setMR(tcb_t *receiver, word_t *receiveIPCBuffer,
 void tcbSchedEnqueue(tcb_t *tcb);
 void tcbSchedAppend(tcb_t *tcb);
 void tcbSchedDequeue(tcb_t *tcb);
+tcb_queue_t tcb_queue_remove(tcb_queue_t queue, tcb_t *tcb);
+
+static inline bool_t PURE tcb_queue_empty(tcb_queue_t queue)
+{
+    return queue.head == NULL;
+}
+
+static inline tcb_queue_t tcb_queue_prepend(tcb_queue_t queue, tcb_t *tcb)
+{
+    if (tcb_queue_empty(queue)) {
+        queue.end = tcb;
+    } else {
+        tcb->tcbSchedNext = queue.head;
+        queue.head->tcbSchedPrev = tcb;
+    }
+
+    queue.head = tcb;
+
+    return queue;
+}
+
+static inline tcb_queue_t tcb_queue_append(tcb_queue_t queue, tcb_t *tcb)
+{
+    if (tcb_queue_empty(queue)) {
+        queue.head = tcb;
+    } else {
+        tcb->tcbSchedPrev = queue.end;
+        queue.end->tcbSchedNext = tcb;
+    }
+
+    queue.end = tcb;
+
+    return queue;
+}
+
+/* Insert a TCB into a queue immediately before another item in the queue
+   (the queue must initially contain at least two items) */
+static inline void tcb_queue_insert(tcb_t *tcb, tcb_t *after)
+{
+    tcb_t *before;
+    before = after->tcbSchedPrev;
+
+    assert(before != NULL);
+    assert(before != after);
+
+    tcb->tcbSchedPrev = before;
+    tcb->tcbSchedNext = after;
+
+    after->tcbSchedPrev = tcb;
+    before->tcbSchedNext = tcb;
+}
 
 #ifdef CONFIG_DEBUG_BUILD
 void tcbDebugAppend(tcb_t *tcb);

--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -608,7 +608,8 @@ BOOT_CODE void init_core_state(tcb_t *scheduler_action)
     NODE_STATE(ksCurSC) = NODE_STATE(ksCurThread->tcbSchedContext);
     NODE_STATE(ksConsumed) = 0;
     NODE_STATE(ksReprogram) = true;
-    NODE_STATE(ksReleaseHead) = NULL;
+    NODE_STATE(ksReleaseQueue.head) = NULL;
+    NODE_STATE(ksReleaseQueue.end) = NULL;
     NODE_STATE(ksCurTime) = getCurrentTime();
 #endif
 }

--- a/src/kernel/thread.c
+++ b/src/kernel/thread.c
@@ -581,8 +581,8 @@ void setNextInterrupt(void)
         next_interrupt = MIN(next_interrupt, NODE_STATE(ksCurTime) + ksDomainTime);
     }
 
-    if (NODE_STATE(ksReleaseHead) != NULL) {
-        next_interrupt = MIN(refill_head(NODE_STATE(ksReleaseHead)->tcbSchedContext)->rTime, next_interrupt);
+    if (NODE_STATE(ksReleaseQueue.head) != NULL) {
+        next_interrupt = MIN(refill_head(NODE_STATE(ksReleaseQueue.head)->tcbSchedContext)->rTime, next_interrupt);
     }
 
     /* We should never be attempting to schedule anything earlier than ksCurTime */
@@ -681,7 +681,8 @@ void rescheduleRequired(void)
 #ifdef CONFIG_KERNEL_MCS
 void awaken(void)
 {
-    while (unlikely(NODE_STATE(ksReleaseHead) != NULL && refill_ready(NODE_STATE(ksReleaseHead)->tcbSchedContext))) {
+    while (unlikely(NODE_STATE(ksReleaseQueue.head) != NULL
+                    && refill_ready(NODE_STATE(ksReleaseQueue.head)->tcbSchedContext))) {
         tcb_t *awakened = tcbReleaseDequeue();
         /* the currently running thread cannot have just woken up */
         assert(awakened != NODE_STATE(ksCurThread));

--- a/src/model/statedata.c
+++ b/src/model/statedata.c
@@ -27,7 +27,7 @@ UP_STATE_DEFINE(word_t, ksReadyQueuesL2Bitmap[CONFIG_NUM_DOMAINS][L2_BITMAP_SIZE
 compile_assert(ksReadyQueuesL1BitmapBigEnough, (L2_BITMAP_SIZE - 1) <= wordBits)
 #ifdef CONFIG_KERNEL_MCS
 /* Head of the queue of threads waiting for their budget to be replenished */
-UP_STATE_DEFINE(tcb_t *, ksReleaseHead);
+UP_STATE_DEFINE(tcb_queue_t, ksReleaseQueue);
 #endif
 
 /* Current thread TCB pointer */

--- a/src/object/tcb.c
+++ b/src/object/tcb.c
@@ -78,6 +78,39 @@ static inline void removeFromBitmap(word_t cpu, word_t dom, word_t prio)
     }
 }
 
+tcb_queue_t tcb_queue_remove(tcb_queue_t queue, tcb_t *tcb)
+{
+    tcb_t *before;
+    tcb_t *after;
+
+    before = tcb->tcbSchedPrev;
+    after = tcb->tcbSchedNext;
+
+    if (queue.head == tcb && queue.end == tcb) {
+        queue.head = NULL;
+        queue.end = NULL;
+    } else {
+        if (queue.head == tcb) {
+            after->tcbSchedPrev = NULL;
+            tcb->tcbSchedNext = NULL;
+            queue.head = after;
+        } else {
+            if (queue.end == tcb) {
+                before->tcbSchedNext = NULL;
+                tcb->tcbSchedPrev = NULL;
+                queue.end = before;
+            } else {
+                before->tcbSchedNext = after;
+                after->tcbSchedPrev = before;
+                tcb->tcbSchedPrev = NULL;
+                tcb->tcbSchedNext = NULL;
+            }
+        }
+    }
+
+    return queue;
+}
+
 /* Add TCB to the head of a scheduler queue */
 void tcbSchedEnqueue(tcb_t *tcb)
 {
@@ -97,17 +130,11 @@ void tcbSchedEnqueue(tcb_t *tcb)
         idx = ready_queues_index(dom, prio);
         queue = NODE_STATE_ON_CORE(ksReadyQueues[idx], tcb->tcbAffinity);
 
-        if (!queue.end) { /* Empty list */
-            queue.end = tcb;
+        if (tcb_queue_empty(queue)) {
             addToBitmap(SMP_TERNARY(tcb->tcbAffinity, 0), dom, prio);
-        } else {
-            queue.head->tcbSchedPrev = tcb;
         }
-        tcb->tcbSchedPrev = NULL;
-        tcb->tcbSchedNext = queue.head;
-        queue.head = tcb;
 
-        NODE_STATE_ON_CORE(ksReadyQueues[idx], tcb->tcbAffinity) = queue;
+        NODE_STATE_ON_CORE(ksReadyQueues[idx], tcb->tcbAffinity) = tcb_queue_prepend(queue, tcb);
 
         thread_state_ptr_set_tcbQueued(&tcb->tcbState, true);
     }
@@ -132,17 +159,11 @@ void tcbSchedAppend(tcb_t *tcb)
         idx = ready_queues_index(dom, prio);
         queue = NODE_STATE_ON_CORE(ksReadyQueues[idx], tcb->tcbAffinity);
 
-        if (!queue.head) { /* Empty list */
-            queue.head = tcb;
+        if (tcb_queue_empty(queue)) {
             addToBitmap(SMP_TERNARY(tcb->tcbAffinity, 0), dom, prio);
-        } else {
-            queue.end->tcbSchedNext = tcb;
         }
-        tcb->tcbSchedPrev = queue.end;
-        tcb->tcbSchedNext = NULL;
-        queue.end = tcb;
 
-        NODE_STATE_ON_CORE(ksReadyQueues[idx], tcb->tcbAffinity) = queue;
+        NODE_STATE_ON_CORE(ksReadyQueues[idx], tcb->tcbAffinity) = tcb_queue_append(queue, tcb);
 
         thread_state_ptr_set_tcbQueued(&tcb->tcbState, true);
     }
@@ -153,6 +174,7 @@ void tcbSchedDequeue(tcb_t *tcb)
 {
     if (thread_state_get_tcbQueued(tcb->tcbState)) {
         tcb_queue_t queue;
+        tcb_queue_t new_queue;
         dom_t dom;
         prio_t prio;
         word_t idx;
@@ -162,24 +184,15 @@ void tcbSchedDequeue(tcb_t *tcb)
         idx = ready_queues_index(dom, prio);
         queue = NODE_STATE_ON_CORE(ksReadyQueues[idx], tcb->tcbAffinity);
 
-        if (tcb->tcbSchedPrev) {
-            tcb->tcbSchedPrev->tcbSchedNext = tcb->tcbSchedNext;
-        } else {
-            queue.head = tcb->tcbSchedNext;
-            if (likely(!tcb->tcbSchedNext)) {
-                removeFromBitmap(SMP_TERNARY(tcb->tcbAffinity, 0), dom, prio);
-            }
-        }
+        new_queue = tcb_queue_remove(queue, tcb);
 
-        if (tcb->tcbSchedNext) {
-            tcb->tcbSchedNext->tcbSchedPrev = tcb->tcbSchedPrev;
-        } else {
-            queue.end = tcb->tcbSchedPrev;
-        }
-
-        NODE_STATE_ON_CORE(ksReadyQueues[idx], tcb->tcbAffinity) = queue;
+        NODE_STATE_ON_CORE(ksReadyQueues[idx], tcb->tcbAffinity) = new_queue;
 
         thread_state_ptr_set_tcbQueued(&tcb->tcbState, false);
+
+        if (likely(tcb_queue_empty(new_queue))) {
+            removeFromBitmap(SMP_TERNARY(tcb->tcbAffinity, 0), dom, prio);
+        }
     }
 }
 
@@ -257,25 +270,41 @@ tcb_queue_t tcbEPDequeue(tcb_t *tcb, tcb_queue_t queue)
 }
 
 #ifdef CONFIG_KERNEL_MCS
+
 void tcbReleaseRemove(tcb_t *tcb)
 {
     if (likely(thread_state_get_tcbInReleaseQueue(tcb->tcbState))) {
-        if (tcb->tcbSchedPrev) {
-            tcb->tcbSchedPrev->tcbSchedNext = tcb->tcbSchedNext;
-        } else {
-            NODE_STATE_ON_CORE(ksReleaseHead, tcb->tcbAffinity) = tcb->tcbSchedNext;
-            /* the head has changed, we might need to set a new timeout */
+        tcb_queue_t queue = NODE_STATE_ON_CORE(ksReleaseQueue, tcb->tcbAffinity);
+
+        if (queue.head == tcb) {
             NODE_STATE_ON_CORE(ksReprogram, tcb->tcbAffinity) = true;
         }
 
-        if (tcb->tcbSchedNext) {
-            tcb->tcbSchedNext->tcbSchedPrev = tcb->tcbSchedPrev;
-        }
+        NODE_STATE_ON_CORE(ksReleaseQueue, tcb->tcbAffinity) = tcb_queue_remove(queue, tcb);
 
-        tcb->tcbSchedNext = NULL;
-        tcb->tcbSchedPrev = NULL;
         thread_state_ptr_set_tcbInReleaseQueue(&tcb->tcbState, false);
     }
+}
+
+static inline ticks_t PURE tcbReadyTime(tcb_t *tcb)
+{
+    return refill_head(tcb->tcbSchedContext)->rTime;
+}
+
+static inline bool_t PURE time_after(tcb_t *tcb, ticks_t new_time)
+{
+    return tcb != NULL && new_time >= tcbReadyTime(tcb);
+}
+
+static tcb_t *find_time_after(tcb_t *tcb, ticks_t new_time)
+{
+    tcb_t *after = tcb;
+
+    while (time_after(after, new_time)) {
+        after = after->tcbSchedNext;
+    }
+
+    return after;
 }
 
 void tcbReleaseEnqueue(tcb_t *tcb)
@@ -283,54 +312,37 @@ void tcbReleaseEnqueue(tcb_t *tcb)
     assert(thread_state_get_tcbInReleaseQueue(tcb->tcbState) == false);
     assert(thread_state_get_tcbQueued(tcb->tcbState) == false);
 
-    tcb_t *before = NULL;
-    tcb_t *after = NODE_STATE_ON_CORE(ksReleaseHead, tcb->tcbAffinity);
+    ticks_t new_time;
+    tcb_queue_t queue;
 
-    /* find our place in the ordered queue */
-    while (after != NULL &&
-           refill_head(tcb->tcbSchedContext)->rTime >= refill_head(after->tcbSchedContext)->rTime) {
-        before = after;
-        after = after->tcbSchedNext;
-    }
+    new_time = tcbReadyTime(tcb);
+    queue = NODE_STATE_ON_CORE(ksReleaseQueue, tcb->tcbAffinity);
 
-    if (before == NULL) {
-        /* insert at head */
-        NODE_STATE_ON_CORE(ksReleaseHead, tcb->tcbAffinity) = tcb;
+    if (tcb_queue_empty(queue) || new_time < tcbReadyTime(queue.head)) {
+        NODE_STATE_ON_CORE(ksReleaseQueue, tcb->tcbAffinity) = tcb_queue_prepend(queue, tcb);
         NODE_STATE_ON_CORE(ksReprogram, tcb->tcbAffinity) = true;
     } else {
-        before->tcbSchedNext = tcb;
+        if (tcbReadyTime(queue.end) <= new_time) {
+            NODE_STATE_ON_CORE(ksReleaseQueue, tcb->tcbAffinity) = tcb_queue_append(queue, tcb);
+        } else {
+            tcb_t *after;
+            after = find_time_after(queue.head, new_time);
+            tcb_queue_insert(tcb, after);
+        }
     }
-
-    if (after != NULL) {
-        after->tcbSchedPrev = tcb;
-    }
-
-    tcb->tcbSchedNext = after;
-    tcb->tcbSchedPrev = before;
 
     thread_state_ptr_set_tcbInReleaseQueue(&tcb->tcbState, true);
 }
 
 tcb_t *tcbReleaseDequeue(void)
 {
-    assert(NODE_STATE(ksReleaseHead) != NULL);
-    assert(NODE_STATE(ksReleaseHead)->tcbSchedPrev == NULL);
-    SMP_COND_STATEMENT(assert(NODE_STATE(ksReleaseHead)->tcbAffinity == getCurrentCPUIndex()));
+    assert(NODE_STATE(ksReleaseQueue.head) != NULL);
+    assert(NODE_STATE(ksReleaseQueue.head)->tcbSchedPrev == NULL);
+    SMP_COND_STATEMENT(assert(NODE_STATE(ksReleaseQueue.head)->tcbAffinity == getCurrentCPUIndex()));
 
-    tcb_t *detached_head = NODE_STATE(ksReleaseHead);
-    NODE_STATE(ksReleaseHead) = NODE_STATE(ksReleaseHead)->tcbSchedNext;
+    tcb_t *detached_head = NODE_STATE(ksReleaseQueue.head);
 
-    if (NODE_STATE(ksReleaseHead)) {
-        NODE_STATE(ksReleaseHead)->tcbSchedPrev = NULL;
-    }
-
-    if (detached_head->tcbSchedNext) {
-        detached_head->tcbSchedNext->tcbSchedPrev = NULL;
-        detached_head->tcbSchedNext = NULL;
-    }
-
-    thread_state_ptr_set_tcbInReleaseQueue(&detached_head->tcbState, false);
-    NODE_STATE(ksReprogram) = true;
+    tcbReleaseRemove(detached_head);
 
     return detached_head;
 }


### PR DESCRIPTION
This introduces library functions for updating the linked lists which use the `tcbSchedNext` and `tcbSchedPrev` pointers of a TCB, and uses these to perform the updates to the ready queues and the release queue.

In order to accommodate this, `ksReleaseQueue` is now of type `tcb_queue_t`.