### PR TITLE
IRQ Fastpath

### DIFF
--- a/config.cmake
+++ b/config.cmake
@@ -309,6 +309,13 @@ config_option(
     DEFAULT_DISABLED OFF
 )
 
+config_option(
+    KernelIRQFastpath IRQ_FASTPATH "Enable IRQ fastpath"
+    DEFAULT OFF
+    DEPENDS "KernelIsMCS; KernelFastpath; KernelSel4ArchAarch64; NOT KernelVerificationBuild"
+    DEFAULT_DISABLED OFF
+)
+
 find_file(
     KernelDomainSchedule default_domain.c
     PATHS src/config

--- a/include/arch/arm/arch/fastpath/fastpath.h
+++ b/include/arch/arm/arch/fastpath/fastpath.h
@@ -33,6 +33,14 @@ void vm_fault_slowpath(vm_fault_type_t type)
 NORETURN;
 #endif
 
+#ifdef CONFIG_IRQ_FASTPATH
+static inline
+void fastpath_irq(void)
+NORETURN;
+#endif
+
+void slowpath_irq(void)
+NORETURN;
 
 static inline
 #ifdef CONFIG_KERNEL_MCS

--- a/include/fastpath/fastpath.h
+++ b/include/fastpath/fastpath.h
@@ -11,7 +11,7 @@
 #include <object/notification.h>
 #endif
 
-#ifdef CONFIG_SIGNAL_FASTPATH
+#if defined(CONFIG_SIGNAL_FASTPATH) || defined(CONFIG_IRQ_FASTPATH)
 /* Equivalent to schedContext_donate without migrateTCB() */
 static inline void maybeDonateSchedContext_fp(tcb_t *dest, sched_context_t *sc)
 {

--- a/src/arch/arm/c_traps.c
+++ b/src/arch/arm/c_traps.c
@@ -101,6 +101,13 @@ void VISIBLE NORETURN c_handle_instruction_fault(void)
     c_handle_vm_fault(seL4_InstructionFault);
 }
 
+void VISIBLE NORETURN slowpath_irq(void)
+{
+    handleInterruptEntry();
+    restore_user_context();
+    UNREACHABLE();
+}
+
 void VISIBLE NORETURN c_handle_interrupt(void)
 {
     NODE_LOCK_IRQ_IF(IRQT_TO_IRQ(getActiveIRQ()) != irq_remote_call_ipi);
@@ -112,8 +119,11 @@ void VISIBLE NORETURN c_handle_interrupt(void)
     ksKernelEntry.core = CURRENT_CPU_INDEX();
 #endif
 
-    handleInterruptEntry();
-    restore_user_context();
+#ifdef CONFIG_IRQ_FASTPATH
+    fastpath_irq();
+#else
+    slowpath_irq();
+#endif
 }
 
 void NORETURN slowpath(syscall_t syscall)

--- a/src/fastpath/fastpath.c
+++ b/src/fastpath/fastpath.c
@@ -902,3 +902,242 @@ void NORETURN fastpath_vm_fault(vm_fault_type_t type)
     fastpath_restore(badge, msgInfo, NODE_STATE(ksCurThread));
 }
 #endif
