### PR TITLE
RISC-V SMP: Fix Compile Error

### DIFF
--- a/include/arch/riscv/arch/model/smp.h
+++ b/include/arch/riscv/arch/model/smp.h
@@ -51,7 +51,8 @@ static inline bool_t try_arch_atomic_exchange_rlx(void *ptr, void *new_val, void
 
 static inline CONST cpu_id_t getCurrentCPUIndex(void)
 {
-    word_t sp = read_sscratch();
+    word_t sp;
+    asm volatile("csrr %0, sscratch" : "=r"(sp));
     sp -= (word_t)kernel_stack_alloc;
     sp -= 8;
     return (sp >> CONFIG_KERNEL_STACK_BITS);


### PR DESCRIPTION
Partially revert commit https://github.com/seL4/seL4/commit/70d1a5f792fbe1ae59a79dd5dcc413cf69447aa0.

Can't include arch/machine.h because that will cause a circular include dependency.