### PR TITLE
mcs: remove parameter from schedContext_unbindTCB

### DIFF
--- a/include/object/schedcontext.h
+++ b/include/object/schedcontext.h
@@ -23,17 +23,16 @@ exception_t decodeSchedContextInvocation(word_t label, cap_t cap, word_t *buffer
  */
 void schedContext_bindTCB(sched_context_t *sc, tcb_t *tcb);
 
-/* Unbind a specific tcb from a scheduling context. If the tcb is runnable,
+/* Unbind the tcb from a scheduling context. If the tcb is runnable,
  * remove from the scheduler.
  *
- * @param sc  scheduling context to unbind
- * @param tcb the tcb to unbind
+ * @param sc the scheduling context whose tcb will be unbound
  *
- * @pre   the tcb is bound to the sc,
- *        (sc->scTcb == tcb && tcb->tcbSchedContext == sc);
- * @post  (tcb->tcbSchedContext == NULL && sc->scTcb == NULL)
+ * @pre   the sc is not NULL and is bound to a tcb
+ *        (sc != NULL && sc->scTcb != NULL);
+ * @post  (sc->scTcb == NULL && sc->scTcb->tcbSchedContext == NULL)
  */
-void schedContext_unbindTCB(sched_context_t *sc, tcb_t *tcb);
+void schedContext_unbindTCB(sched_context_t *sc);
 
 /*
  * Unbind any tcb from a scheduling context. If the tcb bound to the scheduling

--- a/src/object/objecttype.c
+++ b/src/object/objecttype.c
@@ -191,7 +191,7 @@ finaliseCap_ret_t finaliseCap(cap_t cap, bool_t final, bool_t exposed)
 #ifdef CONFIG_KERNEL_MCS
             sched_context_t *sc = SC_PTR(tcb->tcbSchedContext);
             if (sc) {
-                schedContext_unbindTCB(sc, tcb);
+                schedContext_unbindTCB(sc);
                 if (sc->scYieldFrom) {
                     schedContext_completeYieldTo(sc->scYieldFrom);
                 }

--- a/src/object/tcb.c
+++ b/src/object/tcb.c
@@ -1883,7 +1883,7 @@ exception_t invokeTCB_ThreadControlSched(tcb_t *target, cte_t *slot,
         if (sc != NULL && sc != target->tcbSchedContext) {
             schedContext_bindTCB(sc, target);
         } else if (sc == NULL && target->tcbSchedContext != NULL) {
-            schedContext_unbindTCB(target->tcbSchedContext, target);
+            schedContext_unbindTCB(target->tcbSchedContext);
         }
     }
 


### PR DESCRIPTION
This removes the tcb parameter from schedContext_unbindTCB, which is unnecessary, since it is always the scTcb of the given sc.