### PR TITLE
thread state: abandon replyObject NULL invariant

### DIFF
--- a/include/fastpath/fastpath.h
+++ b/include/fastpath/fastpath.h
@@ -46,6 +46,8 @@ static inline void cancelIPC_fp(tcb_t *dest)
         endpoint_ptr_set_state(ep_ptr, EPState_Idle);
     }
 
+    /* we are in BlockedOnReceive, because fastpath_signal explicitly checks for it */
+    assert(thread_state_get_tsType(dest->tcbState) == ThreadState_BlockedOnReceive);
     reply_t *reply = REPLY_PTR(thread_state_get_replyObject(dest->tcbState));
     if (reply != NULL) {
         reply_unlink(reply, dest);

--- a/include/object/reply.h
+++ b/include/object/reply.h
@@ -13,12 +13,16 @@
 /* Unlink a reply from its tcb */
 static inline void reply_unlink(reply_t *reply, tcb_t *tcb)
 {
+    /* check that the tcb has a thread state with reply */
+    assert(thread_state_get_tsType(tcb->tcbState) == ThreadState_BlockedOnReceive ||
+           thread_state_get_tsType(tcb->tcbState) == ThreadState_BlockedOnReply);
+
     /* check the tcb and reply are linked correctly */
     assert(reply->replyTCB == tcb);
     assert(thread_state_get_replyObject(tcb->tcbState) == REPLY_REF(reply));
 
-    thread_state_ptr_set_replyObject(&tcb->tcbState, REPLY_REF(0));
     reply->replyTCB = NULL;
+    /* This means the value of the thread state reply reference no longer matters. */
     setThreadState(tcb, ThreadState_Inactive);
 }
 

--- a/src/fastpath/fastpath.c
+++ b/src/fastpath/fastpath.c
@@ -428,11 +428,6 @@ void NORETURN fastpath_reply_recv(word_t cptr, word_t msgInfo)
     }
 #endif /* ENABLE_SMP_SUPPORT */
 
-#ifdef CONFIG_KERNEL_MCS
-    /* not possible to set reply object and not be blocked */
-    assert(thread_state_get_replyObject(NODE_STATE(ksCurThread)->tcbState) == 0);
-#endif
-
     /*
      * --- POINT OF NO RETURN ---
      *

--- a/src/kernel/thread.c
+++ b/src/kernel/thread.c
@@ -139,7 +139,7 @@ void doReplyTransfer(tcb_t *sender, tcb_t *receiver, cte_t *slot, bool_t grant)
 
     tcb_t *receiver = reply->replyTCB;
     reply_remove(reply, receiver);
-    assert(thread_state_get_replyObject(receiver->tcbState) == REPLY_REF(0));
+    assert(thread_state_get_tsType(receiver->tcbState) == ThreadState_Inactive);
     assert(reply->replyTCB == NULL);
 
     if (sc_sporadic(receiver->tcbSchedContext)

--- a/src/object/endpoint.c
+++ b/src/object/endpoint.c
@@ -334,9 +334,11 @@ void cancelIPC(tcb_t *tptr)
         }
 
 #ifdef CONFIG_KERNEL_MCS
-        reply_t *reply = REPLY_PTR(thread_state_get_replyObject(tptr->tcbState));
-        if (reply != NULL) {
-            reply_unlink(reply, tptr);
+        if (thread_state_ptr_get_tsType(state) == ThreadState_BlockedOnReceive) {
+            reply_t *reply = REPLY_PTR(thread_state_get_replyObject(tptr->tcbState));
+            if (reply != NULL) {
+                reply_unlink(reply, tptr);
+            }
         }
 #endif
         setThreadState(tptr, ThreadState_Inactive);
@@ -389,9 +391,11 @@ void cancelAllIPC(endpoint_t *epptr)
         /* Set all blocked threads to restart */
         for (; thread; thread = thread->tcbEPNext) {
 #ifdef CONFIG_KERNEL_MCS
-            reply_t *reply = REPLY_PTR(thread_state_get_replyObject(thread->tcbState));
-            if (reply != NULL) {
-                reply_unlink(reply, thread);
+            if (thread_state_get_tsType(thread->tcbState) == ThreadState_BlockedOnReceive) {
+                reply_t *reply = REPLY_PTR(thread_state_get_replyObject(thread->tcbState));
+                if (reply != NULL) {
+                    reply_unlink(reply, thread);
+                }
             }
             if (seL4_Fault_get_seL4_FaultType(thread->tcbFault) == seL4_Fault_NullFault) {
                 setThreadState(thread, ThreadState_Restart);
@@ -446,7 +450,7 @@ void cancelBadgedSends(endpoint_t *epptr, word_t badge)
             next = thread->tcbEPNext;
 #ifdef CONFIG_KERNEL_MCS
             /* senders do not have reply objects in their state, and we are only cancelling sends */
-            assert(REPLY_PTR(thread_state_get_replyObject(thread->tcbState)) == NULL);
+            assert(thread_state_get_tsType(thread->tcbState) == ThreadState_BlockedOnSend);
             if (b == badge) {
                 if (seL4_Fault_get_seL4_FaultType(thread->tcbFault) ==
                     seL4_Fault_NullFault) {


### PR DESCRIPTION
We no longer guarantee the invariant that the replyObject reference is `NULL` when the thread state is not `BlockedOnReceive` or `BlockedOnReply`.

It is likely that this invariant was true in the kernel so far, but proving it would require a new proof that the reference is already `NULL` for any `setThreadState` to a simple state such as `Running`, `Inactive`, `Restart`. This either means reasoning about the state the thread had before `setThreadSate`, or explicitly setting the reference to `NULL` more
often.

There are many of these `setThreadState` instances, and the benefit of maintaining the invariant is low. Not maintaining the invariant removes some state updates from low-level functions (called often) at the cost of adding some if-checks in higher-level functions (called less often).
