### PR TITLE
riscv: add wrapper read_sscratch()

### DIFF
--- a/include/arch/riscv/arch/fastpath/fastpath.h
+++ b/include/arch/riscv/arch/fastpath/fastpath.h
@@ -101,8 +101,7 @@ static inline void NORETURN FORCE_INLINE fastpath_restore(word_t badge, word_t m
     word_t cur_thread_regs = (word_t)cur_thread->tcbArch.tcbContext.registers;
 
 #ifdef ENABLE_SMP_SUPPORT
-    word_t sp;
-    asm volatile("csrr %0, sscratch" : "=r"(sp));
+    word_t sp = read_sscratch();
     sp -= sizeof(word_t);
     *((word_t *)sp) = cur_thread_regs;
 #endif

--- a/include/arch/riscv/arch/machine.h
+++ b/include/arch/riscv/arch/machine.h
@@ -221,6 +221,13 @@ static inline void clear_sie_mask(word_t mask_low)
     asm volatile("csrrc %0, sie, %1" : "=r"(temp) : "rK"(mask_low));
 }
 
+static inline word_t read_sscratch(void)
+{
+    word_t temp;
+    asm volatile("csrr %0, sscratch" : "=r"(temp));
+    return temp;
+}
+
 #ifdef CONFIG_HAVE_FPU
 static inline uint32_t read_fcsr(void)
 {

--- a/include/arch/riscv/arch/model/smp.h
+++ b/include/arch/riscv/arch/model/smp.h
@@ -51,8 +51,7 @@ static inline bool_t try_arch_atomic_exchange_rlx(void *ptr, void *new_val, void
 
 static inline CONST cpu_id_t getCurrentCPUIndex(void)
 {
-    word_t sp;
-    asm volatile("csrr %0, sscratch" : "=r"(sp));
+    word_t sp = read_sscratch();
     sp -= (word_t)kernel_stack_alloc;
     sp -= 8;
     return (sp >> CONFIG_KERNEL_STACK_BITS);

--- a/src/arch/riscv/c_traps.c
+++ b/src/arch/riscv/c_traps.c
@@ -26,8 +26,7 @@ void VISIBLE NORETURN restore_user_context(void)
     NODE_UNLOCK_IF_HELD;
 
 #ifdef ENABLE_SMP_SUPPORT
-    word_t sp;
-    asm volatile("csrr %0, sscratch" : "=r"(sp));
+    word_t sp = read_sscratch();
     sp -= sizeof(word_t);
     *((word_t *)sp) = cur_thread_reg;
 #endif


### PR DESCRIPTION
hide assembly code behind a wrapper function