### PR TITLE
vspace: userError for no unallocated ASID pools

### DIFF
--- a/src/arch/arm/32/kernel/vspace.c
+++ b/src/arch/arm/32/kernel/vspace.c
@@ -2547,8 +2547,8 @@ exception_t decodeARMMMUInvocation(word_t invLabel, word_t length, cptr_t cptr,
         /* Find first free pool */
         for (i = 0; i < nASIDPools && armKSASIDTable[i]; i++);
 
-        if (unlikely(i == nASIDPools)) { /* If no unallocated pool is found */
-            userError("ASIDControlMakePool: No free pools found.");
+        if (unlikely(i == nASIDPools)) {
+            userError("ASIDControlMakePool: No unallocated pools found.");
             current_syscall_error.type = seL4_DeleteFirst;
 
             return EXCEPTION_SYSCALL_ERROR;
@@ -2872,4 +2872,3 @@ void Arch_userStackTrace(tcb_t *tptr)
     }
 }
 #endif
-

--- a/src/arch/arm/64/kernel/vspace.c
+++ b/src/arch/arm/64/kernel/vspace.c
@@ -1745,7 +1745,8 @@ exception_t decodeARMMMUInvocation(word_t invLabel, word_t length, cptr_t cptr,
         /* Find first free pool */
         for (i = 0; i < nASIDPools && armKSASIDTable[i]; i++);
 
-        if (unlikely(i == nASIDPools)) { /* If no unallocated pool is found */
+        if (unlikely(i == nASIDPools)) {
+            userError("ASIDControlMakePool: No unallocated pools found.");
             current_syscall_error.type = seL4_DeleteFirst;
 
             return EXCEPTION_SYSCALL_ERROR;
@@ -1998,4 +1999,3 @@ exception_t benchmark_arch_map_logBuffer(word_t frame_cptr)
     return EXCEPTION_NONE;
 }
 #endif /* CONFIG_KERNEL_LOG_BUFFER */
-

--- a/src/arch/riscv/kernel/vspace.c
+++ b/src/arch/riscv/kernel/vspace.c
@@ -974,7 +974,7 @@ exception_t decodeRISCVMMUInvocation(word_t label, word_t length, cptr_t cptr,
         for (i = 0; i < nASIDPools && riscvKSASIDTable[i]; i++);
 
         if (i == nASIDPools) {
-            /* no unallocated pool is found */
+            userError("ASIDControlMakePool: No unallocated pools found.");
             current_syscall_error.type = seL4_DeleteFirst;
 
             return EXCEPTION_SYSCALL_ERROR;

--- a/src/arch/x86/kernel/vspace.c
+++ b/src/arch/x86/kernel/vspace.c
@@ -1304,7 +1304,7 @@ exception_t decodeX86MMUInvocation(
         for (i = 0; i < nASIDPools && x86KSASIDTable[i]; i++);
 
         if (i == nASIDPools) {
-            /* no unallocated pool is found */
+            userError("ASIDControlMakePool: No unallocated pools found.");
             current_syscall_error.type = seL4_DeleteFirst;
 
             return EXCEPTION_SYSCALL_ERROR;


### PR DESCRIPTION
This existed for ARM32, but not for ARM64, RISCV-V, or X86.

I'm not too fussed on the error message or the existence of the comment, feel free to adjust if desired.