### PR TITLE
smp/ipi.c: ipi send mask improvement

### DIFF
--- a/src/smp/ipi.c
+++ b/src/smp/ipi.c
@@ -128,12 +128,10 @@ void generic_ipi_send_mask(irq_t ipi, word_t mask, bool_t isBlocking)
         int index = wordBits - 1 - clzl(mask);
         if (isBlocking) {
             big_kernel_lock.node_owners[index].ipi = 1;
-            target_cores[nr_target_cores] = index;
-            nr_target_cores++;
-        } else {
-            IPI_MEM_BARRIER;
-            ipi_send_target(ipi, cpuIndexToID(index));
         }
+        target_cores[nr_target_cores] = index;
+        nr_target_cores++;
+
         mask &= ~BIT(index);
     }
 


### PR DESCRIPTION
Remove duplicated code:
IPI_MEM_BARRIER and ipi_send_target show up twice when they don't need to. This makes the code simpler and easy to read.

Improve performance:
It is also fast because you only call IPI_MEM_BARRIER once per function execution regardless of the mask.

Not sure if this kind of improvements are accepted but it is worth trying. Let me know if you have some feedback.