### PR TITLE
cmake: add `riscv-none-elf-` as valid gcc prefix

### DIFF
--- a/gcc.cmake
+++ b/gcc.cmake
@@ -74,6 +74,7 @@ if("${CROSS_COMPILER_PREFIX}" STREQUAL "")
                 CROSS_COMPILER_PREFIX
                 "riscv64-unknown-linux-gnu-"
                 "riscv64-unknown-elf-"
+                "riscv64-none-elf-"
                 "riscv64-elf-"
             )
         endif()


### PR DESCRIPTION
The previous commit 05858be didn't actually add it to both instances of the if/else statement, and so doesn't actually work in all cases (e.g. with `../init-build.sh`).