### PR TITLE
sel4-deps: cypthon >=3 breaks pyyaml < 6 at build

### DIFF
--- a/tools/python-deps/setup.py
+++ b/tools/python-deps/setup.py
@@ -35,7 +35,8 @@ DEPS = [
     'pyelftools',
     'sh',
     'pexpect',
-    'pyyaml>=5.1,<6',
+    'cython<3',  # build dependency for pyyaml 5; see https://github.com/yaml/pyyaml/issues/601
+    'pyyaml>=5.1,<5.4',  # <5.4 for cmake-format==0.4.5
     'jsonschema',
     'pyfdt',
     'cmake-format==0.4.5',


### PR DESCRIPTION
Require cython < 3, because >=3 breaks the install for pyyaml at build/install time for more recent python versions. The cython < 3 fix only works on pyyaml < 5.4, so we add < 5.4 there instead of < 6 (which was already required by cmake-format=0.4.5).

See also <https://github.com/yaml/pyyaml/issues/601>

sel4-deps 0.6.0 isn't published yet (yay for pypitest..), so no version bump.

This whole thing is getting somewhat frustrating, but this combination should at least work in a fresh install.