### PR TITLE
aarch64/vcpu: refine guest vcpu context

### DIFF
--- a/include/arch/arm/arch/32/mode/machine.h
+++ b/include/arch/arm/arch/32/mode/machine.h
@@ -193,6 +193,18 @@ static inline void writeTTBCR(word_t val)
     asm volatile("mcr p15, 0, %0, c2, c0, 2":: "r"(val));
 }
 
+static inline word_t readPAR(void)
+{
+    word_t val = 0;
+    asm volatile("mrc p15, 0, %0, c7, c4, 0":"=r"(val):);
+    return val;
+}
+
+static inline void writePAR(word_t val)
+{
+    asm volatile("mcr p15, 0, %0, c7, c4, 0":: "r"(val));
+}
+
 static inline void writeTPIDRURW(word_t reg)
 {
     asm volatile("mcr p15, 0, %0, c13, c0, 2" :: "r"(reg));

--- a/include/arch/arm/arch/32/mode/machine.h
+++ b/include/arch/arm/arch/32/mode/machine.h
@@ -193,15 +193,57 @@ static inline void writeTTBCR(word_t val)
     asm volatile("mcr p15, 0, %0, c2, c0, 2":: "r"(val));
 }
 
-static inline word_t readPAR(void)
+/* PAR is always a 64-bit register and needs to be context switched, because it
+ * can be written to directly in EL1.
+ *
+ * Ignored for verification, because inline asm formalisation cannot deal
+ * with 64-bit asm block output on 32-bit architectures, nor with two
+ * outputs of the same asm block. Read op is side-effect free.
+ */
+/** MODIFIES: */
+/** DONT_TRANSLATE */
+static inline uint64_t readPAR_64(void)
 {
+    uint64_t val = 0;
+    asm volatile("mrrc p15, 0, %Q0, %R0, c7":"=r"(val):);
+    return val;
+}
+
+/* Ignored for verification, because inline asm formalisation cannot deal
+ * with 64-bit asm block output on 32-bit architectures, nor with two
+ * outputs of the same asm block.
+ */
+/** MODIFIES: [*] */
+/** DONT_TRANSLATE */
+static inline void writePAR_64(uint64_t val)
+{
+    asm volatile("mcrr p15, 0, %Q0, %R0, c7":: "r"(val));
+}
+
+static inline word_t readPARhigh(void)
+{
+    uint64_t par = readPAR_64();
+    return (word_t)(par >> 32);
+}
+
+static inline word_t readPARlow(void)
+{
+    /* use 32-bit read to get only the low bits */
     word_t val = 0;
     asm volatile("mrc p15, 0, %0, c7, c4, 0":"=r"(val):);
     return val;
 }
 
-static inline void writePAR(word_t val)
+static inline void writePARhigh(word_t val)
 {
+    uint64_t par_high = (uint64_t) val << 32;
+    uint64_t par_low = readPARlow();
+    writePAR_64(par_high | par_low);
+}
+
+static inline void writePARlow(word_t val)
+{
+    /* avoid read-modify-write by using 32-bit write directly */
     asm volatile("mcr p15, 0, %0, c7, c4, 0":: "r"(val));
 }
 

--- a/include/arch/arm/arch/32/mode/machine_pl2.h
+++ b/include/arch/arm/arch/32/mode/machine_pl2.h
@@ -121,9 +121,15 @@ static inline void invalidateHypTLB(void)
 static inline paddr_t PURE addressTranslateS1(vptr_t vaddr)
 {
     uint32_t ipa0, ipa1;
+    uint32_t saved_ipa0, saved_ipa1;
+
+    asm volatile("mrrc p15, 0, %0, %1, c7"   : "=r"(saved_ipa0), "=r"(saved_ipa1));
+
     asm volatile("mcr  p15, 0, %0, c7, c8, 0" :: "r"(vaddr));
     isb();
     asm volatile("mrrc p15, 0, %0, %1, c7"   : "=r"(ipa0), "=r"(ipa1));
+
+    asm volatile("mcrr p15, 0, %0, %1, c7"   : "=r"(saved_ipa0), "=r"(saved_ipa1));
 
     return ipa0;
 }

--- a/include/arch/arm/arch/64/mode/machine.h
+++ b/include/arch/arm/arch/64/mode/machine.h
@@ -380,5 +380,18 @@ void arch_clean_invalidate_L1_caches(word_t type);
 
 static inline paddr_t addressTranslateS1(vptr_t vaddr)
 {
-    return ats1e1r(vaddr);
+    word_t result;
+    UNUSED word_t saved_par;
+
+    if (config_set(CONFIG_ARM_HYPERVISOR_SUPPORT)) {
+        MRS("par_el1", saved_par);
+    }
+
+    result = ats1e1r(vaddr);
+
+    if (config_set(CONFIG_ARM_HYPERVISOR_SUPPORT)) {
+        MSR("par_el1", saved_par);
+    }
+
+    return result;
 }

