### PR TITLE
Platform support for Cheshire (Digilent Genesys2)

### DIFF
--- a/include/drivers/irq/riscv_plic0.h
+++ b/include/drivers/irq/riscv_plic0.h
@@ -17,6 +17,7 @@
     !defined(CONFIG_PLAT_QEMU_RISCV_VIRT) && \
     !defined(CONFIG_PLAT_ROCKETCHIP_ZCU102) && \
     !defined(CONFIG_PLAT_STAR64) && \
+    !defined(CONFIG_PLAT_CHESHIRE) && \
     !defined(CONFIG_PLAT_ARIANE)
 #error "Check if this platform supports a PLIC."
 #endif

--- a/libsel4/sel4_plat_include/cheshire/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/cheshire/sel4/plat/api/constants.h
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <sel4/config.h>

--- a/src/plat/cheshire/config.cmake
+++ b/src/plat/cheshire/config.cmake
@@ -1,0 +1,29 @@
+#
+# Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+# Copyright 2021, HENSOLDT Cyber
+# Copyright 2024, UNSW
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+cmake_minimum_required(VERSION 3.7.2)
+
+declare_platform(cheshire KernelPlatformCheshire PLAT_CHESHIRE KernelArchRiscV)
+
+if(KernelPlatformCheshire)
+    declare_seL4_arch(riscv64)
+    config_set(KernelRiscVPlatform RISCV_PLAT "cheshire")
+    config_set(KernelPlatformFirstHartID FIRST_HART_ID 0)
+    config_set(KernelOpenSBIPlatform OPENSBI_PLATFORM "fpga/cheshire")
+    set(OPENSBI_PLAT_XLEN "64")
+    set(OPENSBI_PLAT_ISA "rv64imafdc_zicsr_zifencei")
+    list(APPEND KernelDTSList "tools/dts/cheshire.dts")
+    list(APPEND KernelDTSList "src/plat/cheshire/overlay-cheshire.dts")
+    declare_default_headers(
+        TIMER_FREQUENCY 1000000
+        MAX_IRQ 51
+        INTERRUPT_CONTROLLER drivers/irq/riscv_plic0.h
+    )
+else()
+    unset(KernelPlatformFirstHartID CACHE)
+endif()

--- a/src/plat/cheshire/overlay-cheshire.dts
+++ b/src/plat/cheshire/overlay-cheshire.dts
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024,  UNSW
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+/ {
+	chosen {
+		seL4,kernel-devices =
+            &{/soc/clint@2000000},
+		    &{/soc/interrupt-controller@4000000};
+	};
+
+    /*
+     * The size and address of the CLINT is from the memory map listed in the
+     * CVA6 documentation. It can be found here:
+     * https://docs.openhwgroup.org/projects/cva6-user-manual/05_cva6_apu/cva6_apu.html#memory-map
+     */
+    soc {
+        clint@2000000 {
+            compatible = "riscv,cpu-intc";
+            reg = <0x00000000 0x2000000 0x00000000 0x0000c0000>;
+        };
+    };
+};

