### PR TITLE
Fix Ariane (CVA6) support

### DIFF
--- a/include/drivers/irq/riscv_plic0.h
+++ b/include/drivers/irq/riscv_plic0.h
@@ -16,8 +16,9 @@
     !defined(CONFIG_PLAT_POLARFIRE) && \
     !defined(CONFIG_PLAT_QEMU_RISCV_VIRT) && \
     !defined(CONFIG_PLAT_ROCKETCHIP_ZCU102) && \
-    !defined(CONFIG_PLAT_STAR64)
-#error "Check if this platform suppots a PLIC."
+    !defined(CONFIG_PLAT_STAR64) && \
+    !defined(CONFIG_PLAT_ARIANE)
+#error "Check if this platform supports a PLIC."
 #endif
 
 /* tell the kernel we have the set trigger feature */

--- a/src/plat/ariane/config.cmake
+++ b/src/plat/ariane/config.cmake
@@ -16,15 +16,10 @@ if(KernelPlatformAriane)
     config_set(KernelOpenSBIPlatform OPENSBI_PLATFORM "fpga/ariane")
     list(APPEND KernelDTSList "tools/dts/ariane.dts")
     list(APPEND KernelDTSList "src/plat/ariane/overlay-ariane.dts")
-    # This is an experimental platform that supports accessing peripherals, but
-    # the status of support for external interrupts via a PLIC is unclear and
-    # may differ depending on the version that is synthesized. Declaring no
-    # interrupts and using the dummy PLIC driver seems the best option for now
-    # to avoid confusion or even crashes.
     declare_default_headers(
+        MAX_IRQ 30
         TIMER_FREQUENCY 25000000
-        MAX_IRQ 0
-        INTERRUPT_CONTROLLER drivers/irq/riscv_plic_dummy.h
+        INTERRUPT_CONTROLLER drivers/irq/riscv_plic0.h
     )
 else()
     unset(KernelPlatformFirstHartID CACHE)


### PR DESCRIPTION
The current upstream support for Ariane is broken; being unable to launch seL4test (crashes on IRQ setup). This is due to the PLIC being disabled and the an interrupt max of 0 being set.

This commit re-enables the PLIC for Ariane as it is inoperable otherwise. I believe the original PLIC change was backed out due to uncertainty about functionality between different rounds of synthesis, but working sometimes seems like a better outcome than working never.

This is also required to enable Microkit and LibVMM support for Ariane.

Here is an example of seL4test output *without* this change applied:
```
ELF-loader started on (HART 0) (NODES 1)
  paddr=[80200000..80662fff]
Looking for DTB in CPIO archive...found at 802b8228.
Loaded DTB from 802b8228.
   paddr=[84024000..84024fff]
ELF-loading image 'kernel' to 84000000
  paddr=[84000000..84023fff]
  vaddr=[ffffffff84000000..ffffffff84023fff]
  virt_entry=ffffffff84000000
ELF-loading image 'sel4test-driver' to 84025000
  paddr=[84025000..8441afff]
  vaddr=[10000..405fff]
  virt_entry=1bfd4
Enabling MMU and paging
Jumping to kernel-image entry point...

Init local IRQ
no PLIC present, skip hart specific initialisation
Bootstrapping kernel
Initializing PLIC...
no PLIC present, skip platform specific initialisation
available phys memory regions: 1
  [80200000..c0000000]
reserved virt address space regions: 3
  [ffffffc084000000..ffffffc084024000]
  [ffffffc084024000..ffffffc084024c8e]
  [ffffffc084025000..ffffffc08441b000]
Booting all finished, dropped to user space
<<seL4(CPU 0) [Arch_checkIRQ/19 T0xffffffc0bffc9200 "sel4test-driver" @586e2]: Rejecting request for IRQ 5. IRQ is out of range [1..maxIRQ].>>
sel4platsupport_copy_irq_cap@device.c:35 Failed to get cap for irq
sel4test_timer_irq_register@main.c:557 [Cond failed: error]
	Failed to allocate IRQ handler
seL4 root server abort()ed
Debug halt syscall from user thread 0xffffffc0bffc9200 "sel4test-driver"
halting...
Kernel entry via Unknown syscall, word: 1
```