### PR TITLE
microkit: remove const qualifiers from domain variables

### DIFF
--- a/include/model/statedata.h
+++ b/include/model/statedata.h
@@ -103,8 +103,8 @@ extern word_t ksWorkUnitsCompleted;
 extern irq_state_t intStateIRQTable[];
 extern cte_t intStateIRQNode[];
 
-extern const dschedule_t ksDomSchedule[];
-extern const word_t ksDomScheduleLength;
+extern dschedule_t ksDomSchedule[];
+extern word_t ksDomScheduleLength;
 extern word_t ksDomScheduleIdx;
 extern dom_t ksCurDomain;
 #ifdef CONFIG_KERNEL_MCS

--- a/src/config/default_domain.c
+++ b/src/config/default_domain.c
@@ -9,9 +9,9 @@
 #include <model/statedata.h>
 
 /* Default schedule. The length is in ms */
-const dschedule_t ksDomSchedule[] = {
+dschedule_t ksDomSchedule[] = {
     { .domain = 0, .length = 1 },
 };
 
-const word_t ksDomScheduleLength = ARRAY_SIZE(ksDomSchedule);
+word_t ksDomScheduleLength = ARRAY_SIZE(ksDomSchedule);
 


### PR DESCRIPTION
This PR removes the const qualifiers from domain variables. This will allow the Microkit tool to patch the kernel's domain schedule. See #1301 for more information.

Test with: https://github.com/seL4/sel4test/pull/126