### PR TITLE
Review of user manual (only typos and syntax)

### DIFF
--- a/libsel4/arch_include/arm/interfaces/sel4arch.xml
+++ b/libsel4/arch_include/arm/interfaces/sel4arch.xml
@@ -13,9 +13,9 @@
                 Map a page table into an address space.
             </brief>
             <description>
-                Takes a VSpace capability as an argument,
-                and installs a reference to the invoked
-                <texttt text='PageTable'/> in the VSpace according to the provided virtual address.
+                Takes a VSpace capability as an argument, and installs a
+                reference to the page table in the VSpace at the provided
+                virtual address.
             </description>
             <param dir="in" name="vspace" type="seL4_CPtr"
             description="Capability to the VSpace which will contain the mapping.
@@ -137,7 +137,7 @@
                 Map a page into an address space or update the mapping attributes.
             </brief>
             <description>
-                Takes a VSpace capability, as an argument and installs a reference
+                Takes a VSpace capability as an argument and installs a reference
                 to the given <texttt text="Page"/> in the lowest-level unmapped paging structure
                 corresponding to the given address, or updates the mapping attributes if the page is
                 already mapped at this address. The page must not already be mapped through this
@@ -293,7 +293,7 @@
         </method>
         <method id="ARMPageInvalidate_Data" name="Invalidate_Data" manual_name="Invalidate Data">
             <brief>
-                Invalidates the cache range within the given page. The start and end are relative to the page being serviced
+                Invalidates the cache range within the given page. The start and end offsets are relative to the page being serviced
                 and should be aligned to a cache line boundary where possible.
                 An additional clean is performed on the outer cache lines if the start and end are
                 not aligned, to clean out the bytes between the requested and the cache line boundary.
@@ -333,7 +333,7 @@
             manual_name="Clean and Invalidate Data">
             <brief>
                 Clean and invalidates the cache range within the given page. The range will be flushed out to RAM.
-                The start and end are relative to the page being serviced.
+                The start and end offsets are relative to the page being serviced.
             </brief>
             <description>
                 <docref>See <autoref label="ch:vspace"/>.</docref>
@@ -370,7 +370,7 @@
             <brief>
                 Unify Instruction Cache. Cleans data lines to point of unification, invalidate
                 corresponding instruction lines to point of unification, then invalidates branch
-                predictors. The start and end are relative to the page being
+                predictors. The start and end offsets are relative to the page being
                 serviced.
             </brief>
             <description>
@@ -693,7 +693,7 @@
             <param dir="in" name="trigger" type="seL4_Word" description="Indicates whether this IRQ is edge (1) or level (0) triggered."/>
             <param dir="in" name="root" type="seL4_CNode" description="CPtr to the CNode that forms the root of the destination CSpace. Must be at a depth equivalent to the wordsize."/>
             <param dir="in" name="index" type="seL4_Word" description="CPtr to the destination slot. Resolved from the root of the destination CSpace."/>
-            <param dir="in" name="depth" type="seL4_Uint8" description="Number of bits of dest_index to resolve to find the destination slot."/>
+            <param dir="in" name="depth" type="seL4_Uint8" description="Number of bits of index to resolve to find the destination slot."/>
             <error name="seL4_DeleteFirst">
                 <description>
                     The destination slot contains a capability.
@@ -743,8 +743,8 @@
             <param dir="in" name="trigger" type="seL4_Word" description="Indicates whether this IRQ is edge (1) or level (0) triggered."/>
             <param dir="in" name="root" type="seL4_CNode" description="CPtr to the CNode that forms the root of the destination CSpace. Must be at a depth equivalent to the wordsize."/>
             <param dir="in" name="index" type="seL4_Word" description="CPtr to the destination slot. Resolved from the root of the destination CSpace."/>
-            <param dir="in" name="depth" type="seL4_Uint8" description="Number of bits of dest_index to resolve to find the destination slot."/>
-            <param dir="in" name="target" type="seL4_Word" description="Indicates the target core ID to which this irq will be sent."/>
+            <param dir="in" name="depth" type="seL4_Uint8" description="Number of bits of index to resolve to find the destination slot."/>
+            <param dir="in" name="target" type="seL4_Word" description="Indicates the target core ID to which this IRQ will be sent."/>
             <error name="seL4_DeleteFirst">
                 <description>
                     The destination slot contains a capability.
@@ -796,7 +796,7 @@
             <param dir="in" name="sid" type="seL4_Word" description="The SID that you want this capability to manage."/>
             <param dir="in" name="root" type="seL4_CNode" description="CPtr to the CNode that forms the root of the destination CSpace. Must be at a depth equivalent to the wordsize."/>
             <param dir="in" name="index" type="seL4_Word" description="CPtr to the destination slot. Resolved from the root of the destination CSpace."/>
-            <param dir="in" name="depth" type="seL4_Uint8" description="Number of bits of dest_index to resolve to find the destination slot."/>
+            <param dir="in" name="depth" type="seL4_Uint8" description="Number of bits of index to resolve to find the destination slot."/>
             <error name="seL4_DeleteFirst">
                 <description>
                     The destination slot contains a capability.
