### PR TITLE
fix rust stub generation script

### DIFF
--- a/libsel4/tools/syscall_stub_gen_rs.py
+++ b/libsel4/tools/syscall_stub_gen_rs.py
@@ -485,11 +485,8 @@ def generate_stub_file(arch, input_files, output_file, use_only_ipc_buffer, mcs,
     result.append(" */")
     for (interface_name, method_name, method_id, inputs, outputs, condition, comment) in methods:
         if condition != "":
-            if condition == "(!defined CONFIG_KERNEL_MCS) && CONFIG_MAX_NUM_NODES > 1":
-                # NB: CONFIG_MAX_NUM_NODES > 1 =>'s CONFIG_SMP_SUPPORT
-                condition = 'all(not(feature = "CONFIG_KERNEL_MCS"), feature = "CONFIG_SMP_SUPPORT")'
-            elif condition == "CONFIG_MAX_NUM_NODES > 1":
-                condition = 'feature = "CONFIG_SMP_SUPPORT"'
+            if condition == "(!defined(CONFIG_KERNEL_MCS) && defined(CONFIG_ENABLE_SMP_SUPPORT))":
+                condition = 'all(not(feature = "CONFIG_KERNEL_MCS"), feature = "CONFIG_ENABLE_SMP_SUPPORT")'
             elif condition:
                 condition = condition.replace('defined', '')
                 condition = condition.replace('(', '')


### PR DESCRIPTION
Update script to match current code base:
- fix: brackets in check
- fix: use `CONFIG_ENABLE_SMP_SUPPORT`
- conditions for `CONFIG_MAX_NUM_NODES` have been removed

See also https://github.com/seL4/seL4/issues/1223#issuecomment-2015409628, https://github.com/seL4/seL4/issues/1223#issuecomment-2015441234