--- a/tools/dts/cheshire.dts
+++ b/tools/dts/cheshire.dts
@@ -1,0 +1,118 @@
+// Copyright 2022 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Nicole Narr <narrn@student.ethz.ch>
+// Christopher Reinwardt <creinwar@student.ethz.ch>
+// Axel Vanoni <axvanoni@student.ethz.ch>
+
+/dts-v1/;
+/ {
+  #address-cells = <2>;
+  #size-cells = <2>;
+  compatible = "eth,cheshire-dev";
+  model = "eth,cheshire";
+  chosen {
+    console = "/soc/serial@3002000";
+    stdout-path = "/soc/serial@3002000:115200";
+    linux,initrd-start = <0x84000000>;
+    linux,initrd-end = <0x85600000>;
+  };
+  memory@80000000 {
+    device_type = "memory";
+    reg = <0x0 0x80000000 0x0 0x40000000>;
+  };
+  cpus {
+    #address-cells = <1>;
+    #size-cells = <0>;
+    timebase-frequency = <1000000>; // 1 MHz
+    CPU0: cpu@0 {
+      device_type = "cpu";
+      status = "okay";
+      compatible = "eth,cheshire", "riscv";
+      clock-frequency = <50000000>; // 50 MHz
+      riscv,isa = "rv64imafdch";
+      mmu-type = "riscv,sv39";
+      tlb-split;
+      reg = <0>;
+      CPU0_intc: interrupt-controller {
+        #address-cells = <0>;
+        #interrupt-cells = <1>;
+        interrupt-controller;
+        compatible = "riscv,cpu-intc";
+      };
+    };
+  };
+  soc: soc {
+    #address-cells = <2>;
+    #size-cells = <2>;
+    compatible = "eth,cheshire-bare-soc", "simple-bus";
+    ranges;
+    debug@0 {
+      compatible = "riscv,debug-013";
+      reg-names = "control";
+      reg = <0x0 0x0 0x0 0x1000>;
+    };
+    axi_llc@3001000 {
+      compatible = "eth,axi-llc";
+      reg = <0x0 0x3001000 0x0 0x5000>;
+    };
+    ddr_link: memory-controller@3006000 {
+      compatible = "eth,ddr-link";
+      reg = <0x0 0x3006000 0x0 0x1000>;
+    };
+    serial@3002000 {
+      compatible = "ns16550a";
+      clock-frequency = <50000000>; // 50 MHz
+      current-speed = <115200>;
+      interrupt-parent = <&PLIC0>;
+      interrupts = <1>;
+      reg = <0x0 0x3002000 0x0 0x1000>;
+      reg-shift = <2>; // regs are spaced on 32 bit boundary
+      reg-io-width = <4>; // only 32-bit access are supported
+    };
+    i2c@3003000 {
+      compatible = "eth,i2c";
+      interrupt-parent = <&PLIC0>;
+      interrupts = <2 3 4 5 6 7 8 9 10 11 12 13 14 15 16>;
+      reg = <0x0 0x3003000 0x0 0x1000>;
+    };
+    spi@3004000 {
+      compatible = "opentitan,spi-host", "lowrisc,spi";
+      interrupt-parent = <&PLIC0>;
+      interrupts = <17 18>;
+      reg = <0x0 0x3004000 0x0 0x1000>;
+      clock-frequency = <50000000>;
+      max-frequency = <25000000>;
+      #address-cells = <1>;
+      #size-cells = <0>;
+      mmc@0 {
+        compatible = "mmc-spi-slot";
+        reg = <0>;
+        spi-max-frequency = <25000000>;
+        voltage-ranges = <3300 3300>;
+        disable-wp;
+      };
+    };
+    vga@3007000 {
+      compatible = "eth,axi-vga";
+      reg = <0x0 0x3007000 0x0 0x1000>;
+    };
+    clint@2040000 {
+      compatible = "riscv,clint0";
+      interrupts-extended = <&CPU0_intc 3 &CPU0_intc 7>;
+      reg-names = "control";
+      reg = <0x0 0x2040000 0x0 0x040000>;
+    };
+    PLIC0: interrupt-controller@4000000 {
+      compatible = "riscv,plic0";
+      #address-cells = <0>;
+      #interrupt-cells = <1>;
+      interrupt-controller;
+      interrupts-extended = <&CPU0_intc 11 &CPU0_intc 9>;
+      riscv,max-priority = <7>;
+      riscv,ndev = <51>;
+      reg = <0x0 0x4000000 0x0 0x4000000>;
+    };
+  };
+};

--- a/tools/hardware.yml
+++ b/tools/hardware.yml
@@ -209,7 +209,7 @@ devices:
         kernel: PLIC_PPTR
         kernel_size: 0x04000000
 
-  # SiFive CLINT (HiFive, Polarfire, Ariane, QEMU RISC-V virt, Spike)
+  # SiFive CLINT (HiFive, Polarfire, Ariane, Cheshire, QEMU RISC-V virt, Spike)
   # Note that not all CLINTs with this compatible string are of the same size.
   # However, omitting the kernel_size field works as each kernel device frame
   # is of size 0x200000, which is currently larger than the CLINT's of all


### PR DESCRIPTION
This pull request adds support for the [Cheshire](https://github.com/pulp-platform/cheshire) platform - a system built around the CVA6 RISC-V APU design. This implementation specifically targets the Xilinx FPGA implementation of Cheshire for the Digilent Genesys 2 development board.

Cheshire is very similar to the extant Ariane CVA6 design supported by seL4, but is a system which is designed to have a stable interface and behaviour for 64 bit operating systems, as contrasted to a focus on 32 bit applications for Ariane.

Cheshire supports the RISC-V H-extension, but as of now it does not appear to work correctly under seL4 (apparently due to HW issues). As a result, this PR omits any H-extension related code.