--- a/include/arch/arm/armv/armv7-a/armv/vcpu.h
+++ b/include/arch/arm/armv/armv7-a/armv/vcpu.h
@@ -416,6 +416,8 @@ static word_t vcpu_hw_read_reg(word_t reg_index)
         return getSCTLR();
     case seL4_VCPUReg_ACTLR:
         return getACTLR();
+    case seL4_VCPUReg_PAR:
+        return readPAR();
     case seL4_VCPUReg_TTBCR:
         return readTTBCR();
     case seL4_VCPUReg_TTBR0:
@@ -513,6 +515,9 @@ static void vcpu_hw_write_reg(word_t reg_index, word_t reg)
         break;
     case seL4_VCPUReg_ACTLR:
         setACTLR(reg);
+        break;
+    case seL4_VCPUReg_PAR:
+        writePAR(reg);
         break;
     case seL4_VCPUReg_TTBCR:
         writeTTBCR(reg);

--- a/include/arch/arm/armv/armv7-a/armv/vcpu.h
+++ b/include/arch/arm/armv/armv7-a/armv/vcpu.h
@@ -416,8 +416,10 @@ static word_t vcpu_hw_read_reg(word_t reg_index)
         return getSCTLR();
     case seL4_VCPUReg_ACTLR:
         return getACTLR();
-    case seL4_VCPUReg_PAR:
-        return readPAR();
+    case seL4_VCPUReg_PARhigh:
+        return readPARhigh();
+    case seL4_VCPUReg_PARlow:
+        return readPARlow();
     case seL4_VCPUReg_TTBCR:
         return readTTBCR();
     case seL4_VCPUReg_TTBR0:
@@ -516,8 +518,11 @@ static void vcpu_hw_write_reg(word_t reg_index, word_t reg)
     case seL4_VCPUReg_ACTLR:
         setACTLR(reg);
         break;
-    case seL4_VCPUReg_PAR:
-        writePAR(reg);
+    case seL4_VCPUReg_PARhigh:
+        writePARhigh(reg);
+        break;
+    case seL4_VCPUReg_PARlow:
+        writePARlow(reg);
         break;
     case seL4_VCPUReg_TTBCR:
         writeTTBCR(reg);

--- a/include/arch/arm/armv/armv8-a/64/armv/vcpu.h
+++ b/include/arch/arm/armv/armv8-a/64/armv/vcpu.h
@@ -108,7 +108,6 @@
 #define REG_AFSR1_EL1       "afsr1_el1"
 #define REG_ESR_EL1         "esr_el1"
 #define REG_FAR_EL1         "far_el1"
-#define REG_ISR_EL1         "isr_el1"
 #define REG_VBAR_EL1        "vbar_el1"
 #define REG_TPIDR_EL1       "tpidr_el1"
 #define REG_SP_EL1          "sp_el1"
@@ -285,16 +284,6 @@ static inline void writeFAR(word_t reg)
     MSR(REG_FAR_EL1, reg);
 }
 
-/* ISR is read-only */
-/** MODIFIES: */
-/** DONT_TRANSLATE */
-static inline word_t readISR(void)
-{
-    uint32_t reg;
-    MRS(REG_ISR_EL1, reg);
-    return (word_t)reg;
-}
-
 static inline word_t readVBAR(void)
 {
     word_t reg;
@@ -462,8 +451,6 @@ static word_t vcpu_hw_read_reg(word_t reg_index)
         return readESR();
     case seL4_VCPUReg_FAR:
         return readFAR();
-    case seL4_VCPUReg_ISR:
-        return readISR();
     case seL4_VCPUReg_VBAR:
         return readVBAR();
     case seL4_VCPUReg_TPIDR_EL1:
@@ -532,9 +519,6 @@ static void vcpu_hw_write_reg(word_t reg_index, word_t reg)
         break;
     case seL4_VCPUReg_FAR:
         writeFAR(reg);
-        break;
-    case seL4_VCPUReg_ISR:
-        /* ISR is read-only */
         break;
     case seL4_VCPUReg_VBAR:
         writeVBAR(reg);

--- a/include/arch/arm/armv/armv8-a/64/armv/vcpu.h
+++ b/include/arch/arm/armv/armv8-a/64/armv/vcpu.h
@@ -114,6 +114,7 @@
 #define REG_ELR_EL1         "elr_el1"
 #define REG_SPSR_EL1        "spsr_el1"
 #define REG_CPACR_EL1       "cpacr_el1"
+#define REG_PAR_EL1         "par_el1"
 #define REG_CNTV_TVAL_EL0   "cntv_tval_el0"
 #define REG_CNTV_CTL_EL0    "cntv_ctl_el0"
 #define REG_CNTV_CVAL_EL0   "cntv_cval_el0"
@@ -344,6 +345,18 @@ static inline void writeCPACR_EL1(word_t reg)
     MSR(REG_CPACR_EL1, reg);
 }
 
