### PR TITLE
Fix DDR region for Odroid-C4

### DIFF
--- a/tools/dts/odroidc4.dts
+++ b/tools/dts/odroidc4.dts
@@ -2945,7 +2945,7 @@
 
 	memory@0 {
 		device_type = "memory";
-		reg = <0x00 0x00 0x00 0x40000000>;
+		reg = <0x00 0x00 0x00 0xf5800000>;
 	};
 
 	emmc-pwrseq {


### PR DESCRIPTION
The Odroid-C4 is supposed to have 4GB of DDR memory.

According to the SoC manual (S905X3 Revision 02) the DDR region goes from 0x0 to 0xF57FFFFF in Table 7-1.