### PR TITLE
libsel4: remove obsolete --cfile and --word-size

### DIFF
--- a/libsel4/CMakeLists.txt
+++ b/libsel4/CMakeLists.txt
@@ -146,19 +146,14 @@ set(
     "${CMAKE_CURRENT_SOURCE_DIR}/arch_include/${KernelArch}/interfaces/sel4arch.xml"
     "${CMAKE_CURRENT_SOURCE_DIR}/include/interfaces/sel4.xml"
 )
+
 add_custom_command(
     OUTPUT include/interfaces/sel4_client.h
     COMMAND rm -f include/interfaces/sel4_client.h
     COMMAND
-        echo "CONFIG_WORD_SIZE=${KernelWordSize}" > config
-    COMMAND
         "${PYTHON3}" "${SYSCALL_STUB_GEN_PATH}" ${buffer} ${64bitguests} ${mcs} -a
-        "${KernelSel4Arch}" -c config -o include/interfaces/sel4_client.h ${interface_xmls}
-    DEPENDS
-        "${SYSCALL_STUB_GEN_PATH}"
-        ${interface_xmls}
-        BYPRODUCTS
-        config
+        "${KernelSel4Arch}" -o include/interfaces/sel4_client.h ${interface_xmls}
+    DEPENDS "${SYSCALL_STUB_GEN_PATH}" ${interface_xmls}
     COMMENT "Generate sel4_client.h"
     VERBATIM
 )

--- a/libsel4/tools/syscall_stub_gen.py
+++ b/libsel4/tools/syscall_stub_gen.py
@@ -965,7 +965,7 @@ def parse_xml_file(input_file, valid_types):
     return (methods, structs, api)
 
 
-def generate_stub_file(arch, wordsize, input_files, output_file, use_only_ipc_buffer, mcs, args):
+def generate_stub_file(arch, input_files, output_file, use_only_ipc_buffer, mcs, args):
     """
     Generate a header file containing system call stubs for seL4.
     """
@@ -973,7 +973,9 @@ def generate_stub_file(arch, wordsize, input_files, output_file, use_only_ipc_bu
 
     # Ensure architecture looks sane.
     if arch not in WORD_SIZE_BITS_ARCH.keys():
-        raise Exception("Invalid architecture.")
+        raise Exception(f"Invalid architecture: {arch}")
+
+    wordsize = WORD_SIZE_BITS_ARCH[arch]
 
     data_types = init_data_types(wordsize)
     arch_types = init_arch_types(wordsize, args)
@@ -1069,12 +1071,6 @@ def process_args():
                         help="Architecture to generate stubs for.")
     parser.add_argument("--mcs", dest="mcs", action="store_true",
                         help="Generate MCS api.")
-
-    wsizegroup = parser.add_mutually_exclusive_group()
-    wsizegroup.add_argument("-w", "--word-size", dest="wsize",
-                            help="Word size(in bits), for the platform.")
-    wsizegroup.add_argument("-c", "--cfile", dest="cfile",
-                            help="Config file for Kbuild, used to get Word size.")
     parser.add_argument("--x86-vtx-64-bit-guests", dest="x86_vtx_64bit", action="store_true", default=False,
                         help="Whether the vtx VCPU objects need to be large enough for 64-bit guests.")
 
@@ -1085,35 +1081,10 @@ def process_args():
 
 
 def main():
-
     parser = process_args()
     args = parser.parse_args()
-
-    if not (args.wsize or args.cfile):
-        parser.error("Require either -w/--word-size or -c/--cfile argument.")
-        sys.exit(2)
-
-    # Get word size
-    wordsize = -1
-
-    if args.cfile:
-        try:
-            with open(args.cfile) as conffile:
-                for line in conffile:
-                    if line.startswith('CONFIG_WORD_SIZE'):
-                        wordsize = int(line.split('=')[1].strip())
-        except IndexError:
-            print("Invalid word size in configuration file.")
-            sys.exit(2)
-    else:
-        wordsize = int(args.wsize)
-
-    if wordsize == -1:
-        print("Invalid word size.")
-        sys.exit(2)
-
     # Generate the stubs.
-    generate_stub_file(args.arch, wordsize, args.files, args.output, args.buffer, args.mcs, args)
+    generate_stub_file(args.arch, args.files, args.output, args.buffer, args.mcs, args)
 
 
 if __name__ == "__main__":

--- a/libsel4/tools/syscall_stub_gen_rs.py
+++ b/libsel4/tools/syscall_stub_gen_rs.py
@@ -432,11 +432,17 @@ def generate_stub(arch, wordsize, interface_name, method_name, method_id, input_
     return "\n".join(result) + "\n"
 
 
-def generate_stub_file(arch, wordsize, input_files, output_file, use_only_ipc_buffer, mcs, args):
+def generate_stub_file(arch, input_files, output_file, use_only_ipc_buffer, mcs, args):
     """
     Generate a header file containing system call stubs for seL4.
     """
     result = []
+
+    # Ensure architecture looks sane.
+    if arch not in syscall_stub_gen.WORD_SIZE_BITS_ARCH.keys():
+        raise Exception(f"Invalid architecture: {arch}")
+
+    wordsize = syscall_stub_gen.WORD_SIZE_BITS_ARCH[arch]
 
     data_types = syscall_stub_gen.init_data_types(wordsize)
     arch_types = syscall_stub_gen.init_arch_types(wordsize, args)
@@ -532,13 +538,10 @@ def process_args():
 
 
 def main():
-
     parser = process_args()
     args = parser.parse_args()
-
-    wordsize = syscall_stub_gen.WORD_SIZE_BITS_ARCH[args.arch]
     # Generate the stubs.
-    generate_stub_file(args.arch, wordsize, args.files, args.output, args.buffer, args.mcs, args)
+    generate_stub_file(args.arch, args.files, args.output, args.buffer, args.mcs, args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Practically, it seems the word size can be derived from `--arch` easily and that is all we need. The rest is removed to simplify things.
Seem creating the `config` file to pass the word size is a left over from the Kconfig build system and it looks quite obsolete nowadays. Removing the parameters `--cfile` and `--word-size` might break 3rd party workflows, but this could be fixed when a properly defined custom architecture passed via `--arch`.