+
+#ifdef CONFIG_IRQ_FASTPATH
+#ifdef CONFIG_ARCH_ARM
+static inline
+FORCE_INLINE
+#endif
+void NORETURN fastpath_irq()
+{
+    sched_context_t *sc = NULL;
+    bool_t schedulable = false;
+    bool_t idle = false;
+    bool_t contextSwitch = true;
+    tcb_t *dest = NULL;
+    cap_t newVTable;
+    vspace_root_t *cap_pd = NULL;
+    pde_t stored_hw_asid = {0};
+
+    irq_t irq = getActiveIRQ();
+
+    /* check the irq is valid */
+    if (unlikely(IRQT_TO_IRQ(irq) == IRQT_TO_IRQ(irqInvalid))) {
+#ifdef CONFIG_IRQ_REPORTING
+        printf("Spurious interrupt\n");
+#endif
+        handleSpuriousIRQ();
+        restore_user_context();
+        UNREACHABLE();
+    }
+
+    /* The interrupt number is out of range. Mask because it was reported by
+    hardware. maxIRQ may be wrong. */
+    if (unlikely(IRQT_TO_IRQ(irq) > maxIRQ)) {
+        maskInterrupt(true, irq);
+        ackInterrupt(irq);
+        restore_user_context();
+        UNREACHABLE();
+    }
+
+    irq_state_t irqState = intStateIRQTable[IRQT_TO_IDX(irq)];
+
+
+    /* Other than timer IRQs, only fastpath signalling IRQs */
+    if (unlikely(irqState != IRQSignal)) {
+        slowpath_irq();
+        UNREACHABLE();
+    }
+
+    cap_t ntfn_cap = intStateIRQNode[IRQT_TO_IDX(irq)].cap;
+    if (unlikely(cap_get_capType(ntfn_cap) != cap_notification_cap ||
+                 !cap_notification_cap_get_capNtfnCanSend(ntfn_cap))) {
+#ifdef CONFIG_IRQ_REPORTING
+        printf("Undelivered irq: %d\n", (int) IRQT_TO_IRQ(irq));
+#endif
+        maskInterrupt(true, irq);
+        ackInterrupt(irq);
+        restore_user_context();
+        UNREACHABLE();
+    }
+
+    notification_t *ntfn_ptr = NTFN_PTR(cap_notification_cap_get_capNtfnPtr(ntfn_cap));
+    notification_state_t ntfn_state = notification_ptr_get_state(ntfn_ptr);
+    word_t badge = cap_notification_cap_get_capNtfnBadge(ntfn_cap);
+
+    switch (ntfn_state) {
+    case NtfnState_Active:
+#ifdef CONFIG_BENCHMARK_TRACK_KERNEL_ENTRIES
+        ksKernelEntry.is_fastpath = true;
+#endif
+        word_t newBadge = badge | notification_ptr_get_ntfnMsgIdentifier(ntfn_ptr);
+        notification_ptr_set_ntfnMsgIdentifier(ntfn_ptr, newBadge);
+        maskInterrupt(true, irq);
+        ackInterrupt(irq);
+        restore_user_context();
+        UNREACHABLE();
+    case NtfnState_Idle:
+        dest = (tcb_t *) notification_ptr_get_ntfnBoundTCB(ntfn_ptr);
+
+        if (!dest || thread_state_ptr_get_tsType(&dest->tcbState) != ThreadState_BlockedOnReceive) {
+#ifdef CONFIG_BENCHMARK_TRACK_KERNEL_ENTRIES
+            ksKernelEntry.is_fastpath = true;
+#endif
+            ntfn_set_active(ntfn_ptr, badge);
+            maskInterrupt(true, irq);
+            ackInterrupt(irq);
+            restore_user_context();
+            UNREACHABLE();
+        }
+
+        idle = true;
+        break;
+    case NtfnState_Waiting:
+        dest = TCB_PTR(notification_ptr_get_ntfnQueue_head(ntfn_ptr));
+        break;
+    default:
+        fail("Invalid notification state");
+    }
+
+    /* dest will be woken up */
+    assert(dest != NULL);
+
+    if (unlikely(NODE_STATE(ksCurThread)->tcbPriority >= dest->tcbPriority)) {
+        contextSwitch = false;
+    }
+
+    /* Get the bound SC of the signalled thread */
+    sc = dest->tcbSchedContext;
+
+    /* If the signalled thread doesn't have a bound SC, check if one can be
+     * donated from the notification. If not, go to the slowpath */
+    if (!sc) {
+        sc = SC_PTR(notification_ptr_get_ntfnSchedContext(ntfn_ptr));
+        if (sc == NULL || sc->scTcb != NULL) {
+            slowpath_irq();
+            UNREACHABLE();
+        }
+
+        /* Slowpath the case where dest has its FPU context in the FPU of a core*/
+#if defined(ENABLE_SMP_SUPPORT) && defined(CONFIG_HAVE_FPU)
+        if (nativeThreadUsingFPU(dest)) {
+            slowpath_irq();
+            UNREACHABLE();
+        }
+#endif
+    }
+
+    if (ksCurDomain != dest->tcbDomain SMP_COND_STATEMENT( || sc->scCore != getCurrentCPUIndex())) {
+        slowpath_irq();
+        UNREACHABLE();
+    }
+
+    if (sc->scRefillMax > 0) {
+        if (!(refill_ready(sc) && refill_sufficient(sc, 0))) {
+            slowpath_irq();
+            UNREACHABLE();
+        }
+        schedulable = true;
+    }
+
+    /* VTable/ASID objects are only needed in the context switching case,
+    however these are set here as we cannot go to the slowpath after kernel
+    state has changed. */
+    if (contextSwitch) {
+
+        newVTable = TCB_PTR_CTE_PTR(dest, tcbVTable)->cap;
+
+        /* Get vspace root. */
+        cap_pd = cap_vtable_cap_get_vspace_root_fp(newVTable);
+
+        /* Ensure that the destination has a valid VTable. */
+        if (unlikely(!isValidVTableRoot_fp(newVTable))) {
+            slowpath_irq();
+        }
+
+        /* Need to test that the ASID is still valid */
+        asid_t asid = cap_vspace_cap_get_capVSMappedASID(newVTable);
+        asid_map_t asid_map = findMapForASID(asid);
+        if (unlikely(asid_map_get_type(asid_map) != asid_map_asid_map_vspace ||
+                     VSPACE_PTR(asid_map_asid_map_vspace_get_vspace_root(asid_map)) != cap_pd)) {
+            slowpath_irq();
+        }
+#ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
+        /* Ensure the vmid is valid. */
+        if (unlikely(!asid_map_asid_map_vspace_get_stored_vmid_valid(asid_map))) {
+            slowpath_irq();
+        }
+        /* vmids are the tags used instead of hw_asids in hyp mode */
+        stored_hw_asid.words[0] = asid_map_asid_map_vspace_get_stored_hw_vmid(asid_map);
+#else
+        stored_hw_asid.words[0] = asid;
+#endif
+    }
+
+    /*  Point of no return */
+#ifdef CONFIG_BENCHMARK_TRACK_KERNEL_ENTRIES
+    ksKernelEntry.is_fastpath = true;
+#endif
+
+    if (SMP_TERNARY(clh_is_self_in_queue(), 1)) {
+        updateTimestamp();
+        checkBudget();
+    }
+
+    if (idle) {
+        /* Cancel the IPC that the signalled thread is waiting on */
+        cancelIPC_fp(dest);
+    } else {
+        /* Dequeue dest from the notification queue */
+        ntfn_queue_dequeue_fp(dest, ntfn_ptr);
+    }
+
+    /* Wake up the signalled thread and tranfer badge */
+    setRegister(dest, badgeRegister, badge);
+    thread_state_ptr_set_tsType_np(&dest->tcbState, ThreadState_Running);
+
+    /* Donate SC if necessary. The checks for this were already done before
+     * the point of no return */
+    maybeDonateSchedContext_fp(dest, sc);
+
+    /* Left this in the same form as the slowpath. Not sure if optimal */
+    if (sc_sporadic(dest->tcbSchedContext)) {
+        assert(dest->tcbSchedContext != NODE_STATE(ksCurSC));
+        if (dest->tcbSchedContext != NODE_STATE(ksCurSC)) {
+            refill_unblock_check(dest->tcbSchedContext);
+        }
+    }
+
+    /* if destination sc is not schedulable, we are done */
+    if (!schedulable) {
+        maskInterrupt(true, irq);
+        ackInterrupt(irq);
+        restore_user_context();
+        UNREACHABLE();
+    }
+
+    if (contextSwitch) {
+        if (isSchedulable(NODE_STATE(ksCurThread))) {
+            SCHED_ENQUEUE_CURRENT_TCB;
+        }
+        switchToThread_fp(dest, cap_pd, stored_hw_asid);
+
+        if (NODE_STATE(ksReprogram)) {
+            setNextInterrupt();
+            NODE_STATE(ksReprogram) = false;
+        }
+
+        /* update sc */
+        NODE_STATE(ksCurSC) = NODE_STATE(ksCurThread)->tcbSchedContext;
+    } else if (NODE_STATE(ksCurThread)->tcbPriority == dest->tcbPriority) {
+        tcbSchedAppend(dest);
+    } else {
+        tcbSchedEnqueue(dest);
+    }
+
+    maskInterrupt(true, irq);
+    ackInterrupt(irq);
+    restore_user_context();
+    UNREACHABLE();
+}
+#endif


