### PR TITLE
manual/objects: clean garbage

### DIFF
--- a/manual/parts/objects.tex
+++ b/manual/parts/objects.tex
@@ -501,4 +501,3 @@ Useful constants for creating \obj{SchedContext} objects are listed below.
   refill\\
   \bottomrule
 \end{tabular}}
-  iz


### PR DESCRIPTION
This drops unnecessary `iz` text at chapter end.