### PR TITLE
riscv: traps coming from s-mode should not be treated as a u-mode trap

### DIFF
--- a/src/arch/riscv/c_traps.c
+++ b/src/arch/riscv/c_traps.c
@@ -108,6 +108,15 @@ void VISIBLE NORETURN c_handle_interrupt(void)
 
 void VISIBLE NORETURN c_handle_exception(void)
 {
+#ifdef CONFIG_DEBUG_BUILD
+    if (read_sstatus() & SSTATUS_SPP) {
+        printf("\n\nKERNEL ABORT (exception within s-mode)!\n");
+        printf("scause: 0x%"SEL4_PRIx_word", stval: 0x%"SEL4_PRIx_word"\n",
+               read_scause(), read_stval());
+        halt();
+    }
+#endif
+
     NODE_LOCK_SYS;
 
     c_entry_hook();


### PR DESCRIPTION
These are never supposed to happen.
Note, that this will still run on the stack (for CONFIG_KERNEL_PRINTING) and so if page tables are corrupted, may fault, but it should be easier to flag this when looking at a debugger, provided that the trap handler code is still valid (but if it isn't, we can't do anything at all).

Not all traps will be handled via the s-mode trap handler; it depends on the value of the `medeleg` register. This appears to default to 0xf0b509 (in QEMU) and so we can catch page faults.

Without this, traps in the kernel will be attributed to a trap of the current running thread.

Previously, some kernel modifications that corrupted memory caused:

```
Caught cap fault in send phase at address 0
while trying to handle:
vm fault on data at address 0 with status ��7
in thread ��ffffffff8401bc00 "idle_thread" at address 0
With stack:
Invalid vspace
```

Now, the kernel prints out:

```
KERNEL ABORT (exception within s-mode)!
scause: 0xf, stval: 0x0
halting...
Kernel entry via Syscall, number: 1, Call
Cap type: 2, Invocation tag: 1
```

Part of the debug improvements as described in #1374.

Question:

- [x] I could do the check against the `SPP` bit only in debug mode? As opposed to always with different behaviour? This closer matches ARM but probably affects verification and syscall perf...
- [x] It probably should be possible to print out the $pc at when the fault happened?
- [ ] Sidenote: the traps.S is really inconsistent, and uses `x1` (which is calling convention the `$ra` register seemingly as a temporary) which is really confusing... I could fix this but the code isn't quite clear enough to me the execution flow to know the the rename from `$x1 -> $ra` would be semantically correct. I used `$t1` and `$t2` which I think should be fine.
- [ ] This should probably set `ksKernelEntry`, since it's what halt prints out, but there's not an appropriate entry kind to use?