### PR TITLE
constants: Add seL4_ASIDPoolMaxNewPools define

### DIFF
--- a/libsel4/arch_include/arm/interfaces/object-api-arch.xml
+++ b/libsel4/arch_include/arm/interfaces/object-api-arch.xml
@@ -440,6 +440,9 @@
                 Together with a capability to <texttt text="Untyped Memory"/>, which is passed as an argument,
                 create an <texttt text="ASID Pool"/>. The untyped capability must represent a
                 4K memory object. This will create an ASID pool with enough space for 1024 VSpaces.
+
+                A total of <texttt text="seL4_ASIDPoolMaxNewPools"/> can be created,
+                as some ASID pools are created by the kernel during boot.
             </description>
             <param dir="in" name="untyped" type="seL4_Untyped"
             description="Capability to an untyped memory object that will become the pool. Must be 4K bytes."/>

--- a/libsel4/arch_include/riscv/interfaces/object-api-arch.xml
+++ b/libsel4/arch_include/riscv/interfaces/object-api-arch.xml
@@ -235,6 +235,9 @@
                 Together with a capability to <texttt text="Untyped Memory"/>, which is passed as an argument,
                 create an <texttt text="ASID Pool"/>. The untyped capability must represent a
                 4K memory object. This will create an ASID pool with enough space for 1024 VSpaces.
+
+                A total of <texttt text="seL4_ASIDPoolMaxNewPools"/> can be created,
+                as some ASID pools are created by the kernel during boot.
             </description>
             <param dir="in" name="untyped" type="seL4_Untyped"
             description="Capability to an untyped memory object that will become the pool. Must be 4K bytes."/>

--- a/libsel4/arch_include/x86/interfaces/object-api-arch.xml
+++ b/libsel4/arch_include/x86/interfaces/object-api-arch.xml
@@ -482,6 +482,9 @@ contain the mapping"/>
                 Together with a capability to <texttt text="Untyped Memory"/>, which is passed as an argument,
                 create an <texttt text="ASID Pool"/>. The untyped capability must represent a
                 4K memory object. This will create an ASID pool with enough space for 1024 VSpaces.
+
+                A total of <texttt text="seL4_ASIDPoolMaxNewPools"/> can be created,
+                as some ASID pools are created by the kernel during boot.
             </description>
             <cap_param append_description='The master ASIDControl capability.'/>
             <param dir="in" name="untyped" type="seL4_Untyped"

--- a/libsel4/include/sel4/constants.h
+++ b/libsel4/include/sel4/constants.h
@@ -70,6 +70,11 @@ typedef enum {
 } seL4_LookupFailureType;
 #endif /* !__ASSEMBLER__ */
 
+/* The number of pools that can be created with seL4_ARCH_ASIDControl_MakePool
+   The initial thread is allocated an ASID pool (seL4_CapInitThreadASIDPool)
+   so we cannot make all 2^seL4NumASIDPoolsBits - but instead, one less. */
+#define seL4_ASIDPoolMaxNewPools (LIBSEL4_BIT(seL4_NumASIDPoolsBits)-1)
+
 #ifdef CONFIG_KERNEL_MCS
 /* Minimum size of a scheduling context (2^{n} bytes) */
 #define seL4_MinSchedContextBits 7


### PR DESCRIPTION
Previously sel4test had
```
#define N_ASID_POOLS ((int)BIT(seL4_NumASIDPoolsBits))
```
and then would do `N_ASID_POOLS - 1` for making new ASID pools. The 1 pool that couldn't be made was the initial thread's ASID. This exports a constant so that this becomes an implementation detail of the kernel.

Please see https://github.com/seL4/sel4test/pull/130 for adjustment to sel4test.

I'm not too fussed on the exact name or implementation of this, but had discussed this with @Ivan-Velickovic for the best way to do this. Happy to change if needed.

---

Justification: As part of the [time protection - kernel cloning work](https://github.com/seL4/l4v/blob/experimental-timeprot/proof/infoflow/timeprotection/timeprot-branches.md#initial-sel4test-bringup), an ASIDpool was allocated for the kernel image clones. This broke the sel4tests that depended on creating as many ASIDpools as they could.
We move the calculation of the number of allocate-able ASID pools to a kernel constant so that the kernel cloning changes won't break users.