### PR TITLE
Fix incorrect use of NODE_STATE to access ccnt_num_overflows

### DIFF
--- a/include/arch/arm/arch/benchmark.h
+++ b/include/arch/arm/arch/benchmark.h
@@ -37,7 +37,7 @@ static inline void handleOverflowIRQ(void)
     if (likely(NODE_STATE(benchmark_log_utilisation_enabled))) {
         NODE_STATE(ksCurThread)->benchmark.utilisation += UINT32_MAX - NODE_STATE(ksCurThread)->benchmark.schedule_start_time;
         NODE_STATE(ksCurThread)->benchmark.schedule_start_time = 0;
-        NODE_STATE(ccnt_num_overflows)++;
+        ARCH_NODE_STATE(ccnt_num_overflows)++;
     }
     armv_handleOverflowIRQ();
 }
@@ -46,7 +46,7 @@ static inline void handleOverflowIRQ(void)
 static inline void benchmark_arch_utilisation_reset(void)
 {
 #ifdef CONFIG_ARM_ENABLE_PMU_OVERFLOW_INTERRUPT
-    NODE_STATE(ccnt_num_overflows) = 0;
+    ARCH_NODE_STATE(ccnt_num_overflows) = 0;
 #endif /* CONFIG_ARM_ENABLE_PMU_OVERFLOW_INTERRUPT */
 }
 #endif /* CONFIG_ENABLE_BENCHMARKS */

--- a/src/benchmark/benchmark_utilisation.c
+++ b/src/benchmark/benchmark_utilisation.c
@@ -56,7 +56,7 @@ void benchmark_track_utilisation_dump(void)
     /* Total counters */
 #ifdef CONFIG_ARM_ENABLE_PMU_OVERFLOW_INTERRUPT
     buffer[BENCHMARK_TOTAL_UTILISATION] =
-        (NODE_STATE(ccnt_num_overflows) * 0xFFFFFFFFU) + NODE_STATE(benchmark_end_time) - NODE_STATE(benchmark_start_time);
+        (ARCH_NODE_STATE(ccnt_num_overflows) * 0xFFFFFFFFU) + NODE_STATE(benchmark_end_time) - NODE_STATE(benchmark_start_time);
 #else
     buffer[BENCHMARK_TOTAL_UTILISATION] = NODE_STATE(benchmark_end_time) - NODE_STATE(
                                               benchmark_start_time); /* Overall time */


### PR DESCRIPTION
Previously `ccnt_num_overflows` was accessed using the `NODE_STATE` macro. 
On SMP configurations, this would look for the `ccnt_num_overflows` value 
in the system node state (`nodeState_t`) in the `smpStatedata` struct. However,
this value resides in the cpu node state (`archNodeState_t`) and should be accessed
using the `ARCH_NODE_STATE` macro. 