### PR TITLE
vcpu: only trap WFx instructions from vCPUs

### DIFF
--- a/include/arch/arm/armv/armv7-a/armv/vcpu.h
+++ b/include/arch/arm/armv/armv7-a/armv/vcpu.h
@@ -13,19 +13,19 @@
 #include <arch/object/vcpu.h>
 #include <drivers/timer/arm_generic.h>
 
-#ifdef CONFIG_DISABLE_WFI_WFE_TRAPS
 /* Trap SMC and override CPSR.AIF */
 #define HCR_COMMON ( HCR_TSC | HCR_AMO | HCR_IMO \
                    | HCR_FMO | HCR_DC  | HCR_VM)
-#else
-/* Trap WFI/WFE/SMC and override CPSR.AIF */
-#define HCR_COMMON ( HCR_TSC | HCR_TWE | HCR_TWI | HCR_AMO | HCR_IMO \
-                   | HCR_FMO | HCR_DC  | HCR_VM)
-#endif
+
 /* Allow native tasks to run at PL1, but restrict access */
 #define HCR_NATIVE ( HCR_COMMON | HCR_TGE | HCR_TVM | HCR_TTLB | HCR_TCACHE \
                    | HCR_TAC | HCR_SWIO)
+
+#ifdef CONFIG_DISABLE_WFI_WFE_TRAPS
 #define HCR_VCPU   (HCR_COMMON)
+#else
+#define HCR_VCPU   (HCR_COMMON | HCR_TWE | HCR_TWI)
+#endif
 
 /* Amongst other things we set the caches to enabled by default. This
  * may cause problems when booting guests that expect caches to be

--- a/include/arch/arm/armv/armv8-a/64/armv/vcpu.h
+++ b/include/arch/arm/armv/armv8-a/64/armv/vcpu.h
@@ -14,18 +14,18 @@
 #include <drivers/timer/arm_generic.h>
 
 /* Note that the HCR_DC for ARMv8 disables S1 translation if enabled */
-#ifdef CONFIG_DISABLE_WFI_WFE_TRAPS
 /* Trap SMC and override CPSR.AIF */
-#define HCR_COMMON ( HCR_VM | HCR_RW | HCR_AMO | HCR_IMO | HCR_FMO )
-#else
-/* Trap WFI/WFE/SMC and override CPSR.AIF */
-#define HCR_COMMON ( HCR_TWI | HCR_TWE | HCR_VM | HCR_RW | HCR_AMO | HCR_IMO | HCR_FMO )
-#endif
+#define HCR_COMMON ( HCR_VM | HCR_RW | HCR_AMO | HCR_IMO | HCR_FMO | HCR_TSC)
 
 /* Allow native tasks to run at EL0, but restrict access */
 #define HCR_NATIVE ( HCR_COMMON | HCR_TGE | HCR_TVM | HCR_TTLB | HCR_DC \
                    | HCR_TAC | HCR_SWIO |  HCR_TSC )
-#define HCR_VCPU   ( HCR_COMMON | HCR_TSC)
+
+#ifdef CONFIG_DISABLE_WFI_WFE_TRAPS
+#define HCR_VCPU   ( HCR_COMMON)
+#else
+#define HCR_VCPU   ( HCR_COMMON | HCR_TWE | HCR_TWI)
+#endif
 
 #define SCTLR_EL1_UCI       BIT(26)     /* Enable EL0 access to DC CVAU, DC CIVAC, DC CVAC,
                                            and IC IVAU in AArch64 state   */


### PR DESCRIPTION
When KernelArmDisableWFIWFETraps is disabled (trapping of WFI/WFE is enabled), the kernel traps WFx instructions from both native and vCPU threads. This change makes the code in line with the config description.

In any case, there don't exist many use cases for trapping WFx from native threads vs vCPU threads. Example: kvm uses this to yield physical CPU time to other vCPUs instead of busy waiting.