### PR TITLE
gic_v3: fix SRE in hyp mode

### DIFF
--- a/include/arch/arm/arch/machine/gic_v3.h
+++ b/include/arch/arm/arch/machine/gic_v3.h
@@ -42,6 +42,9 @@
 
 #define GICC_SRE_EL1_SRE             BIT(0)
 
+#define GICC_SRE_EL2_SRE             BIT(0)
+#define GICC_SRE_EL2_EN              BIT(3)
+
 #define GICR_WAKER_ProcessorSleep    BIT(1)
 #define GICR_WAKER_ChildrenAsleep    BIT(2)
 
@@ -60,6 +63,7 @@
 #define ICC_CTLR_EL1    "S3_0_C12_C12_4"
 #define ICC_IGRPEN1_EL1 "S3_0_C12_C12_7"
 #define ICC_SRE_EL1     "S3_0_C12_C12_5"
+#define ICC_SRE_EL2     "S3_4_C12_C9_5"
 #define MPIDR           "mpidr_el1"
 /* Virt control registers */
 #define ICH_AP0R0_EL2   "S3_4_C12_C8_0"
@@ -102,6 +106,7 @@
 #define ICC_CTLR_EL1    " p15, 0,  %0, c12,  c12, 4"
 #define ICC_IGRPEN1_EL1 " p15, 0,  %0, c12,  c12, 7"
 #define ICC_SRE_EL1     " p15, 0,  %0, c12,  c12, 5"
+#define ICC_SRE_EL2     " p15, 4,  %0, c12,  c9, 5"
 #define MPIDR           " p15, 0,  %0, c0,  c0, 5"
 
 /* Note: Virtualization control registers not currently defined for AARCH32 */

--- a/include/arch/arm/arch/machine/gic_v3.h
+++ b/include/arch/arm/arch/machine/gic_v3.h
@@ -59,6 +59,13 @@
 #define GICD_TYPE_LINESNR 0x01f
 
 #define GICC_SRE_EL1_SRE             BIT(0)
+#define GICC_SRE_EL1_DFB             BIT(1)
+#define GICC_SRE_EL1_DIB             BIT(2)
+
+#define GICC_SRE_EL2_SRE             BIT(0)
+#define GICC_SRE_EL2_DFB             BIT(1)
+#define GICC_SRE_EL2_DIB             BIT(2)
+#define GICC_SRE_EL2_EN              BIT(3)
 
 #define GICR_WAKER_ProcessorSleep    BIT(1)
 #define GICR_WAKER_ChildrenAsleep    BIT(2)
@@ -78,6 +85,7 @@
 #define ICC_CTLR_EL1    "S3_0_C12_C12_4"
 #define ICC_IGRPEN1_EL1 "S3_0_C12_C12_7"
 #define ICC_SRE_EL1     "S3_0_C12_C12_5"
+#define ICC_SRE_EL2     "S3_4_C12_C9_5"
 #define MPIDR           "mpidr_el1"
 /* Virt control registers */
 #define ICH_AP0R0_EL2   "S3_4_C12_C8_0"
@@ -120,6 +128,7 @@
 #define ICC_CTLR_EL1    " p15, 0,  %0, c12,  c12, 4"
 #define ICC_IGRPEN1_EL1 " p15, 0,  %0, c12,  c12, 7"
 #define ICC_SRE_EL1     " p15, 0,  %0, c12,  c12, 5"
+#define ICC_SRE_EL2     " p15, 4,  %0, c12,  c9, 5"
 #define MPIDR           " p15, 0,  %0, c0,  c0, 5"
 
 /* Note: Virtualization control registers not currently defined for AARCH32 */

--- a/src/arch/arm/machine/gic_v3.c
+++ b/src/arch/arm/machine/gic_v3.c
@@ -125,11 +125,17 @@ static void gicv3_enable_sre(void)
 {
     uint32_t val = 0;
 
-    /* ICC_SRE_EL1 */
+#ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
+    /* ICC_SRE_EL2/ICC_HSRE */
+    SYSTEM_READ_WORD(ICC_SRE_EL2, val);
+    val |= GICC_SRE_EL2_SRE | GICC_SRE_EL2_EN;
+    SYSTEM_WRITE_WORD(ICC_SRE_EL2, val);
+#else
+    /* ICC_SRE_EL1/ICC_SRE */
     SYSTEM_READ_WORD(ICC_SRE_EL1, val);
     val |= GICC_SRE_EL1_SRE;
-
     SYSTEM_WRITE_WORD(ICC_SRE_EL1, val);
+#endif
     isb();
 }
 

--- a/src/arch/arm/machine/gic_v3.c
+++ b/src/arch/arm/machine/gic_v3.c
@@ -137,12 +137,21 @@ static void gicv3_redist_wait_for_rwp(void)
 
 static void gicv3_enable_sre(void)
 {
-    word_t val = 0;
+    word_t val;
 
-    /* ICC_SRE_EL1 */
-    SYSTEM_READ_WORD(ICC_SRE_EL1, val);
-    val |= GICC_SRE_EL1_SRE;
+#ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
+    /* Set SRE to enable register interface for GICv3 in EL2. Disable IRQ/FIQ legacy bypass.
+     * Set ICC_SRE_EL2.Enable to 0, so EL1 accesses to ICC_SRE_EL1 will trap.
+     *
+     * SRE may be RAO/WI and DIB/DFB may be read-only aliases of ICC_SRE_EL3 on cores
+     * with EL3. Writing to them is harmless.
+     */
+    val = GICC_SRE_EL2_SRE | GICC_SRE_EL2_DIB | GICC_SRE_EL2_DFB;
+    SYSTEM_WRITE_WORD(ICC_SRE_EL2, val);
+#endif
 
+    /* Enable register interface for GICv3 in EL1. Disable IRQ/FIQ legacy bypass. */
+    val = GICC_SRE_EL1_SRE | GICC_SRE_EL1_DIB | GICC_SRE_EL1_DFB;
     SYSTEM_WRITE_WORD(ICC_SRE_EL1, val);
     isb();
 }


### PR DESCRIPTION
when hypervisor mode is enabled the kernel shall use ICC_SRE_EL2 or ICC_HSRE. This commit fixes this and supports compatibility between aarch32 and aarch64.