### PR TITLE
platform_gen.h.in: remove platform_interrupt_t symbol

### DIFF
--- a/src/arch/arm/platform_gen.h.in
+++ b/src/arch/arm/platform_gen.h.in
@@ -16,7 +16,7 @@
 
 enum IRQConstants {
     maxIRQ                      = @CONFIGURE_MAX_IRQ@
-} platform_interrupt_t;
+};
 
 #define IRQ_CNODE_SLOT_BITS (@CONFIGURE_IRQ_SLOT_BITS@)
 

--- a/src/arch/riscv/platform_gen.h.in
+++ b/src/arch/riscv/platform_gen.h.in
@@ -35,7 +35,7 @@ enum IRQConstants {
 #endif
     KERNEL_TIMER_IRQ,
     maxIRQ = KERNEL_TIMER_IRQ,
-} platform_interrupt_t;
+};
 
 enum irqNumbers {
     irqInvalid = 0


### PR DESCRIPTION
Presumably intended to be something like

    typedef enum IRQConstants { ... } platform_interrupt_t;

this instead declares a symbol that is exported and kept in the binary, but is never used. Remove it.

Spotted as my kernel.elf binary contained a strange symbol:

     ffffffff8401b7f0 g     O .bss	0000000000000004 platform_interrupt_t

cc @wom-bat 