### PR TITLE
trivial CMake cleanup

### DIFF
--- a/tools/helpers.cmake
+++ b/tools/helpers.cmake
@@ -297,7 +297,6 @@ endfunction(config_option)
 # configuration headers.
 macro(config_set optionname configname value)
     set(${optionname} "${value}" CACHE INTERNAL "" FORCE)
-    set(c_define "CONFIG_${configname}")
     if("${value}" STREQUAL "OFF")
         cfg_str_add_disabled(configure_string ${configname})
     else()


### PR DESCRIPTION
- remove obsolete variable. Seems it's a merge artifact that should never have been in commit ad4ea6cd, and commit c642a398 moved handling to a python script anyway.
- add missing bracket in comment.