### PR TITLE
riscv: fix off-by-1 write for PLIC IRQ priorities, and QEMU MAX_IRQ

### DIFF
--- a/include/drivers/irq/riscv_plic0.h
+++ b/include/drivers/irq/riscv_plic0.h
@@ -183,7 +183,7 @@ static inline void plic_init_controller(void)
     }
 
     /* Set the priorities of all interrupts to 1 */
-    for (int i = 1; i <= PLIC_MAX_IRQ + 1; i++) {
+    for (int i = 1; i <= PLIC_MAX_IRQ; i++) {
         writel(2, PLIC_PPTR_BASE + PLIC_PRIO + PLIC_PRIO_PER_ID * i);
     }
 

--- a/src/plat/qemu-riscv-virt/config.cmake
+++ b/src/plat/qemu-riscv-virt/config.cmake
@@ -190,12 +190,13 @@ if(KernelPlatformQEMURiscVVirt)
         list(APPEND KernelDTSList "${CMAKE_CURRENT_LIST_DIR}/overlay-qemu-riscv-virt32.dts")
     endif()
 
-    # QEMU emulates a SiFive PLIC/CLINT with 127 interrupt sources by default.
+    # QEMU emulates a SiFive PLIC/CLINT with 96 interrupt sources by default.
+    # https://github.com/qemu/qemu/blob/stable-9.1/include/hw/riscv/virt.h#L102
     # The CLINT timer pretends to run at 10 MHz, but this speed may not hold in
     # practical measurements.
     declare_default_headers(
         TIMER_FREQUENCY 10000000
-        MAX_IRQ 128
+        MAX_IRQ 95
         INTERRUPT_CONTROLLER drivers/irq/riscv_plic0.h
     )
 


### PR DESCRIPTION
This produced 'sifive_plic_write: Invalid register write 0x180' in QEMU. https://github.com/seL4/seL4/issues/1350#issuecomment-2464273308

The rest of the code only runs up to `i <= PLIC_MAX_IRQ`, not `+ 1`.

Partially fixes #1350 

---

Also updates the value of `MAX_IRQ` to 95 to completely fix #1350. Yes, the correct value is 95 as 96 is [0, 96) -> [1, 95]. This is not the better solution mentioned but that's a fair amount of work.