### PR TITLE
ioapic: set IOAPIC_IRQ_LINES to max allowed

### DIFF
--- a/include/plat/pc99/plat/machine.h
+++ b/include/plat/pc99/plat/machine.h
@@ -9,7 +9,7 @@
 #include <machine/interrupt.h>
 
 #define PIC_IRQ_LINES 16
-#define IOAPIC_IRQ_LINES 24
+#define IOAPIC_IRQ_LINES 240
 
 /* interrupt vectors (corresponds to IDT entries) */
 


### PR DESCRIPTION
Correctly mask the IOAPICVER register to the Maximum Redirection Entry field to potential avoid spurious higher bits on e.g. AMD processors.

Set IOAPIC_IRQ_LINES to the maximum value this field is allowed to return (239+1). While our `haswell` machines report 24 IRQ lines as expected, the `skylake` machines report 120.

The only impact should be the size of the ioredtbl_state array.

Sources: it was extremely hard to find actual docs for the IOAPIC. The Intel manual was not helpful. [This ancient PDF](https://pdos.csail.mit.edu/6.828/2016/readings/ia32/ioapic.pdf) had information on the register format, max value, and masking requirements, which I followed here. This seems to be consistent with what FreeBSD does in e.g. [apicreg.h](https://cocalc.com/github/freebsd/freebsd-src/blob/main/sys/x86/include/apicreg.h).