### PR TITLE
utils: safer str_to_long

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -106,16 +106,21 @@ long PURE str_to_long(const char *str)
     long val = 0;
     char c;
 
-    /*check for "0x" */
+    /* NULL ptr and empty str */
+    if (str == NULL || *str == 0) {
+        return -1;
+    }
+
+    /* check for "0x", *(str + 1) may be 0, but must be allocated since str is not empty */
     if (*str == '0' && (*(str + 1) == 'x' || *(str + 1) == 'X')) {
         base = 16;
         str += 2;
+        /* '0x' on its own is malformed */
+        if (*str == 0) {
+            return -1;
+        }
     } else {
         base = 10;
-    }
-
-    if (!*str) {
-        return -1;
     }
 
     c = *str;


### PR DESCRIPTION
Make `str_to_long` more defensive against malformed content, since this function runs on user (cmd line) input on x86. The input is from boot time, i.e. trusted, but the function should still be memory safe.

This change does not fix overflow issues which may still lead to undefined behaviour when the supplied string has a value that is too large.

