### PR TITLE
vcpu: guard against NULL ptr dereference

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -26,6 +26,24 @@ Upcoming release: BREAKING
 
 ## Changes
 
+### Security-relevant Changes
+
+* Fixed a kernel-crashing NULL pointer dereference when injecting an IRQ for a non-associated VCPU on SMP
+  configurations. This can be triggered from user-level by any thread that has access to or can create non-associated
+  VCPU objects. While HYP+SMP is not a verified configuration and is not thoroughly tested, it is generally assumed to
+  be working. If you are using this configuration, it is strongly recommended to upgrade.
+
+  * Affected configurations: only unverified HYP+SMP configurations on Arm platforms are affected.
+  * Affected versions: seL4 versions 12.0.0 and 12.1.0.
+  * Exploitability: Any thread that can create or that has access to an unassociated VCPU can cause the crash. In static
+    systems, only the system initialiser thread can create VCPUs and the standard capDL system initialiser will not
+    trigger the issue. VMMs could have the authority to dissociate an existing VCPU from a TCB if they have both
+    capabilities. That is, a malicious VMM could cause a crash, but generally VMMs are trusted, albeit not verified
+    code. Guest VMs generally do not have sufficient authority to exploit this vulnerability.
+  * Severity: Critical. This crashes the entire system.
+
+### Other Changes
+
 * Added support for the ARM Cortex A55
 * Added support for the ODroid C4
 * Added support for the Avnet MaaXBoard

--- a/src/arch/arm/object/vcpu.c
+++ b/src/arch/arm/object/vcpu.c
@@ -378,8 +378,10 @@ exception_t invokeVCPUInjectIRQ(vcpu_t *vcpu, unsigned long index, virq_t virq)
     if (likely(ARCH_NODE_STATE(armHSCurVCPU) == vcpu)) {
         set_gic_vcpu_ctrl_lr(index, virq);
 #ifdef ENABLE_SMP_SUPPORT
-    } else if (vcpu->vcpuTCB->tcbAffinity != getCurrentCPUIndex()) {
-        doRemoteOp3Arg(IpiRemoteCall_VCPUInjectInterrupt, (word_t)vcpu, index, virq.words[0],      vcpu->vcpuTCB->tcbAffinity);
+    } else if (vcpu->vcpuTCB != NULL && vcpu->vcpuTCB->tcbAffinity != getCurrentCPUIndex()) {
+        doRemoteOp3Arg(IpiRemoteCall_VCPUInjectInterrupt,
+                       (word_t)vcpu, index, virq.words[0],
+                       vcpu->vcpuTCB->tcbAffinity);
 #endif /* CONFIG_ENABLE_SMP */
     } else {
         vcpu->vgic.lr[index] = virq;


### PR DESCRIPTION
The vcpu is not guaranteed to be associated with a TCB at this point, so access to vcpuTCB must be guarded.

Fixes #1199

Test with: https://github.com/seL4/sel4test/pull/114

- [x]  update CHANGES