### PR TITLE
machine/capdl.c: fix a corruption

### DIFF
--- a/src/machine/capdl.c
+++ b/src/machine/capdl.c
@@ -29,7 +29,7 @@ int watermark = 0;
 void add_to_seen(cap_t c)
 {
     /* Won't work well if there're more than SEEN_SZ cnode */
-    if (watermark <= SEEN_SZ) {
+    if (watermark < SEEN_SZ) {
         seen_list[watermark] = c;
         watermark++;
     }


### PR DESCRIPTION
This fixes a potential memory corruption in `add_to_seen()` function,