### PR TITLE
arm,gic: add static const qualifier to `irqInvalid`

### DIFF
--- a/include/arch/arm/arch/machine/gic_common.h
+++ b/include/arch/arm/arch/machine/gic_common.h
@@ -51,11 +51,11 @@
                         CORE_IRQ_TO_IRQT(0, (idx) - (CONFIG_MAX_NUM_NODES-1)*NUM_PPI))
 #define IRQT_TO_CORE(irqt) (irqt.target_core)
 #define IRQT_TO_IRQ(irqt) (irqt.irq)
-irq_t irqInvalid = CORE_IRQ_TO_IRQT(-1, -1);
+static const irq_t irqInvalid = CORE_IRQ_TO_IRQT(-1, -1);
 
 #else
 #define IRQ_IS_PPI(irq) HW_IRQ_IS_PPI(irq)
-irq_t irqInvalid = (uint16_t) -1;
+static const irq_t irqInvalid = (uint16_t) -1;
 #endif
 
 /* Setters/getters helpers for hardware irqs */


### PR DESCRIPTION
Commit [2d362cb](https://github.com/seL4/seL4/commit/2d362cb7c8e96a64b9848df06e226f50e79a1ec9) changed `irqInvalid` in `gic_common.h` from an enum constant to a global variable. The latter does not play nicely with the binary verification tools.  Specifically, the `C -> SydTV-GL` lowering inlines its value into `getActiveIRQ`, whereas GCC does not.

Adding the const qualifier encourages GCC to inline it.