### PR TITLE
Remove `UNREACHABLE()` from `resolveAddressBits`

### DIFF
--- a/src/kernel/cspace.c
+++ b/src/kernel/cspace.c
@@ -190,6 +190,4 @@ resolveAddressBits_ret_t resolveAddressBits(cap_t nodeCap, cptr_t capptr, word_t
             return ret;
         }
     }
-
-    UNREACHABLE();
 }


### PR DESCRIPTION
The binary verification tools do not support `__builtin_unreachable`, and `resolveAddressBits` is in scope for binary verification.