### PR TITLE
github: add AARCH64 C proof session

### DIFF
--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -30,6 +30,8 @@ jobs:
             session: CRefine SimplExportAndRefine
           - arch: X64
             session: CRefine
+          - arch: AARCH64
+            session: CRefine
           - arch: RISCV64
             features: MCS
             session: CRefine


### PR DESCRIPTION
CRefine is now available for AARCH64 in l4v.