### PR TITLE
github: disambiguate proof artifact upload

### DIFF
--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -52,11 +52,11 @@ jobs:
     - name: Upload kernel builds
       uses: actions/upload-artifact@v4
       with:
-        name: kernel-builds
+        name: kernel-builds-${{ matrix.arch }}-${{ matrix.features }}
         path: artifacts/kernel-builds
         if-no-files-found: ignore
     - name: Upload logs
       uses: actions/upload-artifact@v4
       with:
-        name: logs-${{ matrix.arch }}
+        name: logs-${{ matrix.arch }}-${{ matrix.features }}
         path: logs.tar.xz


### PR DESCRIPTION
Proof artifact upload had name clashes for different artifacts from the same job that previously would overwrite each other and with v4 actions now error. This commit disambiguates the names.