### PR TITLE
bump autopep8 version

### DIFF
--- a/tools/python-deps/setup.py
+++ b/tools/python-deps/setup.py
@@ -46,6 +46,6 @@ setup(
     url="https://sel4.systems",
     licence='BSD2',
     author='TrustworthySystems',
-    author_email='Stephen.Sherratt@data61.csiro.au',
+    author_email='pypi@trustworthy.systems',
     install_requires=DEPS,
 )

--- a/tools/python-deps/setup.py
+++ b/tools/python-deps/setup.py
@@ -35,13 +35,13 @@ DEPS = [
     'pyfdt',
     'cmake-format==0.4.5',
     'guardonce',
-    'autopep8==1.4.3',
+    'autopep8==2.3.1',
     'libarchive-c',
 ]
 
 setup(
     name='sel4-deps',
-    version='0.4.0',
+    version='0.5.0',
     description='Metapackage for downloading build dependencies for the seL4 microkernel',
     url="https://sel4.systems",
     licence='BSD2',


### PR DESCRIPTION
See also https://github.com/seL4/ci-actions/issues/329, our old version of autopep8 crashes on more recent python code. Layout should be stable.

- bump version of autopep8
- bump version of sel4-deps
- update maintainer email