+static inline word_t readPAR_EL1(void)
+{
+    word_t reg;
+    MRS(REG_PAR_EL1, reg);
+    return reg;
+}
+
+static inline void writePAR_EL1(word_t reg)
+{
+    MSR(REG_PAR_EL1, reg);
+}
+
 static inline word_t readCNTV_TVAL_EL0(void)
 {
     word_t reg;
@@ -443,6 +456,8 @@ static word_t vcpu_hw_read_reg(word_t reg_index)
         return readACTLR();
     case seL4_VCPUReg_CPACR:
         return readCPACR_EL1();
+    case seL4_VCPUReg_PAR:
+        return readPAR_EL1();
     case seL4_VCPUReg_AFSR0:
         return readAFSR0();
     case seL4_VCPUReg_AFSR1:
@@ -507,6 +522,9 @@ static void vcpu_hw_write_reg(word_t reg_index, word_t reg)
         break;
     case seL4_VCPUReg_CPACR:
         writeCPACR_EL1(reg);
+        break;
+    case seL4_VCPUReg_PAR:
+        writePAR_EL1(reg);
         break;
     case seL4_VCPUReg_AFSR0:
         writeAFSR0(reg);

--- a/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/constants.h
@@ -75,6 +75,7 @@ typedef enum {
     seL4_VCPUReg_SCTLR = 0,
     seL4_VCPURegSaveRange_start, /* begin vcpu save/restore reg range */
     seL4_VCPUReg_ACTLR = seL4_VCPURegSaveRange_start,
+    seL4_VCPUReg_PAR,
     seL4_VCPUReg_TTBCR,
     seL4_VCPUReg_TTBR0,
     seL4_VCPUReg_TTBR1,

--- a/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/constants.h
@@ -75,7 +75,6 @@ typedef enum {
     seL4_VCPUReg_SCTLR = 0,
     seL4_VCPURegSaveRange_start, /* begin vcpu save/restore reg range */
     seL4_VCPUReg_ACTLR = seL4_VCPURegSaveRange_start,
-    seL4_VCPUReg_PAR,
     seL4_VCPUReg_TTBCR,
     seL4_VCPUReg_TTBR0,
     seL4_VCPUReg_TTBR1,
@@ -112,7 +111,9 @@ typedef enum {
     seL4_VCPUReg_SPSRund,
     seL4_VCPUReg_SPSRirq,
     seL4_VCPUReg_SPSRfiq,
-    seL4_VCPURegSaveRange_end = seL4_VCPUReg_SPSRfiq, /* end vcpu save/restore reg range */
+    seL4_VCPUReg_PARhigh,
+    seL4_VCPUReg_PARlow,
+    seL4_VCPURegSaveRange_end = seL4_VCPUReg_PARlow, /* end vcpu save/restore reg range */
     seL4_VCPUReg_CNTV_CTL,
     seL4_VCPUReg_CNTV_CVALhigh,
     seL4_VCPUReg_CNTV_CVALlow,

--- a/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
@@ -83,6 +83,7 @@ typedef enum {
     seL4_VCPUReg_AMAIR,
     seL4_VCPUReg_CIDR,
     seL4_VCPUReg_ACTLR,
+    seL4_VCPUReg_PAR,
 
     /* exception handling registers EL1 */
     seL4_VCPUReg_AFSR0,

--- a/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
@@ -83,13 +83,13 @@ typedef enum {
     seL4_VCPUReg_AMAIR,
     seL4_VCPUReg_CIDR,
     seL4_VCPUReg_ACTLR,
-    seL4_VCPUReg_PAR,
 
     /* exception handling registers EL1 */
     seL4_VCPUReg_AFSR0,
     seL4_VCPUReg_AFSR1,
     seL4_VCPUReg_ESR,
     seL4_VCPUReg_FAR,
+    seL4_VCPUReg_PAR,
     seL4_VCPUReg_VBAR,
 
     /* thread pointer/ID registers EL0/EL1 */

--- a/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
@@ -89,7 +89,6 @@ typedef enum {
     seL4_VCPUReg_AFSR1,
     seL4_VCPUReg_ESR,
     seL4_VCPUReg_FAR,
-    seL4_VCPUReg_ISR,
     seL4_VCPUReg_VBAR,
 
     /* thread pointer/ID registers EL0/EL1 */


### PR DESCRIPTION
These commits:
* provides support to save and restore par_el1 between multiple vCPUs on the same pCPU
* deletes isr_el1 from the context since it is read-only. It could be that the user-space can spy the kernel using the register.


Parts that might be missing, but would like feedback from reviewers:
- aarch32 support for par save and restore
- vcpu/kernel switch we might want the kernel not to interfere with execution of the vcpu. (see https://github.com/seL4/seL4/issues/1212)