### PR TITLE
ARM: Allow VMPIDR_EL2 reg to be set on unicore

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -83,6 +83,12 @@ Upcoming release: BREAKING
   optimization.
 * Added SMC Capability (smc_cap) and SMC forwarding for aarch64 platforms. See
   [RFC-9](https://sel4.atlassian.net/browse/RFC-9).
+* Arm+Hyp: Enabled access to seL4_VCPUReg_VMPIDR and seL4_VCPUReg_VMPIDR_EL2 for all hyp configurations.
+  Previously this register was only accessible for SMP kernel configurations. Non-SMP configurations can still require
+  access when wanting to control the value of MPIDR that the guest reads.
+  Note that the initial value for new seL4_ARM_VCPUs for this register is 0 which isn't a legal value for MPIDR_EL1 on
+  AArch64. It may be necessary for the register to be explicitly initialized by user level before launching a thread
+  associated with the new seL4_ARM_VCPU.
 
 ## Upgrade Notes
 

--- a/include/arch/arm/arch/32/mode/machine.h
+++ b/include/arch/arm/arch/32/mode/machine.h
@@ -59,6 +59,7 @@
 #define ID_PFR1    " p15, 0,  %0,  c0,  c1, 1" /* 32-bit RO CPU feature register */
 #define CPACR      " p15, 0,  %0,  c1,  c0, 2" /* 32-bit Architectural Feature Access Control Register */
 #define VMPIDR     " p15, 4,  %0,  c0,  c0, 5" /* 32-bit RW Virtualization Multiprocessor ID Register */
+#define MPIDR      " p15, 0,  %0, c0,  c0, 5"
 
 /* Use Hypervisor Physical timer */
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT

--- a/include/arch/arm/arch/object/vcpu.h
+++ b/include/arch/arm/arch/object/vcpu.h
@@ -78,11 +78,13 @@ struct vcpu {
     word_t regs[seL4_VCPUReg_Num];
     bool_t vppi_masked[n_VPPIEventIRQ];
 #ifdef CONFIG_VTIMER_UPDATE_VOFFSET
-    /* vTimer is 8-bytes wide and has same alignment requirement.
-     * The struct will remain packed on 32-bit platforms when n_VPPIEventIRQ
-     * is odd, but were it to become even, an extra word of padding will be
-     * necessary.
-     * */
+    word_t vcpu_padding;
+    /* vTimer is 8-bytes wide and has the same 8-byte alignment requirement.
+     * If the sum of n_VPPIEventIRQ and seL4_VCPUReg_Num is even, we do not need
+     * extra padding. If the sum is odd we do. It currently is odd, so the extra
+     * padding above is necessary for the struct to remain packed on 32 bit
+     * platforms.
+     */
     struct vTimer virtTimer;
 #endif
 };

--- a/include/arch/arm/armv/armv7-a/armv/vcpu.h
+++ b/include/arch/arm/armv/armv7-a/armv/vcpu.h
@@ -296,7 +296,6 @@ static inline void set_cntv_ctl(word_t val)
     MCR(CNTV_CTL, val);
 }
 
-#ifdef ENABLE_SMP_SUPPORT
 static inline word_t get_vmpidr(void)
 {
     word_t ret = 0;
@@ -308,7 +307,6 @@ static inline void set_vmpidr(word_t val)
 {
     MCR(VMPIDR, val);
 }
-#endif
 
 /** MODIFIES: phantom_machine_state */
 /** DONT_TRANSLATE */
@@ -486,10 +484,8 @@ static word_t vcpu_hw_read_reg(word_t reg_index)
         return get_cntv_off_high();
     case seL4_VCPUReg_CNTVOFFlow:
         return get_cntv_off_low();
-#ifdef ENABLE_SMP_SUPPORT
     case seL4_VCPUReg_VMPIDR:
         return get_vmpidr();
-#endif /* ENABLE_SMP_SUPPORT */
     default:
         fail("ARM/HYP: Invalid register index");
     }

--- a/include/arch/arm/armv/armv8-a/64/armv/vcpu.h
+++ b/include/arch/arm/armv/armv8-a/64/armv/vcpu.h
@@ -123,6 +123,7 @@
 #define REG_HCR_EL2         "hcr_el2"
 #define REG_VTCR_EL2        "vtcr_el2"
 #define REG_VMPIDR_EL2      "vmpidr_el2"
+#define REG_MPIDR_EL1       "mpidr_el1"
 #define REG_ID_AA64MMFR0_EL1 "id_aa64mmfr0_el1"
 
 /* for EL1 SCTLR */
@@ -481,10 +482,8 @@ static word_t vcpu_hw_read_reg(word_t reg_index)
         return readCNTVOFF_EL2();
     case seL4_VCPUReg_CNTKCTL_EL1:
         return readCNTKCTL_EL1();
-#ifdef ENABLE_SMP_SUPPORT
     case seL4_VCPUReg_VMPIDR_EL2:
         return readVMPIDR_EL2();
-#endif /* ENABLE_SMP_SUPPORT */
     default:
         fail("ARM/HYP: Invalid register index");
     }
@@ -564,11 +563,9 @@ static void vcpu_hw_write_reg(word_t reg_index, word_t reg)
     case seL4_VCPUReg_CNTKCTL_EL1:
         writeCNTKCTL_EL1(reg);
         break;
-#ifdef ENABLE_SMP_SUPPORT
     case seL4_VCPUReg_VMPIDR_EL2:
         writeVMPIDR_EL2(reg);
         break;
-#endif /* ENABLE_SMP_SUPPORT */
     default:
         fail("ARM/HYP: Invalid register index");
     }

--- a/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/constants.h
@@ -104,9 +104,7 @@ typedef enum {
     seL4_VCPUReg_R10fiq,
     seL4_VCPUReg_R11fiq,
     seL4_VCPUReg_R12fiq,
-#if  CONFIG_MAX_NUM_NODES > 1
     seL4_VCPUReg_VMPIDR,
-#endif /* CONFIG_MAX_NUM_NODES > 1 */
     seL4_VCPUReg_SPSRsvc,
     seL4_VCPUReg_SPSRabt,
     seL4_VCPUReg_SPSRund,

--- a/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
@@ -97,10 +97,8 @@ typedef enum {
     /* thread pointer/ID registers EL0/EL1 */
     seL4_VCPUReg_TPIDR_EL1,
 
-#if CONFIG_MAX_NUM_NODES > 1
     /* Virtualisation Multiprocessor ID Register */
     seL4_VCPUReg_VMPIDR_EL2,
-#endif /* CONFIG_MAX_NUM_NODES > 1 */
 
     /* general registers x0 to x30 have been saved by traps.S */
     seL4_VCPUReg_SP_EL1,


### PR DESCRIPTION
Currently the seL4_VCPUReg enum only defines the seL4_VCPUReg_VMPIDR_EL2 register when the kernel is configured for SMP. This register should be available for unicore systems too as otherwise a user level VMM is not able to control the value of MPIDR_EL1 that the guest VM reads.

Resolves https://github.com/seL4/seL4/issues/1015