### PR TITLE
tqma: remove virtualisation project settings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,11 +21,19 @@ description indicates whether it is SOURCE-COMPATIBLE, BINARY-COMPATIBLE, or BRE
 
 ---
 
-## Upcoming release: BINARY COMPATIBLE
+## Upcoming release: BREAKING
 
 ### Changes
 
 * Added `zynqmp` and `rpi4` to the set of verified AArch64 configs.
+
+### Platforms
+
+* Removed the default settings `KernelArmVtimerUpdateVOffset` and `KernelArmDisableWFIWFETraps` from the platform
+  `tqma8xqp1gb`, since they are project specific settings, not platform settings. Add
+  `set(KernelArmVtimerUpdateVOffset OFF)` and
+  `set(KernelArmDisableWFIWFETraps ON)`
+  to your project settings to get the same configuration as before if you are using `tqma8xqp1gb`.
 
 ### Upgrade Notes
 

--- a/src/plat/tqma8xqp1gb/config.cmake
+++ b/src/plat/tqma8xqp1gb/config.cmake
@@ -14,8 +14,6 @@ if(KernelPlatformTqma8xqp1gb)
     set(KernelArchArmV8a ON)
     set(KernelArmGicV3 ON)
     config_set(KernelARMPlatform ARM_PLAT ${KernelPlatform})
-    set(KernelArmVtimerUpdateVOffset OFF)
-    set(KernelArmDisableWFIWFETraps ON)
     list(APPEND KernelDTSList "tools/dts/${KernelPlatform}.dts")
     list(APPEND KernelDTSList "src/plat/tqma8xqp1gb/overlay-${KernelPlatform}.dts")
     declare_default_headers(


### PR DESCRIPTION
Following on from the [discussion](https://github.com/seL4/seL4/pull/1356#discussion_r1865124949) in #1356, the settings `KernelArmVtimerUpdateVOffset` and
`KernelArmDisableWFIWFETraps` should be project settings, not platform settings for `tqma`. The values set here are not required for the platform to work -- they just provide a different default.

Setting these in platform configs could lead to inconsistent project builds when switching between platforms.