### PR TITLE
statedata: only define tlbLockCount for cortex-a8

### DIFF
--- a/include/arch/arm/arch/32/mode/model/statedata.h
+++ b/include/arch/arm/arch/32/mode/model/statedata.h
@@ -34,3 +34,6 @@ extern pde_t armUSGlobalPD[BIT(PD_INDEX_BITS)] VISIBLE;
 extern pte_t   armUSGlobalPT[BIT(PT_INDEX_BITS)]   VISIBLE;
 #endif /* CONFIG_ARM_HYPERVISOR_SUPPORT */
 
+#ifdef CONFIG_ARM_HAS_TLB_LOCK
+extern word_t armKSTlbLockCount VISIBLE;
+#endif /* CONFIG_ARM_HAS_TLB_LOCK */

--- a/include/model/statedata.h
+++ b/include/model/statedata.h
@@ -112,7 +112,6 @@ extern ticks_t ksDomainTime;
 #else
 extern word_t ksDomainTime;
 #endif
-extern word_t tlbLockCount VISIBLE;
 
 extern char ksIdleThreadTCB[CONFIG_MAX_NUM_NODES][BIT(seL4_TCBBits)];
 
@@ -130,4 +129,3 @@ extern paddr_t ksUserLogBuffer;
 #define MODE_NODE_STATE(_state)    MODE_NODE_STATE_ON_CORE(_state, getCurrentCPUIndex())
 #define ARCH_NODE_STATE(_state)    ARCH_NODE_STATE_ON_CORE(_state, getCurrentCPUIndex())
 #define NODE_STATE(_state)         NODE_STATE_ON_CORE(_state, getCurrentCPUIndex())
-

--- a/src/arch/arm/32/model/statedata.c
+++ b/src/arch/arm/32/model/statedata.c
@@ -57,3 +57,7 @@ UP_STATE_DEFINE(bool_t, armHSFPUEnabled);
 /* Null state for the Debug coprocessor's break/watchpoint registers */
 user_breakpoint_state_t armKSNullBreakpointState;
 #endif
+
+#ifdef CONFIG_ARM_HAS_TLB_LOCK
+word_t armKSTlbLockCount = 0;
+#endif /* CONFIG_ARM_HAS_TLB_LOCK */

--- a/src/arch/arm/armv/armv7-a/tlb.c
+++ b/src/arch/arm/armv/armv7-a/tlb.c
@@ -6,25 +6,25 @@
 
 #include <arch/machine/hardware.h>
 
-#if defined(CONFIG_ARM_CORTEX_A8)
+#if defined(CONFIG_ARM_HAS_TLB_LOCK)
 
 void lockTLBEntry(vptr_t vaddr)
 {
-    int n = tlbLockCount;
+    int n = armKSTlbLockCount;
     int x, y;
 
     /* tlbLockCount is used only in this function, which is called at most 2 times for unicore
        platforms (and we only have unicore A8 platforms). */
-    assert(tlbLockCount < 2);
+    assert(armKSTlbLockCount < 2);
     /* Since asserts are off in release mode, we enforce the bound on tlbLockCount manually, so we
        don't have to verify calling context. We need the bound to be sure the bit operations below
        are not undefined behaviour. We leave the assert in, because we want to know about it when
        the calling context ever changes. */
-    if (tlbLockCount >= 2) {
+    if (armKSTlbLockCount >= 2) {
         return;
     }
 
-    tlbLockCount ++;
+    armKSTlbLockCount++;
     /* Compute two values, x and y, to write to the lockdown register. */
 
     /* Before lockdown, base = victim = num_locked_tlb_entries. */
@@ -36,7 +36,6 @@ void lockTLBEntry(vptr_t vaddr)
     lockTLBEntryCritical(vaddr, x, y);
 }
 
-/* if CORTEX_A8 */
 #else
 
 /* We don't currently support TLB locking for other processors. */

--- a/src/arch/arm/config.cmake
+++ b/src/arch/arm/config.cmake
@@ -255,6 +255,12 @@ elseif(KernelArmCortexA9)
     config_set(KernelArmCacheLineSizeBits L1_CACHE_LINE_SIZE_BITS "5")
 endif()
 
+if(KernelArmCortexA8)
+    config_set(KernelArmHasTlbLock ARM_HAS_TLB_LOCK ON)
+else()
+    config_set(KernelArmHasTlbLock ARM_HAS_TLB_LOCK OFF)
+endif()
+
 add_sources(
     DEP "KernelArchARM"
     PREFIX src/arch/arm

--- a/src/model/statedata.c
+++ b/src/model/statedata.c
@@ -94,9 +94,6 @@ word_t ksDomainTime;
 /* An index into ksDomSchedule for active domain and length. */
 word_t ksDomScheduleIdx;
 
-/* Only used by lockTLBEntry */
-word_t tlbLockCount = 0;
-
 /* Idle thread. */
 SECTION("._idle_thread") char ksIdleThreadTCB[CONFIG_MAX_NUM_NODES][BIT(seL4_TCBBits)] ALIGN(BIT(seL4_TCBBits));
 


### PR DESCRIPTION
Again, variable was noticed in the objdump of a RISC-V build, despite only being used for a specific ARM CortexA8 platform.

Hopefully this one doesn't affect the proofs, it's not referenced in l4v so :)