### PR TITLE
boot: fix init_freemem skipping reserved regions

### DIFF
--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -970,8 +970,7 @@ BOOT_CODE bool_t init_freemem(word_t n_available, const p_region_t *available,
                 /* the region overlaps with the start of the available region.
                  * trim start of the available region */
                 avail_reg[a].start = MIN(avail_reg[a].end, reserved[r].end);
-                reserve_region(pptr_to_paddr_reg(reserved[r]));
-                r++;
+                /* do not increment reserved index here - there could be more overlapping regions */
             } else {
                 assert(reserved[r].start < avail_reg[a].end);
                 /* take the first chunk of the available region and move

--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -980,8 +980,8 @@ BOOT_CODE bool_t init_freemem(word_t n_available, const p_region_t *available,
                 insert_region(m);
                 if (avail_reg[a].end > reserved[r].end) {
                     avail_reg[a].start = reserved[r].end;
-                    reserve_region(pptr_to_paddr_reg(reserved[r]));
-                    r++;
+                    /* we could increment reserved index here, but it's more consistent with the
+                     * other overlapping case if we don't */
                 } else {
                     a++;
                 }


### PR DESCRIPTION
In cases where the kernel is passed a very fragmented map of available memory (specifically when booting from GRUB on x86), it is possible for multiple available regions to overlap with a single reserved region.

Currently, if there is an overlap (where `avail_reg[a].start >= reserved[r].start`), the available region is trimmed and the region index is incremented. This causes any other overlapping regions to be handled as if they are non-overlapping, since it's now looking at the next reserved region. This eventually leads to reserved memory being passed to the root task and can cause corruption issues if it is used.

It is fine to skip this index increment since the available region is now either empty or non-overlapping, and both cases are already trivially handled.

[Here's a link to the thread about the issue, which has more information about what triggers the bug](https://sel4.discourse.group/t/kernel-triple-fault-when-retyping-untyped-memory-on-x86-qemu/874)