@@ -941,7 +941,7 @@
             <param dir="in" name="cb" type="seL4_Word" description="The CB that you want this capability to manage."/>
             <param dir="in" name="root" type="seL4_CNode" description="CPtr to the CNode that forms the root of the destination CSpace. Must be at a depth equivalent to the wordsize."/>
             <param dir="in" name="index" type="seL4_Word" description="CPtr to the destination slot. Resolved from the root of the destination CSpace."/>
-            <param dir="in" name="depth" type="seL4_Uint8" description="Number of bits of dest_index to resolve to find the destination slot."/>
+            <param dir="in" name="depth" type="seL4_Uint8" description="Number of bits of index to resolve to find the destination slot."/>
             <error name="seL4_DeleteFirst">
                 <description>
                     The destination slot contains a capability.
@@ -1000,7 +1000,7 @@
        <method id="ARMCBAssignVspace" name="AssignVspace" manual_name="Assign VSpace" manual_label="cb_assignvspace">
             <condition><config var="CONFIG_ARM_SMMU"/></condition>
             <brief>
-                Assigning a vspace to a context bank.
+                Assigning a VSpace to a context bank.
             </brief>
             <description>
                 <docref>See <autoref label="sec:smmuv2-configuring-context-banks"/>.</docref>
@@ -1027,7 +1027,7 @@
         <method id="ARMCBUnassignVspace" name="UnassignVspace" manual_name="Unassign VSpace" manual_label="cb_unassignvspace">
             <condition><config var="CONFIG_ARM_SMMU"/></condition>
             <brief>
-                Unassigning a vspace to a context bank.
+                Unassigning a VSpace to a context bank.
             </brief>
             <description>
                 <docref>See <autoref label="sec:smmuv2-configuring-context-banks"/>.</docref>

--- a/libsel4/arch_include/riscv/interfaces/sel4arch.xml
+++ b/libsel4/arch_include/riscv/interfaces/sel4arch.xml
@@ -330,7 +330,7 @@
             <param dir="in" name="trigger" type="seL4_Word" description="Indicates whether this IRQ is edge (1) or level (0) triggered."/>
             <param dir="in" name="root" type="seL4_CNode" description="CPtr to the CNode that forms the root of the destination CSpace. Must be at a depth equivalent to the wordsize."/>
             <param dir="in" name="index" type="seL4_Word" description="CPtr to the destination slot. Resolved from the root of the destination CSpace."/>
-            <param dir="in" name="depth" type="seL4_Uint8" description="Number of bits of dest_index to resolve to find the destination slot."/>
+            <param dir="in" name="depth" type="seL4_Uint8" description="Number of bits of index to resolve to find the destination slot."/>
             <error name="seL4_DeleteFirst">
                 <description>
                     The destination slot contains a capability.

--- a/libsel4/arch_include/x86/interfaces/sel4arch.xml
+++ b/libsel4/arch_include/x86/interfaces/sel4arch.xml
@@ -571,7 +571,7 @@ contain the mapping"/>
             <param dir="in" name="last_port" type="seL4_Word" description="Last port of the range of the issued capability."/>
             <param dir="in" name="root" type="seL4_CNode" description="CPtr to the CNode that forms the root of the destination CSpace."/>
             <param dir="in" name="index" type="seL4_Word" description="CPtr to the destination slot. Resolved from the root of the destination CSpace."/>
-            <param dir="in" name="depth" type="seL4_Uint8" description="Number of bits of dest_index to resolve to find the destination slot."/>
+            <param dir="in" name="depth" type="seL4_Uint8" description="Number of bits of index to resolve to find the destination slot."/>
             <error name="seL4_DeleteFirst">
                 <description>
                     The destination slot contains a capability.

--- a/libsel4/include/interfaces/sel4.xml
+++ b/libsel4/include/interfaces/sel4.xml
@@ -894,7 +894,7 @@
 
         <method id="CNodeCancelBadgedSends" name="CancelBadgedSends" manual_name="Cancel Badged Sends" manual_label="cnode_cancelbadgedsends">
             <brief>
-                The cancel badged sends method is intend to allow for the reuse of badges by an
+                The cancel badged sends method is intended to allow for the reuse of badges by an
                 authority. When used with a badged endpoint capability it
                 will cancel any outstanding send operations for that endpoint and badge.
                 This operation has no effect on un-badged or other objects.
@@ -1204,7 +1204,7 @@
             <param dir="in" name="irq" type="seL4_Word" description="The IRQ that you want this capability to handle."/>
             <param dir="in" name="root" type="seL4_CNode" description="CPtr to the CNode that forms the root of the destination CSpace. Must be at a depth equivalent to the wordsize."/>
             <param dir="in" name="index" type="seL4_Word" description="CPtr to the destination slot. Resolved from the root of the destination CSpace."/>
-            <param dir="in" name="depth" type="seL4_Uint8" description="Number of bits of dest_index to resolve to find the destination slot."/>
+            <param dir="in" name="depth" type="seL4_Uint8" description="Number of bits of index to resolve to find the destination slot."/>
             <error name="seL4_DeleteFirst" description="The destination slot contains a capability."/>
             <error name="seL4_FailedLookup">
                 <description>
@@ -1391,7 +1391,7 @@
                 until it waits on the notification object again.
 
                 This operation will fail for notification objects if the scheduling context is already
-                bound to a notification object, and for thread objects if the the scheduling context is
+                bound to a notification object, and for thread objects if the scheduling context is
                 already bound to a thread.
             </brief>
             <description>
