### PR TITLE
configs: add zynqmp and rpi4 to verified platforms

### DIFF
--- a/CAVEATS.md
+++ b/CAVEATS.md
@@ -17,7 +17,7 @@ architectures is on the roadmap and expected in 2025.
   - Platforms (non-hyp): `sabre` (no FPU), `imx8mm-evk` (with FPU)
   - Platforms (hyp, no FPU): `tk1`, `exynos5`
 - AArch64: Armv8-a with hypervisor extensions only, no SMMU, with fast path
-  - Platforms: `tx2`
+  - Platforms: `tx2`, `zynqmp`, `bcm2711` (rpi4)
 - RISC-V: 64-bit only, no fast path
   - Platforms: `hifive`
 - x64: without VT-x and VT-d, no fast path

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,8 +25,10 @@ description indicates whether it is SOURCE-COMPATIBLE, BINARY-COMPATIBLE, or BRE
 
 ### Changes
 
+* Added `zynqmp` and `rpi4` to the set of verified AArch64 configs.
 
 ### Upgrade Notes
+
 ---
 
 ## 13.0.0 2024-07-01: BREAKING

--- a/configs/AARCH64_bcm2711_verified.cmake
+++ b/configs/AARCH64_bcm2711_verified.cmake
@@ -1,0 +1,26 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2022, Proofcraft Pty Ltd
+# Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+# If this file is executed then build the kernel.elf and kernel_all_pp.c file
+include(${CMAKE_CURRENT_LIST_DIR}/../tools/helpers.cmake)
+cmake_script_build_kernel()
+
+set(KernelPlatform "bcm2711" CACHE STRING "")
+set(KernelSel4Arch "aarch64" CACHE STRING "")
+set(KernelArmHypervisorSupport ON CACHE BOOL "")
+set(KernelVerificationBuild ON CACHE BOOL "")
+set(KernelMaxNumNodes "1" CACHE STRING "")
+set(KernelOptimisation "-O2" CACHE STRING "")
+set(KernelRetypeFanOutLimit "256" CACHE STRING "")
+set(KernelBenchmarks "none" CACHE STRING "")
+set(KernelDangerousCodeInjection OFF CACHE BOOL "")
+set(KernelFastpath ON CACHE BOOL "")
+set(KernelPrinting OFF CACHE BOOL "")
+set(KernelNumDomains 16 CACHE STRING "")
+set(KernelMaxNumBootinfoUntypedCaps 50 CACHE STRING "")
+set(KernelArmSMMU OFF CACHE BOOL "")

--- a/configs/AARCH64_zynqmp_verified.cmake
+++ b/configs/AARCH64_zynqmp_verified.cmake
@@ -1,0 +1,26 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2022, Proofcraft Pty Ltd
+# Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+# If this file is executed then build the kernel.elf and kernel_all_pp.c file
+include(${CMAKE_CURRENT_LIST_DIR}/../tools/helpers.cmake)
+cmake_script_build_kernel()
+
+set(KernelPlatform "zynqmp" CACHE STRING "")
+set(KernelSel4Arch "aarch64" CACHE STRING "")
+set(KernelArmHypervisorSupport ON CACHE BOOL "")
+set(KernelVerificationBuild ON CACHE BOOL "")
+set(KernelMaxNumNodes "1" CACHE STRING "")
+set(KernelOptimisation "-O2" CACHE STRING "")
+set(KernelRetypeFanOutLimit "256" CACHE STRING "")
+set(KernelBenchmarks "none" CACHE STRING "")
+set(KernelDangerousCodeInjection OFF CACHE BOOL "")
+set(KernelFastpath ON CACHE BOOL "")
+set(KernelPrinting OFF CACHE BOOL "")
+set(KernelNumDomains 16 CACHE STRING "")
+set(KernelMaxNumBootinfoUntypedCaps 50 CACHE STRING "")
+set(KernelArmSMMU OFF CACHE BOOL "")


### PR DESCRIPTION
The AARCH64 config now also works for functional correctness for zcu102/zcu106 and rpi4.

Needs the corresponding l4v PR to be merged first.