### PR TITLE
Make write-only mapping message consistent

### DIFF
--- a/src/arch/riscv/kernel/vspace.c
+++ b/src/arch/riscv/kernel/vspace.c
@@ -641,6 +641,11 @@ vm_rights_t CONST maskVMRights(vm_rights_t vm_rights, seL4_CapRights_t cap_right
             return VMReadWrite;
         }
     }
+    if (vm_rights == VMReadWrite &&
+        !seL4_CapRights_get_capAllowRead(cap_rights_mask) &&
+        seL4_CapRights_get_capAllowWrite(cap_rights_mask)) {
+        userError("Attempted to make unsupported write only mapping");
+    }
     return VMKernelOnly;
 }
 

--- a/src/arch/x86/kernel/vspace.c
+++ b/src/arch/x86/kernel/vspace.c
@@ -682,6 +682,11 @@ vm_rights_t CONST maskVMRights(vm_rights_t vm_rights, seL4_CapRights_t cap_right
             return VMReadWrite;
         }
     }
+    if (vm_rights == VMReadWrite &&
+        !seL4_CapRights_get_capAllowRead(cap_rights_mask) &&
+        seL4_CapRights_get_capAllowWrite(cap_rights_mask)) {
+        userError("Attempted to make unsupported write only mapping");
+    }
     return VMKernelOnly;
 }
 


### PR DESCRIPTION
There is a warning when creating a write-only mapping on AArch32/AArch64.

This patch simply makes the message consistent across all architectures since the behaviour when creating a write-only mapping is also consistent across all architectures.

`x86/kernel/vspace.c` is used for x86 and ia32 right?