### PR TITLE
fix: invisible chars due to ANSI escape codes

### DIFF
--- a/include/api/types.h
+++ b/include/api/types.h
@@ -103,11 +103,11 @@ static inline word_t CONST wordFromMessageInfo(seL4_MessageInfo_t mi)
 #ifdef CONFIG_COLOUR_PRINTING
 #define ANSI_RESET "\033[0m"
 #define ANSI_GREEN ANSI_RESET "\033[32m"
-#define ANSI_DARK  ANSI_RESET "\033[30;1m"
+#define ANSI_BOLD  ANSI_RESET "\033[1m"
 #else
 #define ANSI_RESET ""
 #define ANSI_GREEN ANSI_RESET ""
-#define ANSI_DARK  ANSI_RESET ""
+#define ANSI_BOLD  ANSI_RESET ""
 #endif
 
 /*
@@ -135,8 +135,8 @@ extern struct debug_syscall_error current_debug_error;
  */
 #define userError(M, ...) \
     do {                                                                       \
-        out_error(ANSI_DARK "<<" ANSI_GREEN "seL4(CPU %" SEL4_PRIu_word ")"    \
-                ANSI_DARK " [%s/%d T%p \"%s\" @%lx]: " M ">>" ANSI_RESET "\n", \
+        out_error(ANSI_BOLD "<<" ANSI_GREEN "seL4(CPU %" SEL4_PRIu_word ")"    \
+                ANSI_BOLD " [%s/%d T%p \"%s\" @%lx]: " M ">>" ANSI_RESET "\n", \
                 CURRENT_CPU_INDEX(),                                           \
                 __func__, __LINE__, NODE_STATE(ksCurThread),                   \
                 THREAD_NAME,                                                   \


### PR DESCRIPTION
The prior behavior would emit ANSI escape codes which set the terminal
foreground color to black bold (`[30;1m`), leaving the default
background color. On many terminals configured with a dark color scheme,
this creates black on black characters, i.e. the output is invisible.

This change moves to a better adapted output, where the output is only
marked as bold (`[1m]`), which works well on all color schemes.

Fixes #1243