### PR TITLE
mcs: refactor awaken

### DIFF
--- a/include/object/tcb.h
+++ b/include/object/tcb.h
@@ -103,7 +103,6 @@ void tcbDebugRemove(tcb_t *tcb);
 #ifdef CONFIG_KERNEL_MCS
 void tcbReleaseRemove(tcb_t *tcb);
 void tcbReleaseEnqueue(tcb_t *tcb);
-tcb_t *tcbReleaseDequeue(void);
 #endif
 
 #ifdef ENABLE_SMP_SUPPORT

--- a/src/kernel/thread.c
+++ b/src/kernel/thread.c
@@ -679,22 +679,35 @@ void rescheduleRequired(void)
 }
 
 #ifdef CONFIG_KERNEL_MCS
+
+static inline bool_t PURE release_q_non_empty_and_ready(void)
+{
+    return NODE_STATE(ksReleaseQueue.head) != NULL
+           && refill_ready(NODE_STATE(ksReleaseQueue.head)->tcbSchedContext);
+}
+
+static void tcbReleaseDequeue(void)
+{
+    assert(NODE_STATE(ksReleaseQueue.head) != NULL);
+    assert(NODE_STATE(ksReleaseQueue.head)->tcbSchedPrev == NULL);
+    SMP_COND_STATEMENT(assert(NODE_STATE(ksReleaseQueue.head)->tcbAffinity == getCurrentCPUIndex()));
+
+    tcb_t *awakened = NODE_STATE(ksReleaseQueue.head);
+    assert(awakened != NODE_STATE(ksCurThread));
+    tcbReleaseRemove(awakened);
+    /* round robin threads should not be in the release queue */
+    assert(!isRoundRobin(awakened->tcbSchedContext));
+    /* threads should wake up on the correct core */
+    SMP_COND_STATEMENT(assert(awakened->tcbAffinity == getCurrentCPUIndex()));
+    /* threads HEAD refill should always be >= MIN_BUDGET */
+    assert(refill_sufficient(awakened->tcbSchedContext, 0));
+    possibleSwitchTo(awakened);
+}
+
 void awaken(void)
 {
-    while (unlikely(NODE_STATE(ksReleaseQueue.head) != NULL
-                    && refill_ready(NODE_STATE(ksReleaseQueue.head)->tcbSchedContext))) {
-        tcb_t *awakened = tcbReleaseDequeue();
-        /* the currently running thread cannot have just woken up */
-        assert(awakened != NODE_STATE(ksCurThread));
-        /* round robin threads should not be in the release queue */
-        assert(!isRoundRobin(awakened->tcbSchedContext));
-        /* threads should wake up on the correct core */
-        SMP_COND_STATEMENT(assert(awakened->tcbAffinity == getCurrentCPUIndex()));
-        /* threads HEAD refill should always be >= MIN_BUDGET */
-        assert(refill_sufficient(awakened->tcbSchedContext, 0));
-        possibleSwitchTo(awakened);
-        /* changed head of release queue -> need to reprogram */
-        NODE_STATE(ksReprogram) = true;
+    while (unlikely(release_q_non_empty_and_ready())) {
+        tcbReleaseDequeue();
     }
 }
 #endif

--- a/src/object/tcb.c
+++ b/src/object/tcb.c
@@ -333,19 +333,6 @@ void tcbReleaseEnqueue(tcb_t *tcb)
 
     thread_state_ptr_set_tcbInReleaseQueue(&tcb->tcbState, true);
 }
-
-tcb_t *tcbReleaseDequeue(void)
-{
-    assert(NODE_STATE(ksReleaseQueue.head) != NULL);
-    assert(NODE_STATE(ksReleaseQueue.head)->tcbSchedPrev == NULL);
-    SMP_COND_STATEMENT(assert(NODE_STATE(ksReleaseQueue.head)->tcbAffinity == getCurrentCPUIndex()));
-
-    tcb_t *detached_head = NODE_STATE(ksReleaseQueue.head);
-
-    tcbReleaseRemove(detached_head);
-
-    return detached_head;
-}
 #endif
 
 cptr_t PURE getExtraCPtr(word_t *bufferPtr, word_t i)


### PR DESCRIPTION
This refactors awaken, providing an inline function for the while loop condition, and modifying tcbReleaseDequeue to now perform the entire loop body.

Since tcbReleaseDequeue will perform tcbReleaseRemove on the head of the release queue, the variable ksReprogram will be set to true within tcbReleaseRemove, and therefore, we do not need to set this variable separately within the loop body of awaken.