### PR TITLE
hifive: reflect lower TIMER_PRECISION in config

### DIFF
--- a/src/plat/hifive/config.cmake
+++ b/src/plat/hifive/config.cmake
@@ -20,6 +20,7 @@ if(KernelPlatformHifive)
         TIMER_FREQUENCY 1000000
         MAX_IRQ 53
         INTERRUPT_CONTROLLER drivers/irq/riscv_plic0.h
+        TIMER_PRECISION 3u
     )
 else()
     unset(KernelPlatformFirstHartID CACHE)


### PR DESCRIPTION
Reflect the slow timer read on this platform by increasing the value for TIMER_PRECISION.

MCS+SMP+debug tests have been failing the clock sync boot test (see also issue #1053). The proposed fix, which was to make reading the timer faster, only works for certain OpenSBI versions and is not enabled by default.