### PR TITLE
fix parameter for log buffer cleanup

### DIFF
--- a/src/arch/arm/32/object/objecttype.c
+++ b/src/arch/arm/32/object/objecttype.c
@@ -195,7 +195,7 @@ finaliseCap_ret_t Arch_finaliseCap(cap_t cap, bool_t final)
                     ksUserLogBuffer = 0;
 
                     /* Invalidate log page table entries */
-                    clearMemory((void *) armKSGlobalLogPT, BIT(seL4_PageTableBits));
+                    clearMemory((void *) armKSGlobalLogPT, seL4_PageTableBits);
 
                     cleanCacheRange_PoU((pptr_t) &armKSGlobalLogPT[0],
                                         (pptr_t) &armKSGlobalLogPT[0] + BIT(seL4_PageTableBits),

--- a/src/arch/x86/32/object/objecttype.c
+++ b/src/arch/x86/32/object/objecttype.c
@@ -80,7 +80,7 @@ finaliseCap_ret_t Mode_finaliseCap(cap_t cap, bool_t final)
                         ksUserLogBuffer = 0;
 
                         /* Invalidate log page table entries */
-                        clearMemory(ia32KSGlobalLogPT, BIT(seL4_PageTableBits));
+                        clearMemory(ia32KSGlobalLogPT, seL4_PageTableBits);
 
                         for (int idx = 0; idx < BIT(PT_INDEX_BITS); idx++) {
                             invalidateTLBEntry(KS_LOG_PPTR + (idx << seL4_PageBits), MASK(ksNumCPUs));


### PR DESCRIPTION
I ran into this while reviewing https://github.com/seL4/seL4/pull/1289. It looks broken to pass the size here, as the function just expects the 2^n bit-size. This wipes the entire memory practically.
This came in with commit 16c34811.