@@ -1456,7 +1456,7 @@
             </description>
             <return><errorenumdesc/></return>
             <param dir="in" name="cap" type="seL4_CPtr"
-                description="Capability to a notification that is bound to the scheduling context or capability to a tcb that is bound to this scheduling context or has received it through scheduling context donation."/>
+                description="Capability to a notification that is bound to the scheduling context or capability to a TCB that is bound to this scheduling context or has received it through scheduling context donation."/>
             <error name="seL4_IllegalOperation">
                 <description>
                     The <texttt text="_service"/> is a CPtr to a capability of the wrong type.

--- a/libsel4/include/sel4/syscalls.h
+++ b/libsel4/include/sel4/syscalls.h
@@ -215,7 +215,7 @@ seL4_BenchmarkFinalizeLog(void);
  * @brief Set log buffer.
  *
  * Provide a large frame object for the kernel to use as a log-buffer.
- * The object must not be device memory, and must be seL4_LargePageBits in size.
+ * The object must not be device memory, and must be `seL4_LargePageBits` in size.
  *
  * @param[in] frame_cptr A capability pointer to a user allocated frame of seL4_LargePage size.
  * @return A `seL4_IllegalOperation` error if `frame_cptr` is not valid and couldn't set the buffer.
@@ -338,7 +338,7 @@ seL4_BenchmarkResetAllThreadsUtilisation(void);
  *      - `SEL4_VMENTER_CALL_CONTROL_ENTRY_MR` New value for the VM Entry Controls
  *
  * On return these same three message registers will be filled with the values at the point
- * that the privlidged mode ceased executing. If this function returns with `SEL4_VMENTER_RESULT_FAULT`
+ * that the privileged mode ceased executing. If this function returns with `SEL4_VMENTER_RESULT_FAULT`
  * then the following additional message registers will be filled out
  *      - `SEL4_VMENTER_FAULT_REASON_MR`
  *      - `SEL4_VMENTER_FAULT_QUALIFICATION_MR`