### PR DESCRIPTION
Add an IRQ fastpath for aarch64 MCS. This fastpath is similar to the signal fastpath but also handles the case when the destination thread is of higher priority than the interrupted thread, in which case a direct context switch occurs.

seL4Bench IRQUser benchmarks (non context switching benchmark is [here](https://github.com/danshea00/sel4bench/tree/irq_signal_low_process)):
|          | Context switching |          |        | Non context switching |          |        |
| -------- | ----------------- | -------- | ------ | --------------------- | -------- | ------ |
|          | Slowpath          | Fastpath | Diff   | Slowpath              | Fastpath | Diff   |
| imx8mm   | 808 (13)          | 594 (11) | 26% | 762 (10)              | 367 (3)  | 52% |
| imx8mq   | 1365 (3)          | 625 (3)  | 54% | 1393 (20)             | 367 (3)  | 74% |
| odroidc4 | 836 (5)           | 745 (15) | 11% | 814 (49)              | 512 (39) | 37% |
| tqma     | 863 (5)           | 757 (10) | 12% | 868 (7)               | 468 (3)  | 46% |
| tx1      | 810 (5)           | 735 (10) | 9%  | 767 (6)               | 489 (5)  | 36% |
| zcu106   | 705 (10)          | 557 (12) | 21% | 749 (14)              | 492 (44) | 34% |