### PR TITLE
x86: initialize variables

### DIFF
--- a/src/arch/x86/object/ioport.c
+++ b/src/arch/x86/object/ioport.c
@@ -222,7 +222,7 @@ exception_t decodeX86PortInvocation(
     word_t *buffer
 )
 {
-    exception_t ret;
+    exception_t ret = EXCEPTION_NONE;
 
     if (invLabel == X86IOPortIn8 || invLabel == X86IOPortIn16 || invLabel == X86IOPortIn32) {
         if (length < 1) {
@@ -263,7 +263,7 @@ exception_t decodeX86PortInvocation(
            passed to invokeX86PortOut. Whilst invokeX86PortOut will ignore any extra data and
            cast down to the correct word size removing the extra here is currently relied upon
            for verification */
-        uint32_t data;
+        uint32_t data = 0;
 
         switch (invLabel) {
         case X86IOPortOut8:


### PR DESCRIPTION
Multiple versions of GCC were unable to determine that these variables in `decodeX86PortInvocation` are initialized in all cases.

Oddly, this compilation failure was only observed with `-O1`. Compilation with `-O2` was not failing.