### PR TITLE
sel4-deps: tighten deps; update instructions

### DIFF
--- a/tools/python-deps/setup.py
+++ b/tools/python-deps/setup.py
@@ -10,11 +10,16 @@ Setup script for dependency metapackage.
 
 To add a python dependency, add it to the DEPS list below.
 
+To publish using these instructions, you need the virtualenv package installed,
+and a ~/.pypirc file with authentication setup for testpypi and pypi.
+
 To publish to pypitest:
-python setup.py sdist upload -r pypitest
+python3 -m build
+twine upload -r testpypi dist/*
 
 To publish to pypi:
-python setup.py sdist upload -r pypi
+python3 -m build
+twine upload -r pypi dist/*
 """
 
 from setuptools import setup
@@ -30,7 +35,7 @@ DEPS = [
     'pyelftools',
     'sh',
     'pexpect',
-    'pyyaml>=5.1',
+    'pyyaml>=5.1,<6',
     'jsonschema',
     'pyfdt',
     'cmake-format==0.4.5',
@@ -41,11 +46,19 @@ DEPS = [
 
 setup(
     name='sel4-deps',
-    version='0.5.0',
+    version='0.6.0',
     description='Metapackage for downloading build dependencies for the seL4 microkernel',
+    long_description="""
+This meta package depends on all python packages you need to build the seL4 microkernel and manual.
+
+This package is maintained on <https://github.com/seL4/seL4>,
+in directory <https://github.com/seL4/seL4/tree/master/tools/python-deps>
+""",
+    long_description_content_type="text/markdown",
     url="https://sel4.systems",
     licence='BSD2',
     author='TrustworthySystems',
     author_email='pypi@trustworthy.systems',
     install_requires=DEPS,
+    python_requires='>=3'
 )


### PR DESCRIPTION
- require python >= 3
- require pyyaml < 6, because cmake-format breaks with pyyaml >= 6
- update upload instructions
- provide long-form release description of PyPi
- bump version, because the < 6 requirement might technically break compatibility