### PR TITLE
gicv3: Use split EOI mode

### DIFF
--- a/include/arch/arm/arch/smp/ipi.h
+++ b/include/arch/arm/arch/smp/ipi.h
@@ -16,6 +16,9 @@ typedef enum {
     IpiRemoteCall_InvalidateTranslationAll,
     IpiRemoteCall_switchFpuOwner,
     IpiRemoteCall_MaskPrivateInterrupt,
+#ifdef CONFIG_ARM_GIC_V3_SUPPORT
+    IpiRemoteCall_DeactivatePrivateInterrupt,
+#endif
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
     IpiRemoteCall_VCPUInjectInterrupt,
 #endif

--- a/include/arch/arm/arch/smp/ipi_inline.h
+++ b/include/arch/arm/arch/smp/ipi_inline.h
@@ -41,5 +41,12 @@ static inline void doRemoteMaskPrivateInterrupt(word_t cpu, word_t disable, word
 {
     doRemoteOp2Arg(IpiRemoteCall_MaskPrivateInterrupt, disable, irq, cpu);
 }
+
+#ifdef CONFIG_ARM_GIC_V3_SUPPORT
+static inline void doRemoteDeactivatePrivateInterrupt(word_t cpu, word_t irq)
+{
+    doRemoteOp1Arg(IpiRemoteCall_DeactivatePrivateInterrupt, irq, cpu);
+}
+#endif /* CONFIG_ARM_GIC_V3_SUPPORT */
 #endif /* ENABLE_SMP_SUPPORT */
 

--- a/include/machine/interrupt.h
+++ b/include/machine/interrupt.h
@@ -98,6 +98,20 @@ static inline void maskInterrupt(bool_t disable, irq_t irq);
 static inline void ackInterrupt(irq_t irq);
 
 /**
+ * Deactivates the interrupt
+ *
+ * When the interrupt controller supports delegating the interrupt to a lower
+ * privilege level, this function can be called to signal the completion of
+ * interrupt processing so that the interrupt state machine can be moved out of
+ * the active state.
+ *
+ * Currently only supported by gicv3 driver.
+ *
+ * @param[in]  irq   The interrupt request
+ */
+static inline void deactivateInterrupt(irq_t irq);
+
+/**
  * Called when getActiveIRQ returns irqInvalid while the kernel is handling an
  * interrupt entry. An implementation is not required to do anything here, but
  * can report the spurious IRQ or try prevent it from reoccuring.
@@ -116,3 +130,7 @@ static inline void handleSpuriousIRQ(void);
  */
 static inline void handleReservedIRQ(irq_t irq);
 
+#ifndef CONFIG_ARM_GIC_V3_SUPPORT
+
+static inline void deactivateInterrupt(irq_t irq) {}
+#endif

--- a/src/arch/arm/machine/gic_v3.c
+++ b/src/arch/arm/machine/gic_v3.c
@@ -276,9 +276,9 @@ BOOT_CODE static void cpu_iface_init(void)
     /* Set priority mask register: ICC_PMR_EL1 */
     SYSTEM_WRITE_WORD(ICC_PMR_EL1, DEFAULT_PMR_VALUE);
 
-    /* EOI drops priority and deactivates the interrupt: ICC_CTLR_EL1 */
+    /* EOI drops priority of the interrupt, deactivation happens separately: ICC_CTLR_EL1 */
     SYSTEM_READ_WORD(ICC_CTLR_EL1, icc_ctlr);
-    icc_ctlr &= ~GICC_CTLR_EL1_EOImode_drop;
+    icc_ctlr |= GICC_CTLR_EL1_EOImode_drop;
     SYSTEM_WRITE_WORD(ICC_CTLR_EL1, icc_ctlr);
 
     /* Enable Group1 interrupts: ICC_IGRPEN1_EL1 */

--- a/src/arch/arm/smp/ipi.c
+++ b/src/arch/arm/smp/ipi.c
@@ -43,6 +43,12 @@ void handleRemoteCall(IpiRemoteCall_t call, word_t arg0, word_t arg1, word_t arg
             maskInterrupt(arg0, IDX_TO_IRQT(arg1));
             break;
 
+#ifdef CONFIG_ARM_GIC_V3_SUPPORT
+        case IpiRemoteCall_DeactivatePrivateInterrupt:
+            deactivateInterrupt(IDX_TO_IRQT(arg1));
+            break;
+#endif
+
 #if defined CONFIG_ARM_HYPERVISOR_SUPPORT && defined ENABLE_SMP_SUPPORT
         case IpiRemoteCall_VCPUInjectInterrupt: {
             virq_t virq;

--- a/src/object/interrupt.c
+++ b/src/object/interrupt.c
@@ -145,7 +145,14 @@ void invokeIRQHandler_AckIRQ(irq_t irq)
 
 #if defined ENABLE_SMP_SUPPORT && defined CONFIG_ARCH_ARM
     if (IRQ_IS_PPI(irq) && IRQT_TO_CORE(irq) != getCurrentCPUIndex()) {
+#ifdef CONFIG_ARM_GIC_V3_SUPPORT
+        /* According to the GICv3 spec, SPIs can be deactivated from any PE,
+         * but SGIs and PPIs must be deactivated from their target PE.
+         */
+        doRemoteDeactivatePrivateInterrupt(IRQT_TO_CORE(irq), IRQT_TO_IDX(irq));
+#else /* CONFIG_ARM_GIC_V3_SUPPORT */
         doRemoteMaskPrivateInterrupt(IRQT_TO_CORE(irq), false, IRQT_TO_IDX(irq));
+#endif /* CONFIG_ARM_GIC_V3_SUPPORT */
         return;
     }
 #endif

--- a/src/object/interrupt.c
+++ b/src/object/interrupt.c
@@ -149,8 +149,12 @@ void invokeIRQHandler_AckIRQ(irq_t irq)
         return;
     }
 #endif
-    maskInterrupt(false, irq);
-#endif
+    if (config_set(CONFIG_ARM_GIC_V3_SUPPORT)) {
+        deactivateInterrupt(irq);
+    } else {
+        maskInterrupt(false, irq);
+    }
+#endif /* CONFIG_ARCH_RISCV */
 }
 
 void invokeIRQHandler_SetIRQHandler(irq_t irq, cap_t cap, cte_t *slot)
@@ -218,8 +222,11 @@ void handleInterrupt(irq_t irq)
 #endif
         }
 #ifndef CONFIG_ARCH_RISCV
-        maskInterrupt(true, irq);
+        if (!config_set(CONFIG_ARM_GIC_V3_SUPPORT)) {
+            maskInterrupt(true, irq);
+        }
 #endif
+
         break;
     }
 


### PR DESCRIPTION
Separate priority drop from deactivation so that when the kernel
delegates interrupts to userlevel, they can be left in the active state
until user level performs the ack invocation which deactivates them.
This is more efficient than doing a disable and enable operation
for each handled interrupt as it is core local and doesn't require
sending operations to the GIC distributor.
