### PR TITLE
boot: Fix root cnode size compile-time assert

### DIFF
--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -272,7 +272,7 @@ BOOT_CODE void write_slot(slot_ptr_t slot_ptr, cap_t cap)
 compile_assert(root_cnode_size_valid,
                CONFIG_ROOT_CNODE_SIZE_BITS < 32 - seL4_SlotBits &&
                BIT(CONFIG_ROOT_CNODE_SIZE_BITS) >= seL4_NumInitialCaps &&
-               BIT(CONFIG_ROOT_CNODE_SIZE_BITS) >= (seL4_PageBits - seL4_SlotBits))
+               CONFIG_ROOT_CNODE_SIZE_BITS >= (seL4_PageBits - seL4_SlotBits))
 
 BOOT_CODE cap_t
 create_root_cnode(void)


### PR DESCRIPTION
The check was not enforcing the minimum radix intended by 5fac9e8 and still allowed a radix of 4 to be specified.