### PR TITLE
arm tlb: guard TLB lockdown count

### DIFF
--- a/src/arch/arm/armv/armv7-a/machine_asm.S
+++ b/src/arch/arm/armv/armv7-a/machine_asm.S
@@ -7,18 +7,15 @@
 #include <config.h>
 #include <machine/assembler.h>
 
-#if defined(CONFIG_ARM_CORTEX_A15) || defined(CONFIG_ARM_CORTEX_A7)
-  /* The hardware does not support tlb locking */
-
-#else
+#if defined(CONFIG_ARM_CORTEX_A8)
 
 .code 32
 .section .text, "ax"
 .global lockTLBEntryCritical
 
-.balign (16*4)    
+.balign (16*4)
 BEGIN_FUNC(lockTLBEntryCritical)
- 
+
  /* lockTLBEntryCritical should lie within a single page so that spurious TLB walks do
  * not interfere. Aligning to a 64-byte instruction boundary will suffice, as
  * the critical section (i.e. this function) fits within 64 bytes.
@@ -38,4 +35,8 @@ BEGIN_FUNC(lockTLBEntryCritical)
     bx lr
 END_FUNC(lockTLBEntryCritical)
 
-#endif /* ARM_CORTEX_A15 */
+#else
+
+/* We don't currently support TLB locking for other processors. */
+
+#endif /* ARM_CORTEX_A8 */

--- a/src/arch/arm/armv/armv7-a/tlb.c
+++ b/src/arch/arm/armv/armv7-a/tlb.c
@@ -6,14 +6,7 @@
 
 #include <arch/machine/hardware.h>
 
-#if defined(CONFIG_ARM_CORTEX_A15) || defined(CONFIG_ARM_CORTEX_A7)
-/* The hardware does not support tlb locking */
-void lockTLBEntry(vptr_t vaddr)
-{
-
-}
-
-#else
+#if defined(CONFIG_ARM_CORTEX_A8)
 
 void lockTLBEntry(vptr_t vaddr)
 {
@@ -23,32 +16,22 @@ void lockTLBEntry(vptr_t vaddr)
     tlbLockCount ++;
     /* Compute two values, x and y, to write to the lockdown register. */
 
-#if defined(CONFIG_ARM_CORTEX_A8)
-
     /* Before lockdown, base = victim = num_locked_tlb_entries. */
     x = 1 | (n << 22) | (n << 27);
     n ++;
     /* After lockdown, base = victim = num_locked_tlb_entries + 1. */
     y = (n << 22) | (n << 27);
 
-#elif defined(CONFIG_ARM_CORTEX_A9)
-
-    /* Before lockdown, victim = num_locked_tlb_entries. */
-    x = 1 | (n << 28);
-    n ++;
-    /* After lockdown, victim = num_locked_tlb_entries + 1. */
-    y = (n << 28);
-
-#else
-
-    userError("Undefined CPU for TLB lockdown.\n");
-    halt();
-
-#endif /* A8/A9 */
-
     lockTLBEntryCritical(vaddr, x, y);
 }
 
-#endif /* A15/A7 */
+/* if CORTEX_A8 */
+#else
 
+/* We don't currently support TLB locking for other processors. */
+void lockTLBEntry(vptr_t vaddr)
+{
 
+}
+
+#endif

--- a/src/arch/arm/armv/armv7-a/tlb.c
+++ b/src/arch/arm/armv/armv7-a/tlb.c
@@ -13,6 +13,17 @@ void lockTLBEntry(vptr_t vaddr)
     int n = tlbLockCount;
     int x, y;
 
+    /* tlbLockCount is used only in this function, which is called at most 2 times for unicore
+       platforms (and we only have unicore A8 platforms). */
+    assert(tlbLockCount < 2);
+    /* Since asserts are off in release mode, we enforce the bound on tlbLockCount manually, so we
+       don't have to verify calling context. We need the bound to be sure the bit operations below
+       are not undefined behaviour. We leave the assert in, because we want to know about it when
+       the calling context ever changes. */
+    if (tlbLockCount >= 2) {
+        return;
+    }
+
     tlbLockCount ++;
     /* Compute two values, x and y, to write to the lockdown register. */
 


### PR DESCRIPTION
- `lockTLBEntry` uses the global `tlbLockCount` as input without checking bounds. This is fine, because the function is called at most 2 times on unicore platforms, but this is only apparent when checking the entire possible calling context.

  Make this bound obvious locally by doing nothing if the function is called with values of `tlbLockCount` of 2 or greater. This is safe, because TLB lockdown is a performance change only. Also add an assert for debug mode, because we want to know if calling context ever changes.

- remove TLB locking for Cortex A9. The code shared the A8 locking sequence with A9, but not all of these instructions are supported on A9. As far as we have been able to tell, they are silently ignored on the A9 platforms that seL4 supports, but it is of course better to remove them in case future platforms behave differently, which they would be allowed to do.

To properly add TLB locking for A9 in the future, the code would need to use the corresponding A9 instructions and take SMP into account for e.g. the `sabre` platforms, where `lockTLBEntry` is called 2 times *per core*, instead of 2 times overall.

These two potential issues were reported by The UK's National Cyber Security Centre (NCSC).