### PR TITLE
boot: clear freeIndex of memory untypeds

### DIFF
--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -693,7 +693,7 @@ BOOT_CODE static bool_t provide_untyped_cap(
             .isDevice = device_memory,
             .padding  = {0}
         };
-        ut_cap = cap_untyped_cap_new(MAX_FREE_INDEX(size_bits),
+        ut_cap = cap_untyped_cap_new(device_memory ? MAX_FREE_INDEX(size_bits) : 0,
                                      device_memory, size_bits, pptr);
         ret = provide_cap(root_cnode_cap, ut_cap);
     } else {


### PR DESCRIPTION

Original untyped memory objects appear as fully used right after boot, thus confuses free memory calculation. This uses 0 freeIndex so that free memory calculation based on it is right at the beginning.
