### PR TITLE
DRAFT: domain,fpu: Reset FPU on domain switch

### DIFF
--- a/src/kernel/thread.c
+++ b/src/kernel/thread.c
@@ -308,6 +308,11 @@ static void nextDomain(void)
 #ifdef CONFIG_KERNEL_MCS
     NODE_STATE(ksReprogram) = true;
 #endif
+#if defined(CONFIG_HAVE_FPU) && CONFIG_NUM_DOMAINS > 1
+    // Reset FPU state on domain switch.
+    // Domains > 1 and SMP are not supported.
+    switchFpuOwner(NULL, SMP_TERNARY(assert(0), 0));
+#endif
     ksWorkUnitsCompleted = 0;
     ksCurDomain = ksDomSchedule[ksDomScheduleIdx].domain;
 #ifdef CONFIG_KERNEL_MCS


### PR DESCRIPTION
The FPU is lazily switched to allow lower latency context switching when only some threads in the system are accessing the FPU. However domain switching should cause any FPU state to be written back the thread eagerly to avoid writing the state back from a different domain.