### PR TITLE
Fix Odroid-C4 MAX_IRQ setting

### DIFF
--- a/src/plat/odroidc4/config.cmake
+++ b/src/plat/odroidc4/config.cmake
@@ -15,9 +15,10 @@ if(KernelPlatformOdroidc4)
     config_set(KernelARMPlatform ARM_PLAT odroidc4)
     set(KernelArmMachFeatureModifiers "+crc" CACHE INTERNAL "")
     list(APPEND KernelDTSList "tools/dts/odroidc4.dts" "src/plat/odroidc4/overlay-odroidc4.dts")
+    # MAX_IRQ is based on the section 7.10.2 of the S905X3 SoC manual
     declare_default_headers(
         TIMER_FREQUENCY 24000000
-        MAX_IRQ 250
+        MAX_IRQ 255
         NUM_PPI 32
         TIMER drivers/timer/arm_generic.h
         INTERRUPT_CONTROLLER arch/machine/gic_v2.h


### PR DESCRIPTION
The S905X3 manual (Revision 02) specifies the highest IRQ to be 255 in section 7.10.2 of the manual.

This issue was encountered when trying to use the PCIe device on the platform