### PR TITLE
github: pin style check to ubuntu-22.04

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,7 +29,7 @@ jobs:
 
   style:
     name: Style
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: seL4/ci-actions/style@master
 


### PR DESCRIPTION
The default python version changes on ubuntu-24, which breaks the version of cmake-format we are currently using.