### PR TITLE
arm: add missing `seL4_VPPIEvent_Length` constants

### DIFF
--- a/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/constants.h
@@ -61,6 +61,7 @@ typedef enum {
 
 typedef enum {
     seL4_VPPIEvent_IRQ,
+    seL4_VPPIEvent_Length,
     SEL4_FORCE_LONG_ENUM(seL4_VPPIEvent_Msg),
 } seL4_VPPIEvent_Msg;
 

--- a/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
@@ -60,6 +60,7 @@ typedef enum {
 
 typedef enum {
     seL4_VPPIEvent_IRQ,
+    seL4_VPPIEvent_Length,
     SEL4_FORCE_LONG_ENUM(seL4_VPPIEvent_Msg),
 } seL4_VPPIEvent_Msg;
 


### PR DESCRIPTION
`*_Length` constants exist for all `*_Msg` enums except for `seL4_VPPIEvent_Msg`.