### PR TITLE
CI: remove obsolete concurrency setup in job

### DIFF
--- a/.github/workflows/sel4bench-pr.yml
+++ b/.github/workflows/sel4bench-pr.yml
@@ -89,8 +89,6 @@ jobs:
             req: skylake
           - platform: pc99
             req: haswell3
-    # do run concurrently in the build matrix, but only one overall run per PR at a time
-    concurrency: sel4bench-hw-pr-${{ github.event.number }}-${{ strategy.job-index }}
     steps:
       - name: Get machine queue
         uses: actions/checkout@v4


### PR DESCRIPTION
The concurrency is set for the whole workflow already, just forgot to remove these line in https://github.com/seL4/seL4/pull/1178