### PR TITLE
Remove const qualifiers from domain variables

### DIFF
--- a/include/model/statedata.h
+++ b/include/model/statedata.h
@@ -103,8 +103,8 @@ extern word_t ksWorkUnitsCompleted;
 extern irq_state_t intStateIRQTable[];
 extern cte_t intStateIRQNode[];
 
-extern const dschedule_t ksDomSchedule[];
-extern const word_t ksDomScheduleLength;
+extern dschedule_t ksDomSchedule[];
+extern word_t ksDomScheduleLength;
 extern word_t ksDomScheduleIdx;
 extern dom_t ksCurDomain;
 #ifdef CONFIG_KERNEL_MCS

--- a/src/config/default_domain.c
+++ b/src/config/default_domain.c
@@ -9,9 +9,9 @@
 #include <model/statedata.h>
 
 /* Default schedule. The length is in ms */
-const dschedule_t ksDomSchedule[] = {
+dschedule_t ksDomSchedule[] = {
     { .domain = 0, .length = 1 },
 };
 
-const word_t ksDomScheduleLength = ARRAY_SIZE(ksDomSchedule);
+word_t ksDomScheduleLength = ARRAY_SIZE(ksDomSchedule);
 


### PR DESCRIPTION
This PR removes the const qualifiers from variables related to domain scheduling: ksDomSchedule and ksDomScheduleLength. This enables patching of these variables in an already-built kernel ELF.

### Context

The seL4 Microkit uses an SDK model. Users download a Microkit SDK that includes one or more pre-built seL4 kernel images. When the user builds their Microkit system using the SDK, the SDK copies one of the kernel images it is packaged with into the final image. Importantly, Microkit users do not need to build the seL4 kernel.

Domain scheduling in seL4 is configured at kernel build time. Users provide a source file specifying the ksDomSchedule and ksDomScheduleLength variables which dictate the kernel's behaviour. Unfortunately, this means that domain scheduling as it exists now is incompatible with the Microkit's SDK model: only the Microkit maintainers would be able to configure a domain schedule, when we would like Microkit users to be able to do so.

In the future seL4 may support runtime configuration of the domain schedule using a capability, in the same way that currently TCBs can be assigned to domains using the domain cap. Until then, if we want domain scheduling to be available to Microkit users, we need a workaround.

The Microkit already makes extensive use of ELF patching of user programs. We wish to use this approach on the kernel itself. By setting KernelNumDomains to 256 (the maximum) and patching the values of the ksDomSchedule and ksDomScheduleLength variables in the kernel ELF at Microkit SDK run time, we can support user-specified domain schedules, allowing users to use domain scheduling in Microkit systems.

For ELF patching to work, the variables can't be qualified const, as they currently are.

### Caveats

The CONFIG_NUM_DOMAINS and `enum domainConstants` constants are also referenced in the code. These constants cannot be patched. Practically, this makes no difference since references to these constants are either in assertions, or just checking if domains are enabled or not, except for one case in `decodeDomainInvocation()` where there is the check `if (domain >= numDomains)`. Here, if patching the domain schedule, there will be no runtime check that userspace provided a valid domain number in a domain invocation. In the case of Microkit, this does not matter since the loader should not provide invalid domain numbers.

This breaks existing users' domain schedule C files as those declarations will now have a conflicting type with the kernel declaration.