### PR TITLE
move cache flush from untyped reset to retype

### DIFF
--- a/include/arch/arm/arch/machine.h
+++ b/include/arch/arm/arch/machine.h
@@ -42,12 +42,10 @@ void cleanInvalidate_L1D(void);
 void cleanCaches_PoU(void);
 void cleanInvalidateL1Caches(void);
 
-/* Cleaning memory before user-level access */
+/* Cleaning memory before user-level access. Does not flush cache. */
 static inline void clearMemory(word_t *ptr, word_t bits)
 {
     memzero(ptr, BIT(bits));
-    cleanCacheRange_RAM((word_t)ptr, (word_t)ptr + BIT(bits) - 1,
-                        addrFromPPtr(ptr));
 }
 
 /* Cleaning memory before page table walker access */

--- a/include/arch/riscv/arch/machine.h
+++ b/include/arch/riscv/arch/machine.h
@@ -146,7 +146,7 @@ static inline void hwASIDFlush(asid_t asid)
 word_t PURE getRestartPC(tcb_t *thread);
 void setNextPC(tcb_t *thread, word_t v);
 
-/* Cleaning memory before user-level access */
+/* Cleaning memory before user-level access. Does not flush cache. */
 static inline void clearMemory(void *ptr, unsigned int bits)
 {
     memzero(ptr, BIT(bits));

--- a/include/arch/x86/arch/machine.h
+++ b/include/arch/x86/arch/machine.h
@@ -339,11 +339,10 @@ static inline void x86_load_fsgs_base(tcb_t *thread, cpu_id_t cpu)
     x86_write_gs_base(gs_base, cpu);
 }
 
-/* Cleaning memory before user-level access */
+/* Cleaning memory before user-level access. Does not flush cache. */
 static inline void clearMemory(void *ptr, unsigned int bits)
 {
     memzero(ptr, BIT(bits));
-    /* no cleaning of caches necessary on IA-32 */
 }
 
 /* Initialises MSRs required to setup sysenter and sysexit */

