### PR TITLE
mcs: rewrite guard in preemptionPoint

### DIFF
--- a/src/model/preemption.c
+++ b/src/model/preemption.c
@@ -30,8 +30,8 @@ exception_t preemptionPoint(void)
         ksWorkUnitsCompleted = 0;
 #ifdef CONFIG_KERNEL_MCS
         updateTimestamp();
-        if (!(sc_active(NODE_STATE(ksCurSC)) && refill_sufficient(NODE_STATE(ksCurSC), NODE_STATE(ksConsumed)))
-            || isCurDomainExpired() || isIRQPending()) {
+        if (isIRQPending() || isCurDomainExpired()
+            || !(sc_active(NODE_STATE(ksCurSC)) && refill_sufficient(NODE_STATE(ksCurSC), NODE_STATE(ksConsumed)))) {
 #else
         if (isIRQPending()) {
 #endif


### PR DESCRIPTION
This reorders the guard in one of the if statements in preemptionPoint to first check isIRQPending, since it is the most likely cause of this guard being true. This also eases verification.