### PR TITLE
CI: cancel older concurrent PR runs

### DIFF
--- a/.github/workflows/compilation-checks.yml
+++ b/.github/workflows/compilation-checks.yml
@@ -12,6 +12,13 @@ on:
       - master
   pull_request:
 
+# To reduce the load we cancel any older runs of this workflow for the current
+# PR. For deployment to the master branch, the workflow will run on each push,
+# and the `run_id` parameter will prevent cancellation.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || format('run-{0}', github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   standalone_kernel:
     name: kernel


### PR DESCRIPTION
It turned out to be quite convenient on my forks, that pushes to PRs kill any older runs, so this PR enables this feature for the other workflows also. Even if they are not running very long at their core, many of them do pull docker images or do other setup stepts. This can cause them ending up in a queue and effectively block runners unnecessarily.
In my tests the concurrency check worked fine to just kill runs from PRs, but not the pushes to master for deployment. Picking a group name with a really unique ID is a bit of a hack, but unfortunately there seems no explicit concurrency property for conditional usage.
Note that I renamed the workflow "C Parser" to "C-Parser" to avoid spaces in the concurrency group name, as it uses `github.workflow`. I'm not sure if this is really necessary, but this has been done in the other workflows also to play safe. An alternative way could be using `github.workflow_sha` instead everywhere, so the workflow names can be anything.