### PR TITLE
config.py: fix SUPERSECTION_BITS for arm_hyp

### DIFF
--- a/tools/hardware/config.py
+++ b/tools/hardware/config.py
@@ -54,7 +54,7 @@ class ARMConfig(Config):
         self.SUPERSECTION_BITS = 25 if sel4arch == 'arm_hyp' else 24
 
     def get_kernel_phys_align(self) -> int:
-        ''' on ARM the ELF loader expects to be able to map a supersection page to load the kernel. '''
+        ''' On AArch32 the kernel requires at least super section alignment for physBase. '''
         return self.SUPERSECTION_BITS
 
     def align_memory(self, regions: Set[Region]) -> List[Region]:

--- a/tools/hardware/config.py
+++ b/tools/hardware/config.py
@@ -48,7 +48,10 @@ class Config:
 class ARMConfig(Config):
     ''' Config class for ARM '''
     arch = 'arm'
-    SUPERSECTION_BITS = 24  # 2^24 = 16 MiByte
+
+    def __init__(self, sel4arch, addrspace_max):
+        super().__init__(sel4arch, addrspace_max)
+        self.SUPERSECTION_BITS = 25 if sel4arch == 'arm_hyp' else 24
 
     def get_kernel_phys_align(self) -> int:
         ''' on ARM the ELF loader expects to be able to map a supersection page to load the kernel. '''


### PR DESCRIPTION
This addresses #1186

It's not entirely clear to me what this does for AArch64 -- is that code used there?