### PR TITLE
Fix QEMU/arm CPU selection

### DIFF
--- a/src/plat/qemu-arm-virt/config.cmake
+++ b/src/plat/qemu-arm-virt/config.cmake
@@ -12,7 +12,10 @@ declare_platform(qemu-arm-virt KernelPlatformQEMUArmVirt PLAT_QEMU_ARM_VIRT Kern
 set(qemu_user_top 0xa0000000)
 
 macro(setup_qemu_armv7)
-    cmake_parse_arguments(ARMV7_OPTIONS "ve" "" "")
+    cmake_parse_arguments(ARMV7_OPTIONS "ve" "" "" ${ARGN})
+    if(ARMV7_OPTIONS_UNPARSED_ARGUMENTS)
+        message(FATAL_ERROR "Unknown arguments: ${ARMV7_OPTIONS_UNPARSED_ARGUMENTS}")
+    endif()
     set(QEMU_ARCH "arm")
     set(KernelArchArmV7a ON)
     if(ARMV7_OPTIONS_ve)

--- a/src/plat/qemu-arm-virt/config.cmake
+++ b/src/plat/qemu-arm-virt/config.cmake
@@ -38,8 +38,23 @@ endmacro()
 if(KernelPlatformQEMUArmVirt)
 
     if(NOT ARM_CPU)
-        message(STATUS "ARM_CPU not set, defaulting to cortex-a53")
-        set(ARM_CPU "cortex-a53")
+        # Our default QEMU configuration is AARCH64/Cortex-a53. If
+        # KernelSel4Arch is set to aarch32/arm_hyp, the default is Cortex-a15.
+        # If both ARM_CPU and KernelSel4Arch are set, conflicting values will be
+        # detected eventually. Note that the KernelSel4Archxxx variables are not
+        # set up here, because declare_seL4_arch() has not been called yet.
+        set(
+            arch_cpu_mapping # element format: "KernelSel4Arch:ARM_CPU"
+            ":cortex-a53" # used if KernelSel4Arch is empty or not set
+            "aarch64:cortex-a53"
+            "arm_hyp:cortex-a15"
+            "aarch32:cortex-a15"
+        )
+        if(NOT ";${arch_cpu_mapping};" MATCHES ";${KernelSel4Arch}:([^;]*);")
+            message(FATAL_ERROR "unsupported KernelSel4Arch: '${KernelSel4Arch}'")
+        endif()
+        set(ARM_CPU "${CMAKE_MATCH_1}")
+        message(STATUS "ARM_CPU not set, defaulting to ${ARM_CPU}")
     endif()
 
     if("${ARM_CPU}" STREQUAL "cortex-a7")


### PR DESCRIPTION
- CMake, QEMU/arm: fix parser usage, so the "ve" extension is enabled
- QEMU/arm: select CPU from architecture, so aarch32 defaults to Cortex-A15 and aarch64 to Cortex-A53

Fixed the issue from https://github.com/seL4/seL4/pull/824#issuecomment-1921221807

Since we are not using QEMU for ARMv7 virtualzation, these issues have not shown up. See also https://github.com/seL4/camkes-vm-examples/issues/73