--- a/src/arch/arm/32/object/objecttype.c
+++ b/src/arch/arm/32/object/objecttype.c
@@ -392,6 +392,9 @@ cap_t Arch_createObject(object_t t, void *regionBase, word_t userSize, bool_t de
             /** GHOSTUPD: "(True, gs_new_frames vmpage_size.ARMSmallPage
                                                     (ptr_val \<acute>regionBase)
                                                     (unat ARMSmallPageBits))" */
+            cleanCacheRange_RAM((word_t)regionBase,
+                                (word_t)regionBase + MASK(pageBitsForSize(ARMSmallPage)),
+                                addrFromPPtr(regionBase));
         }
         return cap_small_frame_cap_new(
                    ASID_LOW(asidInvalid), VMReadWrite,
@@ -415,6 +418,9 @@ cap_t Arch_createObject(object_t t, void *regionBase, word_t userSize, bool_t de
             /** GHOSTUPD: "(True, gs_new_frames vmpage_size.ARMLargePage
                                                     (ptr_val \<acute>regionBase)
                                                     (unat ARMLargePageBits))" */
+            cleanCacheRange_RAM((word_t)regionBase,
+                                (word_t)regionBase + MASK(pageBitsForSize(ARMLargePage)),
+                                addrFromPPtr(regionBase));
         }
         return cap_frame_cap_new(
                    ARMLargePage, ASID_LOW(asidInvalid), VMReadWrite,
@@ -444,6 +450,9 @@ cap_t Arch_createObject(object_t t, void *regionBase, word_t userSize, bool_t de
             /** GHOSTUPD: "(True, gs_new_frames vmpage_size.ARMSection
                                             (ptr_val \<acute>regionBase)
                                             (unat ARMSectionBits))" */
+            cleanCacheRange_RAM((word_t)regionBase,
+                                (word_t)regionBase + MASK(pageBitsForSize(ARMSection)),
+                                addrFromPPtr(regionBase));
         }
         return cap_frame_cap_new(
                    ARMSection, ASID_LOW(asidInvalid), VMReadWrite,
@@ -473,6 +482,9 @@ cap_t Arch_createObject(object_t t, void *regionBase, word_t userSize, bool_t de
             /** GHOSTUPD: "(True, gs_new_frames vmpage_size.ARMSuperSection
                                                 (ptr_val \<acute>regionBase)
                                                 (unat ARMSuperSectionBits))" */
+            cleanCacheRange_RAM((word_t)regionBase,
+                                (word_t)regionBase + MASK(pageBitsForSize(ARMSuperSection)),
+                                addrFromPPtr(regionBase));
         }
         return cap_frame_cap_new(
                    ARMSuperSection, ASID_LOW(asidInvalid), VMReadWrite,
@@ -487,7 +499,9 @@ cap_t Arch_createObject(object_t t, void *regionBase, word_t userSize, bool_t de
         /** AUXUPD: "(True, ptr_retyps 1
               (Ptr (ptr_val \<acute>regionBase) :: (pte_C[256]) ptr))" */
 #endif /* CONFIG_ARM_HYPERVISOR_SUPPORT */
-
+        cleanCacheRange_PoU((word_t)regionBase,
+                            (word_t)regionBase + MASK(seL4_PageTableBits),
+                            addrFromPPtr(regionBase));
         return cap_page_table_cap_new(false, asidInvalid, 0,
                                       (word_t)regionBase);
 
@@ -500,8 +514,9 @@ cap_t Arch_createObject(object_t t, void *regionBase, word_t userSize, bool_t de
               (Ptr (ptr_val \<acute>regionBase) :: (pde_C[4096]) ptr))" */
 #endif /* CONFIG_ARM_HYPERVISOR_SUPPORT */
         copyGlobalMappings((pde_t *)regionBase);
+        /* Clean the entire PD to PoU for table walker */
         cleanCacheRange_PoU((word_t)regionBase,
-                            (word_t)regionBase + (1 << (PD_INDEX_BITS + PDE_SIZE_BITS)) - 1,
+                            (word_t)regionBase + MASK(seL4_PageDirBits),
                             addrFromPPtr(regionBase));
 
         return cap_page_directory_cap_new(false, asidInvalid,
@@ -516,10 +531,8 @@ cap_t Arch_createObject(object_t t, void *regionBase, word_t userSize, bool_t de
 
 #ifdef CONFIG_TK1_SMMU
     case seL4_ARM_IOPageTableObject:
-        /* When the untyped was zeroed it was cleaned to the PoU, but the SMMUs
-         * typically pull directly from RAM, so we do a futher clean to RAM here */
         cleanCacheRange_RAM((word_t)regionBase,
-                            (word_t)regionBase + (1 << seL4_IOPageTableBits) - 1,
+                            (word_t)regionBase + MASK(seL4_IOPageTableBits),
                             addrFromPPtr(regionBase));
         return cap_io_page_table_cap_new(0, asidInvalid, (word_t)regionBase, 0);
 #endif

--- a/src/arch/arm/64/object/objecttype.c
+++ b/src/arch/arm/64/object/objecttype.c
@@ -350,6 +350,9 @@ cap_t Arch_createObject(object_t t, void *regionBase, word_t userSize, bool_t de
             /** GHOSTUPD: "(True, gs_new_frames vmpage_size.ARMSmallPage
                                                     (ptr_val \<acute>regionBase)
                                                     (unat ARMSmallPageBits))" */
+            cleanCacheRange_RAM((word_t)regionBase,
+                                (word_t)regionBase + MASK(pageBitsForSize(ARMSmallPage)),
+                                addrFromPPtr(regionBase));
         }
         return cap_frame_cap_new(
                    asidInvalid,           /* capFMappedASID */
@@ -373,6 +376,9 @@ cap_t Arch_createObject(object_t t, void *regionBase, word_t userSize, bool_t de
             /** GHOSTUPD: "(True, gs_new_frames vmpage_size.ARMLargePage
                                                     (ptr_val \<acute>regionBase)
                                                     (unat ARMLargePageBits))" */
+            cleanCacheRange_RAM((word_t)regionBase,
+                                (word_t)regionBase + MASK(pageBitsForSize(ARMLargePage)),
+                                addrFromPPtr(regionBase));
         }
         return cap_frame_cap_new(
                    asidInvalid,           /* capFMappedASID */
@@ -396,6 +402,9 @@ cap_t Arch_createObject(object_t t, void *regionBase, word_t userSize, bool_t de
             /** GHOSTUPD: "(True, gs_new_frames vmpage_size.ARMHugePage
                                                     (ptr_val \<acute>regionBase)
                                                     (unat ARMHugePageBits))" */
+            cleanCacheRange_RAM((word_t)regionBase,
+                                (word_t)regionBase + MASK(pageBitsForSize(ARMHugePage)),
+                                addrFromPPtr(regionBase));
         }
         return cap_frame_cap_new(
                    asidInvalid,           /* capFMappedASID */
@@ -406,8 +415,13 @@ cap_t Arch_createObject(object_t t, void *regionBase, word_t userSize, bool_t de
                    !!deviceMemory         /* capFIsDevice */
                );
     case seL4_ARM_VSpaceObject:
+        /** AUXUPD: "(True, ptr_retyps 1
+              (Ptr (ptr_val \<acute>regionBase) :: (pte_C[vs_array_len]) ptr))" */
+        /** GHOSTUPD: "(True, gs_new_pt_t VSRootPT_T (ptr_val \<acute>regionBase))" */
+        cleanCacheRange_PoU((word_t)regionBase,
+                            (word_t)regionBase + MASK(seL4_VSpaceBits),
+                            addrFromPPtr(regionBase));
 #ifdef CONFIG_ARM_SMMU
-
         return cap_vspace_cap_new(
                    asidInvalid,           /* capVSMappedASID */
                    (word_t)regionBase,    /* capVSBasePtr    */
@@ -415,10 +429,6 @@ cap_t Arch_createObject(object_t t, void *regionBase, word_t userSize, bool_t de
                    CB_INVALID             /* capVSMappedCB   */
                );
 #else
-
-        /** AUXUPD: "(True, ptr_retyps 1
-              (Ptr (ptr_val \<acute>regionBase) :: (pte_C[vs_array_len]) ptr))" */
-        /** GHOSTUPD: "(True, gs_new_pt_t VSRootPT_T (ptr_val \<acute>regionBase))" */
         return cap_vspace_cap_new(
                    asidInvalid,           /* capVSMappedASID */
                    (word_t)regionBase,    /* capVSBasePtr    */
@@ -429,6 +439,9 @@ cap_t Arch_createObject(object_t t, void *regionBase, word_t userSize, bool_t de
         /** AUXUPD: "(True, ptr_retyps 1
               (Ptr (ptr_val \<acute>regionBase) :: (pte_C[pt_array_len]) ptr))" */
         /** GHOSTUPD: "(True, gs_new_pt_t NormalPT_T (ptr_val \<acute>regionBase))" */
+        cleanCacheRange_PoU((word_t)regionBase,
+                            (word_t)regionBase + MASK(seL4_PageTableBits),
+                            addrFromPPtr(regionBase));
         return cap_page_table_cap_new(
                    asidInvalid,           /* capPTMappedASID    */
                    (word_t)regionBase,    /* capPTBasePtr       */


### PR DESCRIPTION
Do not perform cache flushing in clearMemory. Instead flush the cache only for those object types where it is necessary, and only when the object is retyped, not when the untyped cap is reset.

This reduces overall need for flushing and delays it to the point of use. This should speed up boot time significantly, but may impact WCET, because the largest flush is now the largest page size (e.g. 24) instead of CONFIG_RESET_CHUNK_BITS (8). The user could already request a flush of the largest page size before, though, so it this may not actually impact WCET. Remains to be investigated.

Why this is safe:

- Flushing is only necessary for objects that are seen by other parts of the system, not for kernel-internal object. These objects are non-device frames (including IOMMU pages) and page tables. All other objects are only read/written by the kernel or are never read/written by the kernel (device frames + untypeds). Frames need to be flushed to RAM (as clearMemory did), because they could be seen uncached by devices. Page tables only to PoU for the page table walker.

- Before createNewObject in retype, these objects do not exist and cannot be seen by any part of the system. createNewObject is the point where new objects can become visible to the user.

- Theoretically, we could defer flushing further to the point where frames or page tables are mapped, but it is more complex to track whether a flush has already happened when they are mapped multiple times, whereas at retype the object cannot have been flushed already.

- The original implementation, before clearing memory was moved into reset untyped, also flushed at the same points.

This implements option 2 of the discussion in #481