### PR TITLE
CI: cancel older concurrent PR runs

### DIFF
--- a/.github/workflows/sel4bench-pr.yml
+++ b/.github/workflows/sel4bench-pr.yml
@@ -4,7 +4,7 @@
 
 # Build and run sel4bench on pull requests, on label request
 
-name: seL4Bench PR
+name: seL4Bench-HW
 
 on:
   pull_request_target:
@@ -13,6 +13,19 @@ on:
 # downgrade permissions to read-only as you would have in a standard PR action
 permissions:
   contents: read
+
+# To reduce the load (especiually on the machine queue) we cancel any older runs
+# of this workflow for the current PR. Such runs exist, if there were new pushes
+# to the PR's branch without waiting for the workflow to finish. As a side
+# effect, pushing new commits now becomes a convenient way to cancel all the
+# older runs, e.g. if they are stuck and would only be stopped by the timeout
+# eventually.
+# Note that we could do the concurrency handling at a finer level, and only wrap
+# the actual run on the hardware. But there seems not much gain in letting the
+# older builds run, as these are usually obsolete with new pushes also.
+concurrency:
+  group: ${{ github.workflow }}-pr-${{ github.event.number }}
+  cancel-in-progress: true
 
 jobs:
   code:

--- a/.github/workflows/sel4test-hw.yml
+++ b/.github/workflows/sel4test-hw.yml
@@ -6,7 +6,7 @@
 #
 # See sel4test-hw/builds.yml in the repo seL4/ci-actions for configs.
 
-name: seL4Test HW
+name: seL4Test-HW
 
 on:
   # needs PR target for secrets access; guard by requiring label
@@ -16,6 +16,19 @@ on:
 # downgrade permissions to read-only as you would have in a standard PR action
 permissions:
   contents: read
+
+# To reduce the load (especiually on the machine queue) we cancel any older runs
+# of this workflow for the current PR. Such runs exist, if there were new pushes
+# to the PR's branch without waiting for the workflow to finish. As a side
+# effect, pushing new commits now becomes a convenient way to cancel all the
+# older runs, e.g. if they are stuck and would only be stopped by the timeout
+# eventually.
+# Note that we could do the concurrency handling at a finer level, and only wrap
+# the actual run on the hardware. But there seems not much gain in letting the
+# older builds run, as these are usually obsolete with new pushes also.
+concurrency:
+  group: ${{ github.workflow }}-pr-${{ github.event.number }}
+  cancel-in-progress: true
 
 jobs:
   hw-build:

--- a/.github/workflows/sel4test-sim.yml
+++ b/.github/workflows/sel4test-sim.yml
@@ -6,7 +6,7 @@
 #
 # See sel4test-sim/builds.yml in the repo seL4/ci-actions for configs.
 
-name: seL4Test Sim
+name: seL4Test-Sim
 
 on:
   pull_request:
@@ -14,6 +14,15 @@ on:
       - 'manual/**'
       - 'LICENSES/**'
       - '*.md'
+
+# To reduce the load we cancel any older runs of this workflow for the current
+# PR. Such runs exist, if there were new pushes to the PR's branch without
+# waiting for the workflow to finish. As a side effect, pushing new commits now
+# becomes a convenient way to cancel all the older runs, e.g. if they are stuck
+# and would only be stopped by the timeout eventually.
+concurrency:
+  group: ${{ github.workflow }}-pr-${{ github.event.number }}
+  cancel-in-progress: true
 
 jobs:
   sim:


### PR DESCRIPTION
This also removes the space in the workflow name to ensure there are no side effects when using it as an identifier.

This applies what has been done in https://github.com/seL4/camkes-vm-examples/pull/69