### PR TITLE
aarch64: fix building with clang-18

### DIFF
--- a/include/arch/arm/arch/64/mode/machine/fpu.h
+++ b/include/arch/arm/arch/64/mode/machine/fpu.h
@@ -18,6 +18,7 @@ static inline void saveFpuState(user_fpu_state_t *dest)
 
     asm volatile(
         /* SIMD and floating-point register file */
+        ".arch_extension fp\n"
         "stp     q0, q1, [%1, #16 * 0]      \n"
         "stp     q2, q3, [%1, #16 * 2]      \n"
         "stp     q4, q5, [%1, #16 * 4]      \n"
@@ -40,6 +41,7 @@ static inline void saveFpuState(user_fpu_state_t *dest)
         "str     %w0, [%1, #16 * 32]        \n"
         "mrs     %0, fpcr                   \n"
         "str     %w0, [%1, #16 * 32 + 4]    \n"
+        ".arch_extension nofp\n"
         : "=&r"(temp)
         : "r"(dest)
         : "memory"
@@ -53,6 +55,7 @@ static inline void loadFpuState(user_fpu_state_t *src)
 
     asm volatile(
         /* SIMD and floating-point register file */
+        ".arch_extension fp\n"
         "ldp     q0, q1, [%1, #16 * 0]      \n"
         "ldp     q2, q3, [%1, #16 * 2]      \n"
         "ldp     q4, q5, [%1, #16 * 4]      \n"
@@ -75,6 +78,7 @@ static inline void loadFpuState(user_fpu_state_t *src)
         "msr     fpsr, %0                   \n"
         "ldr     %w0, [%1, #16 * 32 + 4]    \n"
         "msr     fpcr, %0                   \n"
+        ".arch_extension nofp\n"
         : "=&r"(temp)
         : "r"(src)
         : "memory"


### PR DESCRIPTION
On aarch64, clang interprets the compile option `-mgeneral-regs-only` as disabling all FPU-related registers and instructions, which not only include those generated by the compiler (which is how gcc would interpret this option), but also those in (inline) assemblies written explicitly by the programmer, which gcc does not forbid with this option. This commit enables FPU-related registers and instruction explicitly in the FPU-context switching code, so the kernel will build under clang-18 on aarch64.

LLVM project's issue tracking the inconsistency of this option between clang and gcc: https://github.com/llvm/llvm-project/issues/30140 --- it remains an open issue as of this writing.

Similar commit in other projects: https://github.com/TF-RMM/tf-rmm/commit/ffcc90415364933dcd5670226a0b9c9573f2c939