### PR TITLE
machine/statedata: align idle thread

### DIFF
--- a/src/model/statedata.c
+++ b/src/model/statedata.c
@@ -98,7 +98,7 @@ word_t ksDomScheduleIdx;
 word_t tlbLockCount = 0;
 
 /* Idle thread. */
-SECTION("._idle_thread") char ksIdleThreadTCB[CONFIG_MAX_NUM_NODES][BIT(seL4_TCBBits)] ALIGN(BIT(TCB_SIZE_BITS));
+SECTION("._idle_thread") char ksIdleThreadTCB[CONFIG_MAX_NUM_NODES][BIT(seL4_TCBBits)] ALIGN(BIT(seL4_TCBBits));
 
 #ifdef CONFIG_KERNEL_MCS
 /* Idle thread Schedcontexts */


### PR DESCRIPTION

The `TCB_PTR_CTE_PTR()` macro assumes that thread block aligns with `bit(seL4_TCBBits)`. However this is not true for the idle thread block, thus using the macro with idle thread leads to invalid results. This fixes the issue by apply same alignment to idle thread block so that the macro applies to all threads.
