### PR TITLE
github: use default Isabelle version for proofs

### DIFF
--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -43,7 +43,6 @@ jobs:
       with:
         L4V_ARCH: ${{ matrix.arch }}
         L4V_FEATURES: ${{ matrix.features }}
-        isa_branch: ts-2023
         session: ${{ matrix.session }}
         manifest: ${{ matrix.features == 'MCS' && 'mcs.xml' || 'default.xml' }}
       env:


### PR DESCRIPTION
Use the Isabelle version set in the verification manifest instead of overriding to a specific version here. This will automatically update as the verification repository updates to new Isabelle versions.