--- a/libsel4/include/sel4/syscalls_master.h
+++ b/libsel4/include/sel4/syscalls_master.h
@@ -201,7 +201,7 @@ seL4_Wait(seL4_CPtr src, seL4_Word *sender);
 
 /**
  * @xmlonly <manual name="Poll" label="sel4_poll"/> @endxmlonly
- * @brief Perform a non-blocking recv on a notification object
+ * @brief Perform a non-blocking receive on a notification object
  *
  * This is not a proper system call known by the kernel. Rather, it is a
  * convenience wrapper which calls seL4_NBRecv().

--- a/libsel4/include/sel4/syscalls_mcs.h
+++ b/libsel4/include/sel4/syscalls_mcs.h
@@ -104,7 +104,7 @@ seL4_NBSend(seL4_CPtr dest, seL4_MessageInfo_t msgInfo);
  *               This parameter is ignored if `NULL`.
  *
  * @param[in] reply The capability to the reply object, which is first invoked and then used
- *                  for the recv phase to store a new reply capability.
+ *                  for the receive phase to store a new reply capability.
  * @return A `seL4_MessageInfo_t` structure
  * @xmlonly
  * <docref>as described in <autoref label="sec:messageinfo"/></docref>
@@ -141,7 +141,7 @@ seL4_NBRecv(seL4_CPtr src, seL4_Word *sender, seL4_CPtr reply);
 
 /**
  * @xmlonly <manual name="Non-Blocking Send Recv" label="sel4_nbsendrecv"/> @endxmlonly
- * @brief Non-blocking send on one capability, and a blocking recieve on another in a single
+ * @brief Non-blocking send on one capability, and a blocking receive on another in a single
  *        system call.
  *
  * @xmlonly
@@ -158,7 +158,7 @@ seL4_NBRecv(seL4_CPtr src, seL4_Word *sender, seL4_CPtr reply);
  *               This parameter is ignored if `NULL`.
  * @param[in] src The capability to receive on.
  * @param[in] reply The capability to the reply object, which is first invoked and then used
- *                  for the recv phase to store a new reply capability.
+ *                  for the receive phase to store a new reply capability.
  * @return A `seL4_MessageInfo_t` structure
  * @xmlonly
  * as described in <autoref label="sec:messageinfo"/>
@@ -210,7 +210,7 @@ seL4_Yield(void);
  *
  * Block on a notification or endpoint waiting for a message. No reply object is
  * required for a Wait. Wait should not be paired with Call, as it does not provide
- * a reply object. If Wait is paired with a Call the waiter will block after recieving
+ * a reply object. If Wait is paired with a Call the waiter will block after receiving
  * the message.
  *
  * @xmlonly
@@ -260,7 +260,7 @@ seL4_NBWait(seL4_CPtr src, seL4_Word *sender);
 
 /**
  * @xmlonly <manual name="Poll" label="sel4_mcs_poll"/> @endxmlonly
- * @brief Perform a non-blocking recv on a notification object
+ * @brief Perform a non-blocking receive on a notification object
  *
  * This is not a proper system call known by the kernel. Rather, it is a
  * convenience wrapper which calls seL4_NBWait().

--- a/libsel4/sel4_arch_include/aarch64/interfaces/sel4arch.xml
+++ b/libsel4/sel4_arch_include/aarch64/interfaces/sel4arch.xml
@@ -220,11 +220,11 @@
     <interface name="seL4_ARM_SMC" manual_name="SMC" cap_description="Capability to allow threads to make Secure Monitor Calls.">
         <method id="ARMSMCCall" name="Call" manual_name="SMC Call" manual_label="smc_call">
             <brief>
-                Tell the microkernel to make the real SMC call.
+                Tell the kernel to make the real SMC call.
             </brief>
             <description>
                 Takes x0-x7 as arguments to an SMC call which are defined as a seL4_ARM_SMCContext
-                struct. The microkernel makes the SMC call and then returns the results as a
+                struct. The kernel makes the SMC call and then returns the results as a
                 new seL4_ARM_SMCContext.
             </description>
             <param dir="in" name="smc_args" type="seL4_ARM_SMCContext"

--- a/manual/parts/cspace.tex
+++ b/manual/parts/cspace.tex
@@ -65,7 +65,8 @@ bytes on 32-bit architectures and 32 bytes on 64-bit architectures.
 Like any other object, a \obj{CNode} must be created by calling
 \apifunc{seL4\_Untyped\_Retype}{untyped_retype} on an appropriate
 amount of untyped memory (see \autoref{sec:object_sizes}).  The caller
-must therefore have a capability to enough untyped memory as well as
+must therefore have a capability to untyped memory with at least the size
+of a CSpace as well as
 enough free capability slots available in existing \obj{CNode}s for
 the \apifunc{seL4\_Untyped\_Retype}{untyped_retype} invocation to
 succeed.
@@ -384,7 +385,7 @@ features:
 \end{itemize}
 
 It should be noted that \autoref{fig1.4} demonstrates only what is
-possible, not what is usually practical. Although the CSpace is legal,
+possible, not what is usually practical. Although the example CSpace is legal,
 it would be reasonably difficult to work with due to the small number
 of slots and the circular references within it.
 

--- a/manual/parts/glossary.tex
+++ b/manual/parts/glossary.tex
@@ -71,7 +71,7 @@
 
 \newglossaryentry{irqcontrol}{
     name=IRQControl,
-    description={A single capability from which IRQHandler capabilities to all IRQ numbers in the system can be derived. This capability can be moved between CSpaces and CSlots but cannot be duplicated. Revoking this capability removes all IRQHandlers}
+    description={A single capability from which IRQHandler capabilities to all IRQ numbers in the system can be derived. This capability can be moved between CSpaces and CSpace slots but cannot be duplicated. Revoking this capability removes all IRQHandlers}
 }
 
 \newglossaryentry{irqhandler}{

--- a/manual/parts/io.tex
+++ b/manual/parts/io.tex
@@ -30,7 +30,7 @@ configure a certain interrupt. They have three methods:
 
     \item[\apifunc{seL4\_IRQHandler\_Ack}{irq_handleracknowledge}]
     informs the kernel that the userspace driver has finished processing
-    the interrupt and the microkernel can send further pending or new
+    the interrupt and the kernel can send further pending or new
     interrupts to the application.
 
     \item[\apifunc{seL4\_IRQHandler\_Clear}{irq_handlerclear}]
@@ -208,7 +208,7 @@ TLB maintenance operations are required to keep SMMU translation caches
 consistent when there are changes to any valid page table mapping entries.
 
 An SMMU implementation usually has a maximum number of StreamIDs that it supports.
-The specificiation allows StreamIDs to be up to 16bits wide. There are also a
+The specification allows StreamIDs to be up to 16bits wide. There are also a
 fixed number of context banks, up to a maximum of 128. Context banks can
 be generic or support only a single address translation stage. This information
 is reported by ID registers in each implementation.
@@ -228,7 +228,7 @@ track which VSpace a context bank has bound to it, and which context bank a
 StreamID is bound to.
 
 The capabilities allow access control policies to be implemented by a user thread.
-When StreamID, context bank capabilities are revoked, the kernel will disable
+When StreamID or context bank capabilities are revoked, the kernel will disable
 the context banks or StreamID mappings.
 
 TLB maintenance is handled by the kernel via tracking which context banks are
@@ -251,7 +251,7 @@ Four capabilities types provide access to SMMU resources:
     \item[\obj{seL4\_ARM\_SID}] A capability granting access to a single
         transaction stream, which can be used to bind and unbind a stream to a
         single context bank.
-    \item[\obj{seL4\_ARM\_CB}] A capbility representing a single specific context
+    \item[\obj{seL4\_ARM\_CB}] A capability representing a single specific context
         bank. It can be used to bind and unbind a VSpace to assign what page
         tables the context bank should use for translation, assign StreamIDs and
         process context bank faults.
@@ -285,7 +285,7 @@ tasks in the system.
     allocated in a system.
 \end{description}
 
-The Arm SMMU 2.0 specification descibes many ways of associating StreamIDs with
+The Arm SMMU 2.0 specification describes many ways of associating StreamIDs with
 context banks. Currently only direct mapping of a StreamID to a context bank is
 supported.
 
@@ -324,7 +324,7 @@ VSpace used by the bank with the following API:
 The SMMU-v2 uses the same paging structure as the MMU (AArch\_64 and AArch\_32
 formats). Therefore, there is no need to provide a new set of page structure caps
 nor a separate set of map and unmap functions. To manage the assignment, the
-kernel has an internal CNode, called smmuStateCBNode, that stores copies of the
+kernel has an internal CNode, called \obj{smmuStateCBNode}, that stores copies of the
 \obj{VSpace\_cap} created by executing the above API. The copy of the
 \obj{VSpace\_cap} contains its assigned ContextBank number. Therefore the kernel
 can conduct context bank invalidation if the \obj{VSpace\_cap} is revoked.
@@ -356,11 +356,11 @@ software should use the fault handling mechanisms to resolve them.
 \subsubsection{Copying and Deleting caps}
 \label{sec:smmuv2-copying-and-deleting-caps}
 The kernel allows copying both \obj{ARM\_SID} cap and \obj{seL4\_ARM\_CB} cap.
-This allows capabilites to be delegated to different threads.
+This allows capabilities to be delegated to different threads.
 The kernel does not allow copying neither the \obj{seL4\_ARM\_SIDControl} nor
 the \obj{seL4\_ARM\_CBControl} capabilities.
 
-Deleting a \obj{seL4\_ARM\_CB} cap that contains a valid capBindSID field will:
+Deleting a \obj{seL4\_ARM\_CB} cap that contains a valid \obj{capBindSID} field will:
 \begin{itemize}
     \item invalidate the streamID to ContextBank assignment in hardware.
 \end{itemize}
@@ -369,13 +369,13 @@ Deleting the last \obj{seL4\_ARM\_CB} cap will:
 \begin{itemize}
     \item perform an \apifunc{seL4\_ARM\_CB\_UnassignVspace}{arm_cb_unassignvspace},
     removing any configured VSpace,
-    \item conduct a TLB invalidation.
+    \item invalidate the TLB.
 \end{itemize}
 
-Similarly, deleting a VSpace\_cap that contains assigned context bank number will:
+Similarly, deleting a VSpace\_cap that contains an assigned context bank number will:
 \begin{itemize}
     \item invalidate the context bank
-    \item conduct a TLB invalidation
+    \item invalidate the TLB.
 \end{itemize}
 
 Deleting the last ARM\_SID cap will:
@@ -413,7 +413,7 @@ given context bank is using. There are a few reasons behind this design.
 an ASID which is assigned before the VSpace is ready to be used and will never
 change until the VSpace is deleted. Recording how many context banks are using a
 VSpace's ASID is equivalent to recording the VSpace's usage in context banks.
-\item Second, all TLB invalidation operation requires knowledge of the ASID. There are
+\item Second, all TLB invalidation operations require knowledge of the ASID. There are
 two types of TLB invalidation operations: invalidating a page table entry using
 its ASID (triggered by updating a page table entry, e.g. unmapping a page), and
 invalidating all mappings of an ASID (triggered by deleting a VSpace).
@@ -432,13 +432,13 @@ system. This allows the SMMU to maintain TLB coherency by listening for TLB
 broadcasting messages. This means the context banks should be configured with
 the correct ASID or VMID when the StreamID is enabled. This is not a problem for
 stage 1 translation, as there are a large number of ASID bits and an ASID can be
-assigned to a vspace root with existing APIs. However, the VMID used in stage 2
+assigned to a VSpace root with existing APIs. However, the VMID used in stage 2
 only has 8 bits, and the kernel allocates them on demand and can reclaim a
-VSpace's hardware ASID to reuse if there are more VSpaces than available ASIDS.
+VSpace's hardware ASID to reuse if there are more VSpaces than available ASIDs.
 While it is possible to do this when the VSpace is only used in an MMU, it is
 not possible with multiple active context banks.
 Due to this, the context bank in SMMU cannot be configured with the correct VMID.
-Currently, the SMMU driver uses private VMID space, and uses the context bank
+Currently, the SMMU driver uses a private VMID space, and uses the context bank
 number as the corresponding VMID number.
 
 
@@ -446,7 +446,7 @@ number as the corresponding VMID number.
 \subsubsection{Fault handling}
 \label{sec:smmuv2-fault-handling}
 The number of IRQs used for reporting transaction faults is hardware dependent.
-There are two kinds of faults: global faults ( general configuration and
+There are two kinds of faults: global faults (general configuration and
 transaction faults), or context bank faults. For transaction faults, the SMMU
 reports faulty stream IDs. The global faults reports:
 \begin{itemize}
@@ -468,12 +468,12 @@ which can be used to identify its context bank ID.
 \begin{itemize}
 \item System assumption: Both the SMMU's IRQ handler and the owner of the
     \obj{seL4\_ARM\_SIDControl} cap (controlling stream ID distributions) are trusted.
-\item SMMU interrupts are handled as same as other IRQs, i,e, the kernel does not
+\item SMMU interrupts are handled as same as other IRQs, i.e. the kernel does not
     treat the SMMU IRQs special, reporting the interrupt via IRQ notifications.
-\item The kernel provides a API for reading the global fault registers:
+\item The kernel provides an API for reading the global fault registers:
     \apifunc{seL4\_ARM\_SIDControl\_GetFault}{arm_sid_controlgetfault}. Because
     the IRQ notification can only deliver information via the badge, the owner
-    of the StreamControl\_cap can retrieve more information via this API.
+    of the \obj{seL4\_ARM\_SIDControl} cap can retrieve more information via this API.
 \item If the fault is related to a transaction, the owner of the
     \obj{seL4\_ARM\_SIDControl} cap will notify the holder of the corresponding
     stream ID cap, which should also have a copy of the context bank cap bound to

--- a/manual/parts/ipc.tex
+++ b/manual/parts/ipc.tex
@@ -111,10 +111,10 @@ system call or the second half of \apifunc{seL4\_ReplyRecv}{sel4_replyrecv}
 will wait for the first available sender.
 
 Trying to Send or Call without the Write right will fail and return an error. In
-the case of Send the error is ignored (The kernel isn't allowed to reply). Thus
-there is no way of knowing that a send has failed because of missing right.
+the case of Send the error is ignored (the kernel isn't allowed to reply). Thus
+there is no way of knowing that a send has failed because of a missing right.
 On the other hand calling \apifunc{seL4\_Recv}{sel4_recv} with a endpoint capability that
-does not have the Read right will raise a fault, see \autoref{sec:faults}. This
+does not have the Read right will raise a fault, see \autoref{sec:faults}. This is
 because otherwise the error message would be indistinguishable from a normal
 message received from another thread via the endpoint.
 
@@ -144,7 +144,7 @@ Messages may contain capabilities, which will be copied to the
 receiver, provided that the endpoint capability
 invoked by the sending thread has Grant rights. An attempt to send
 capabilities using an endpoint capability without the Grant right will
-result in transfer of the raw message, without any capability transfer.
+result in a transfer of the raw message, without any capability transfer.
 
 Capabilities to be sent in a message are specified in the sending thread's
 IPC buffer in the \texttt{caps} field. Each entry in that array is interpreted
@@ -191,7 +191,7 @@ reason, \apifunc{seL4\_Send}{sel4_send} and \apifunc{seL4\_Call}{sel4_call} syst
 no IPC or capability transfer takes place. The system call will return
 a lookup failure error as described in \autoref{sec:errors}.
 
-In the receive phase, seL4 transfers capabilities in the order that they
+In the receive phase, seL4 transfers capabilities in the order they
 are found in the sending thread's IPC buffer \texttt{caps} array
 and terminates as soon as an error is encountered. Possible error
 conditions are:
@@ -205,12 +205,12 @@ conditions are:
     CSpace may have changed and the source capability pointers may
     no longer be valid.
 
-    \item The destination slot cannot be looked up. Unlike the send
-    system call, the \apifunc{seL4\_Recv}{sel4_recv} system call does not check that the
-    destination slot exists and is empty before it initiates the receive.
-    Hence, the \apifunc{seL4\_Recv}{sel4_recv} system call will not fail with an error if the
-    destination slot is invalid and will instead transfer badged
-    capabilities until an attempt to save a capability to the
+    \item The destination slot cannot be looked up. Unlike the send system call,
+    the \apifunc{seL4\_Recv}{sel4_recv} system call does not check that the
+    destination slot exists and is empty before it initiates the receive
+    operation. Hence, the \apifunc{seL4\_Recv}{sel4_recv} system call will not
+    fail with an error if the destination slot is invalid and will instead
+    transfer badged capabilities until an attempt to save a capability to the
     destination slot is made.
 
     \item The capability being transferred cannot be derived. See
@@ -281,6 +281,6 @@ efficiency reasons (combining two operations into a single system
 call). It differs from
 \apifunc{seL4\_Send}{sel4_send} immediately followed by
 \apifunc{seL4\_Recv}{sel4_recv} in ways that allow certain system setup to work
-much more efficiently with much less setup that with a traditional setup.
+much more efficiently with much less setup than with a traditional setup.
 In particular, it is guaranteed that the reply received by the caller comes from
 the thread that received the call without having to check any kind of badge.

--- a/manual/parts/objects.tex
+++ b/manual/parts/objects.tex
@@ -21,7 +21,7 @@ The basic services seL4 provides are as follows:
     \item[Threads] are an abstraction of CPU execution that supports
     running software;
 
-    \item[Scheduling contexts] (MCS only) are an abstraction of CPU execution time.
+    \item[Scheduling contexts] (MCS only) are an abstraction of CPU execution time;
 
     \item[Address spaces] are virtual memory spaces that each contain an
     application. Applications are limited to accessing memory in their
@@ -31,7 +31,7 @@ The basic services seL4 provides are as follows:
     threads to communicate using message passing;
 
     \item[Reply objects] (MCS only) are used to store single-use reply capabilities,
-    and are provided by the receiver during message passing.
+    and are provided by the receiver during message passing;
 
     \item[Notifications] provide a non-blocking signalling mechanism
       similar to binary semaphores;
@@ -44,8 +44,8 @@ The basic services seL4 provides are as follows:
     kernel services along with their book-keeping information.
 \end{description}
 
-This chapter gives an overview of these services, describes how kernel
-objects are accessed by userspace applications, and describes how new
+This chapter gives an overview of these services and describes how kernel
+objects are accessed by userspace applications and how new
 objects can be created.
 
 \section{Capability-based Access Control}
@@ -173,7 +173,7 @@ The fundamental system calls are:
     section \ref{sec:faults}) when attempted with other capability types.
 
     In the MCS configuration, \emph{Receive} takes a reply capability---a
-    capability to a reply object--as a parameter.
+    capability to a reply object---as a parameter.
 \end{description}
 
 % TODO: seL4_Recv() gets hyphenated as
@@ -281,7 +281,7 @@ manipulation, and combination of these kernel objects:
        CPU time in seL4. Users can create scheduling contexts from untyped objects, however on
        creation scheduling contexts are \textit{empty} and do not represent any time.
        Initially, there is a capability to \obj{SchedControl} for each node, which
-       allows scheduling context to be populated with parameters, which combined with priority
+       allows scheduling context to be populated with parameters, which when combined with a priority
        control thread's access to CPU time.
 
     \item[\obj{Endpoints}] (see \autoref{ch:ipc}) facilitate message-passing
@@ -376,7 +376,7 @@ more of its clients.
 
 Untyped memory objects represent two different types of memory:
 general purpose memory, or device memory.
-\emph{General purpose} memory can be untyped into any other object
+\emph{General purpose} memory can be retyped into any other object
 type and used for any operation on untyped memory provided by the kernel.
 \emph{Device memory} covers memory regions reserved for devices
 as determined by the hardware platform, and usage of these objects
@@ -386,13 +386,13 @@ is restricted by the kernel in the following ways:
 \item Device untyped objects can only be retyped into frames or other
 untyped objects; developers cannot, for example, create an endpoint from device memory.
 \item Frame objects retyped from device untyped objects cannot be set as thread IPC buffers, or used
-in the creation of an ASID pool
+in the creation of an ASID pool.
 \end{itemize}
 
 The type attribute (whether it represents \emph{general purpose} or
 \emph{device} memory) of a child untyped object is inherited from its
-parent untyped object. That is, any child of a device untyped will
-also be a device untyped. Developers cannot change the type attribute of an untyped.
+parent untyped object. That is, any child of a device untyped object will
+also be a device untyped object. Developers cannot change the type attribute of an untyped object.
 
 \subsection{Reusing Memory}
 \label{s:memRevoke}
@@ -452,7 +452,7 @@ When retyping untyped memory it is useful to know how much memory the
 object will require. Object sizes are defined in libsel4.
 
 Note that \obj{CNode}s, \obj{SchedContext}s (MCS only), and \obj{Untyped Object}s
-have variables sizes. When retyping untyped memory into \obj{CNode}s
+have variable sizes. When retyping untyped memory into \obj{CNode}s
 or \obj{SchedContext}s, or breaking an
 \obj{Untyped Object} into smaller \obj{Untyped Object}s, the
 \texttt{size\_bits} argument to

--- a/manual/parts/threads.tex
+++ b/manual/parts/threads.tex
@@ -123,7 +123,7 @@ thread to run for more than $b$ out of every $p$ microseconds. However, $\frac{b
 represent a lower bound on execution, as a thread must have the highest or equal highest priority
 of all runnable threads to be guaranteed to be scheduled at all, and the kernel does not conduct
 an admission test. As a result the set of all parameters is not necessarily schedulable. If
-multiple threads have available budget concurrently they are scheduled first-in first-out, and
+multiple threads have budgets available concurrently they are scheduled first-in first-out, and
 round-robin scheduling is applied once the budget is expired.
 
 A scheduling context that is eligible to be picked by the scheduler, i.e has budget available, is
@@ -150,7 +150,7 @@ While a thread is executing, it constantly drains the budget from the \texttt{rA
 replenishment list. If the \texttt{rTime} is in the future, the thread bound to that
 scheduling context is placed in a queue of threads waiting for more budget.
 
-Round-robin threads are treated that same as sporadic threads except for one case: how the
+Round-robin threads are treated that same as sporadic threads except regarding one aspect: how the
 budget is charged. Round-robin threads have two refills only, both of which are always ready to be
 used. When a round-robin thread stops executing, budget is moved from the head to the tail
 replenishment. Once the head budget is consumed, the thread is removed from the scheduling queue
@@ -169,7 +169,7 @@ value of 2 and is limited by the size of the scheduling context.
 
 Threads that have short execution times (e.g interrupt handlers) and are not frequently preempted
 should have less refills, while longer running threads with long values of $b$ should have a higher
-value. Threads bound to a scheduling context with 0 extra refills will behave periodically -- tasks
+value. Threads bound to a scheduling context with 0 extra refills will run periodically -- tasks
 that use their head replenishment, or call yield, will not be scheduled again until the start of
 their next period.
 
@@ -177,7 +177,7 @@ Given the number of replenishments is limited, if a node's SC changes and the ou
 have enough space to store the new replenishment, space is created by removing the current
 replenishment which can result in preemption if the next replenishment is not yet available.
 Scheduling contexts with a higher number of configured refills will consume closer
-to their whole budget, as they can be preempted or switch threads more often without filling their
+to their whole budget, as they can be preempted and switch threads more often without filling their
 replenishment queue. However, the scheduling overhead will be higher as the replenishment list is
 subject to fragmentation.
 
@@ -197,7 +197,7 @@ Threads can be unbound from a scheduling context with
 \apifunc{seL4\_SchedContext\_UnbindObject}{schedcontext_unbindobject}.  This is distinct from
 suspending a thread, in that threads that are blocked waiting in an endpoint or notification queue
 will remain in the queue and can still receive messages and signals.  However, the unbound thread
-will not be schedulable again until it receives a scheduling context.  Threads without scheduling
+will not be schedul\-able again until it receives a scheduling context.  Threads without scheduling
 contexts are referred to as \emph{passive} threads, as they cannot execute without the action of
 another thread.
 
@@ -251,7 +251,7 @@ invoked, the scheduling context will return to A.
 \apifunc{seL4\_NBSendRecv}{sel4_nbsendrecv} can also result in scheduling context donation.
 If the non-blocking send phase of the operation results in message delivery to a passive thread, the
 scheduling context will be donated to that passive thread and the thread making the system call becomes passive on the
-receiving endpoint in the receive phase.  No reply capability generated, so there
+receiving endpoint in the receive phase.  No reply capability is generated, so there
 is no guarantee that the scheduling context will return, which increases book keeping complexity but allows
 for data-flow like architectures rather than remote-procedure calls. Note that \apifunc{seL4\_Call}{sel4_call}
 does not guarantee the return of a scheduling context: this is an inherently trusted operation as the
@@ -284,7 +284,7 @@ Threads of sufficient maximum controlled priority and with possession of the
 appropriate scheduling context capability can manipulate the scheduler and
 implement user-level schedulers using IPC.
 
-Scheduling contexts provide access to and an upper bound on execution CPU time,
+Scheduling contexts provide access to an upper bound on execution CPU time,
 however when a thread executes is determined by thread priority.  Consequently,
 access to CPU is a function of thread MCPs, scheduling contexts and the
 \obj{SchedControl} capability.  The kernel will enforce that threads do not
@@ -304,7 +304,7 @@ sends this to the endpoint. This thread can then take the appropriate action.
 Fault IPC messages are described in \autoref{sec:faults}.  Standard exception-handler
 endpoints can be set with the \apifunc{seL4\_TCB\_SetSpace}{tcb_setspace} or
 \apifunc{seL4\_TCB\_SetSchedParams}{tcb_setschedparams} methods while Timeout exception
-handlers an be set with \apifunc{seL4\_TCB\_SetTimeoutEndpoint}{tcb_settimeoutendpoint} (MCS only).
+handlers can be set with \apifunc{seL4\_TCB\_SetTimeoutEndpoint}{tcb_settimeoutendpoint} (MCS only).
 With these methods, a
 capability address for the exception handler can be associated with a thread.
 This address is then used to lookup the handler endpoint, and the capability to
@@ -553,10 +553,14 @@ can be configured as single-steppers, to one at any given time. The register tha
 is currently configured (if any) for single-stepping will be the implicit
 \texttt{bp\_num} argument in a single-step debug fault reply.
 
-The kernel's single-stepping, also supports skipping a certain number of
+% The description for skipping num_instructions had an off-by-one error
+% I.e. num_instruction = 1 does not skip any instructions between stopps
+% num_instruction = 2 "skips" 1 instruction, but executes 2 instructions before stopping
+
+The kernel's single-stepping, also supports executing a certain number of
 instructions before delivering the single-step fault message. \texttt{Num\_instructions}
-should be set to \texttt{1} when single-stepping, or any non-zero integer value to skip that many
-instructions before resuming single-stepping. This skip-count can also be set in
+should be set to \texttt{1} when single-stepping, or any non-zero integer value to execute that many
+instructions before resuming single-stepping. This execution-count can also be set in
 the fault-reply to a single-step debug fault.
 
 \begin{table}[h]
@@ -564,7 +568,7 @@ the fault-reply to a single-step debug fault.
 \toprule
 \textbf{Value sent} & \textbf{Register set by reply} & \textbf{IPC buffer location} \\
 \midrule
-\reg{Breakpoint instruction address} & \texttt{num\_instructions} to skip & \ipcbloc{IPCBuffer[0]} \\
+\reg{Breakpoint instruction address} & \texttt{num\_instructions} to execute & \ipcbloc{IPCBuffer[0]} \\
 \reg{Exception reason} & --- & \ipcbloc{IPCBuffer[1]} \\
 \bottomrule
 \end{tabularx}
@@ -593,6 +597,8 @@ in the same format as outlined in \autoref{sec:read_write_registers}.
     consumed since last reset & \ipcbloc{seL4\_TimeoutFault\_Consumed\_LowBits}
     \\ \bottomrule \end{tabularx}\\ \\ \caption{\label{tbl:tf_message_32}
     Timeout fault outcome on 32-bit architectures.} \end{table}
+
+% TODO: describe outcome for 64-bit architectures
 
 \subsection{VM Fault}
 \label{sec:vm-fault}

--- a/manual/parts/vspace.tex
+++ b/manual/parts/vspace.tex
@@ -320,7 +320,7 @@ can be updated on existing mappings using the Map invocation with the same virtu
       \texttt{seL4\_x86\_WriteBack} & Read and writes are cached \\
       \texttt{seL4\_x86\_CacheDisabled} & Prevent data in this mapping
       from being cached \\
-      \texttt{seL4\_x86\_WriteThrough} & Enable write through cacheing for this mapping \\
+      \texttt{seL4\_x86\_WriteThrough} & Enable write through caching for this mapping \\
       \texttt{seL4\_x86\_WriteCombining} & Enable write combining for this mapping \\
       \bottomrule
     \end{tabularx}


### PR DESCRIPTION
I reviewed the user manual up to before section 10.7 (part 1) with regard to typos and consistency. Since I am neither a native speaker nor an expert, please review my changes, thanks.