### PR TITLE
make SMP conditional check more general

### DIFF
--- a/include/arch/arm/arch/64/mode/machine.h
+++ b/include/arch/arm/arch/64/mode/machine.h
@@ -304,7 +304,7 @@ static inline void invalidateByVA_I(vptr_t vaddr, paddr_t paddr)
 
 static inline void invalidate_I_PoU(void)
 {
-#if CONFIG_MAX_NUM_NODES > 1
+#ifdef CONFIG_ENABLE_SMP_SUPPORT
     asm volatile("ic ialluis");
 #else
     asm volatile("ic iallu");

--- a/libsel4/include/sel4/syscalls.h
+++ b/libsel4/include/sel4/syscalls.h
@@ -118,7 +118,7 @@ seL4_DebugCapIdentify(seL4_CPtr cap);
  */
 LIBSEL4_INLINE_FUNC void
 seL4_DebugNameThread(seL4_CPtr tcb, const char *name);
-#if CONFIG_MAX_NUM_NODES > 1 && defined CONFIG_ARCH_ARM
+#if defined(CONFIG_ENABLE_SMP_SUPPORT) && defined(CONFIG_ARCH_ARM)
 /**
  * @xmlonly <manual name="Send SGI 0-15" label="sel4_debugsendipi"/> @endxmlonly
  * @brief Sends arbitrary SGI.

--- a/src/arch/arm/64/traps.S
+++ b/src/arch/arm/64/traps.S
@@ -32,7 +32,7 @@
 
 .macro lsp_i _tmp
     mrs     \_tmp, TPIDR
-#if CONFIG_MAX_NUM_NODES > 1
+#ifdef CONFIG_ENABLE_SMP_SUPPORT
     bic     \_tmp, \_tmp, #0xfff
 #endif
     mov     sp, \_tmp

--- a/src/arch/riscv/head.S
+++ b/src/arch/riscv/head.S
@@ -30,7 +30,7 @@ _start:
   la sp, (kernel_stack_alloc + BIT(CONFIG_KERNEL_STACK_BITS))
   csrw sscratch, x0 /* zero sscratch for the init task */
 
-#if CONFIG_MAX_NUM_NODES > 1
+#ifdef CONFIG_ENABLE_SMP_SUPPORT
 /* setup the per-core stack */
   mv t0, a7
   slli t0, t0, CONFIG_KERNEL_STACK_BITS


### PR DESCRIPTION
Check for `CONFIG_ENABLE_SMP_SUPPORT` everywhere instead of checking `CONFIG_MAX_NUM_NODES > 1`. This are the remaining places in the code where `CONFIG_MAX_NUM_NODES` was used in the check. This change now allows enabling SMP support manually with just one node also, which comes handy for running some test configurations. 