### PR TITLE
aarch32: remove unused functions

### DIFF
--- a/include/arch/arm/arch/32/mode/machine.h
+++ b/include/arch/arm/arch/32/mode/machine.h
@@ -223,12 +223,17 @@ static inline void writeTPIDRPRW(word_t reg)
     asm volatile("mcr p15, 0, %0, c13, c0, 4" :: "r"(reg));
 }
 
+
+#ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
+
 static inline word_t readTPIDRPRW(void)
 {
     word_t reg;
     asm volatile("mrc p15, 0, %0, c13, c0, 4" :"=r"(reg));
     return reg;
 }
+
+#endif
 
 static void arm_save_thread_id(tcb_t *thread)
 {
@@ -287,15 +292,6 @@ static inline void setKernelStack(word_t stack_address)
         writeHTPIDR(stack_address);
     } else {
         writeTPIDRPRW(stack_address);
-    }
-}
-
-static inline word_t getKernelStack(void)
-{
-    if (config_set(CONFIG_ARM_HYPERVISOR_SUPPORT)) {
-        return readHTPIDR();
-    } else {
-        return readTPIDRPRW();
     }
 }
 

--- a/include/arch/arm/arch/32/mode/machine_pl2.h
+++ b/include/arch/arm/arch/32/mode/machine_pl2.h
@@ -173,13 +173,6 @@ static inline void writeHTPIDR(word_t reg)
     asm volatile("mcr p15, 4, %0, c13, c0, 2" :: "r"(reg));
 }
 
-static inline word_t readHTPIDR(void)
-{
-    word_t reg;
-    asm volatile("mrc p15, 4, %0, c13, c0, 2" : "=r"(reg));
-    return reg;
-}
-
 #else
 
 /* used in other files without guards */
@@ -188,10 +181,6 @@ static inline void invalidateHypTLB(void) {}
 static inline void writeContextIDPL2(word_t pd_val) {}
 static inline void writeContextIDAndPD(word_t id, word_t pd_val) {}
 static inline void writeHTPIDR(word_t htpidr) {}
-static inline word_t readHTPIDR(void)
-{
-    return 0;
-}
 static inline paddr_t addressTranslateS1(vptr_t vaddr)
 {
     return vaddr;


### PR DESCRIPTION
- `getKernelStack()` is never called
- `readHTPIDRO()` was only called in `getKernelStack()`
- `readTPIDRPRW()` is only used in hyp configurations
