### PR TITLE
RISC-V: make trap_entry a function 

### DIFF
--- a/include/arch/riscv/arch/kernel/traps.h
+++ b/include/arch/riscv/arch/kernel/traps.h
@@ -43,4 +43,3 @@ void restore_user_context(void)
 VISIBLE NORETURN SECTION(".text.traps");
 
 void handle_exception(void);
-

--- a/include/arch/riscv/arch/kernel/traps.h
+++ b/include/arch/riscv/arch/kernel/traps.h
@@ -20,6 +20,9 @@ static inline void arch_c_exit_hook(void)
     /* Nothing architecture specific to be done. */
 }
 
+/* ASM trap entry. */
+void NORETURN trap_entry(void);
+
 #ifdef CONFIG_KERNEL_MCS
 void c_handle_fastpath_reply_recv(word_t cptr, word_t msgInfo, word_t reply)
 #else

--- a/src/arch/riscv/kernel/boot.c
+++ b/src/arch/riscv/kernel/boot.c
@@ -14,6 +14,7 @@
 #include <object/interrupt.h>
 #include <arch/machine.h>
 #include <arch/kernel/boot.h>
+#include <arch/kernel/traps.h>
 #include <arch/kernel/vspace.h>
 #include <arch/benchmark.h>
 #include <linker.h>
@@ -110,9 +111,6 @@ BOOT_CODE static void init_irqs(cap_t root_cnode_cap)
     /* provide the IRQ control cap */
     write_slot(SLOT_PTR(pptr_of_cap(root_cnode_cap), seL4_CapIRQControl), cap_irq_control_cap_new());
 }
-
-/* ASM symbol for the CPU initialisation trap. */
-extern char trap_entry[1];
 
 /* This and only this function initialises the CPU. It does NOT initialise any kernel state. */
 

--- a/src/arch/riscv/traps.S
+++ b/src/arch/riscv/traps.S
@@ -14,16 +14,14 @@
 
 #define REGBYTES (CONFIG_WORD_SIZE / 8)
 
-.section .text.traps, "ax"
-
-.global trap_entry
 .extern c_handle_syscall
 .extern c_handle_fastpath_reply_recv
 .extern c_handle_fastpath_call
 .extern c_handle_interrupt
 .extern c_handle_exception
 
-trap_entry:
+.section .text.traps, "ax"
+BEGIN_FUNC(trap_entry)
 
 #ifdef ENABLE_SMP_SUPPORT
 /* The sscratch contains the stack for the current core */
@@ -145,3 +143,5 @@ interrupt:
   /* Save NextIP */
   STORE   x1, (34*REGBYTES)(t0)
   j c_handle_interrupt
+
+END_FUNC(trap_entry)


### PR DESCRIPTION
Making this a function makes debugging a bit nicer, as we have a nice function symbol available then