### PR TITLE
arm: Save VCPU virt timer registers when disabled

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,16 @@ description indicates whether it is SOURCE-COMPATIBLE, BINARY-COMPATIBLE, or BRE
   KernelArmTLSReg can be used to select either `tpidru` or `tpidruro` as the TLS register used for `seL4_TCB_SetTLSBase` and `seL4_SetTLSBase` operations.
   This config option's default value is `tpidru` which is what the register that the kernel currently uses for the TLS register for aarch32 and aarch64 platforms.
 
+* Fixed: under some circumstances, writes by a VMM to VCPU timer registers could have been reverted by the kernel to
+  their previous state. This was triggered when:
+
+  * a VCPU thread was running,
+  * the VCPU was then disabled but remained active by switching to a non-VCPU thread,
+  * that VCPU thread had the VCPU cap and performed the timer register writes,
+  * and execution then switched back to the VCPU thread.
+
+  This was found by Alison Felizzi and independently by Ryan Barry during the integrity proofs for AArch64 hyp mode.
+
 ### Upgrade Notes
 
 ---

--- a/include/arch/arm/armv/armv7-a/armv/vcpu.h
+++ b/include/arch/arm/armv/armv7-a/armv/vcpu.h
@@ -848,6 +848,11 @@ static inline bool_t vcpu_reg_saved_when_disabled(word_t field)
 {
     switch (field) {
     case seL4_VCPUReg_SCTLR:
+    case seL4_VCPUReg_CNTV_CTL:
+    case seL4_VCPUReg_CNTV_CVALhigh:
+    case seL4_VCPUReg_CNTV_CVALlow:
+    case seL4_VCPUReg_CNTVOFFhigh:
+    case seL4_VCPUReg_CNTVOFFlow:
         return true;
     default:
         return false;

--- a/include/arch/arm/armv/armv8-a/64/armv/vcpu.h
+++ b/include/arch/arm/armv/armv8-a/64/armv/vcpu.h
@@ -744,6 +744,9 @@ static inline bool_t vcpu_reg_saved_when_disabled(word_t field)
     switch (field) {
     case seL4_VCPUReg_SCTLR:
     case seL4_VCPUReg_CNTV_CTL:
+    case seL4_VCPUReg_CNTV_CVAL:
+    case seL4_VCPUReg_CNTVOFF:
+    case seL4_VCPUReg_CNTKCTL_EL1:
 #ifdef CONFIG_HAVE_FPU
     case seL4_VCPUReg_CPACR:
 #endif


### PR DESCRIPTION
The virtual timer registers managed within a VCPU context are not saved if written to, if the VCPU in question is disabled. This results in any updates to the virtual timer registers being lost/written over when that VCPU is next scheduled and context switched in.