### PR TITLE
aarch32: make sure `irqInvalid` is `irq_t`

### DIFF
--- a/include/arch/arm/arch/machine/gic_common.h
+++ b/include/arch/arm/arch/machine/gic_common.h
@@ -52,11 +52,11 @@
                         CORE_IRQ_TO_IRQT(0, (idx) - (CONFIG_MAX_NUM_NODES-1)*NUM_PPI))
 #define IRQT_TO_CORE(irqt) (irqt.target_core)
 #define IRQT_TO_IRQ(irqt) (irqt.irq)
-irq_t irqInvalid = CORE_IRQ_TO_IRQT(-1, -1);
+static const irq_t irqInvalid = CORE_IRQ_TO_IRQT(-1, -1);
 
 #else
 #define IRQ_IS_PPI(irq) HW_IRQ_IS_PPI(irq)
-irq_t irqInvalid = (uint16_t) -1;
+static const irq_t irqInvalid = (uint16_t) -1;
 #endif
 
 /* Setters/getters helpers for hardware irqs */

--- a/include/drivers/irq/am335x.h
+++ b/include/drivers/irq/am335x.h
@@ -14,7 +14,7 @@
 /* No SGIs on this platform. */
 #define NUM_SGIS 0
 
-irq_t irqInvalid = 255;
+static const irq_t irqInvalid = 255;
 
 #define CMPER_REG(base, off) ((volatile uint32_t *)((base) + (off)))
 #define CMPER_TIMER3_CLKCTRL    0x84

--- a/include/drivers/irq/am335x.h
+++ b/include/drivers/irq/am335x.h
@@ -14,9 +14,7 @@
 /* No SGIs on this platform. */
 #define NUM_SGIS 0
 
-enum irqNumbers {
-    irqInvalid = 255
-};
+irq_t irqInvalid = 255;
 
 #define CMPER_REG(base, off) ((volatile uint32_t *)((base) + (off)))
 #define CMPER_TIMER3_CLKCTRL    0x84

--- a/include/drivers/irq/bcm2836-armctrl-ic.h
+++ b/include/drivers/irq/bcm2836-armctrl-ic.h
@@ -122,7 +122,7 @@ volatile struct core_regs {
 #define LOCAL_TIMER_CTRL_EN_BIT 28
 #define LOCAL_TIMER_CTRL_RL_MASK MASK(28)
 
-irq_t irqInvalid = 255;
+static const irq_t irqInvalid = 255;
 
 static inline bool_t isIRQPending(void)
 {

--- a/include/drivers/irq/bcm2836-armctrl-ic.h
+++ b/include/drivers/irq/bcm2836-armctrl-ic.h
@@ -122,9 +122,7 @@ volatile struct core_regs {
 #define LOCAL_TIMER_CTRL_EN_BIT 28
 #define LOCAL_TIMER_CTRL_RL_MASK MASK(28)
 
-enum irqNumbers {
-    irqInvalid = 255
-};
+irq_t irqInvalid = 255;
 
 static inline bool_t isIRQPending(void)
 {

--- a/include/drivers/irq/omap3.h
+++ b/include/drivers/irq/omap3.h
@@ -20,7 +20,7 @@
 
 #define INTCPS_SIR_IRQ_SPURIOUSIRQFLAG 0xFF0000
 
-irq_t irqInvalid = 255;
+static const irq_t irqInvalid = 255;
 
 /*
  * The struct below is used to discourage the compiler from generating literals

--- a/include/drivers/irq/omap3.h
+++ b/include/drivers/irq/omap3.h
@@ -20,9 +20,7 @@
 
 #define INTCPS_SIR_IRQ_SPURIOUSIRQFLAG 0xFF0000
 
-enum irqNumbers {
-    irqInvalid = 255
-};
+irq_t irqInvalid = 255;
 
 /*
  * The struct below is used to discourage the compiler from generating literals


### PR DESCRIPTION
The GIC platforms use `irq_t` for `irqInvalid` -- bring remaining AArch32 platforms in line with that.

`irq_t` is an unsigned type (when it is an integer) and enum constants are signed. For the proofs to treat these platforms uniformly, they need to be the same kind. They can't all be enums, because `irq_t` can be a more complex type for SMP platforms.
