### PR TITLE
Ensure the memory ordering of IPI arguments and the IPI pending flag for aarch64 using address dependency

### DIFF
--- a/include/smp/ipi.h
+++ b/include/smp/ipi.h
@@ -14,21 +14,18 @@
 #ifdef ENABLE_SMP_SUPPORT
 #define MAX_IPI_ARGS    3   /* Maximum number of parameters to remote function */
 
+struct ipi_args {
+    word_t remoteCall;          // IPI remote call type
+    word_t args[MAX_IPI_ARGS];  // IPI remote call args
+    word_t totalCoreBarrier;    // Number of cores involved
+};
+
 static volatile struct {
     word_t count;
     word_t globalsense;
 
     PAD_TO_NEXT_CACHE_LN(sizeof(word_t) + sizeof(word_t));
 } ipiSyncBarrier = {0};                  /* IPI barrier for remote call synchronization */
-
-static volatile word_t totalCoreBarrier; /* number of cores involved in IPI 'in progress' */
-static word_t ipi_args[MAX_IPI_ARGS];    /* data to be passed to the remote call function */
-
-static inline word_t get_ipi_arg(word_t n)
-{
-    assert(n < MAX_IPI_ARGS);
-    return ipi_args[n];
-}
 
 static inline void ipi_wait(word_t cores)
 {

--- a/include/smp/lock.h
+++ b/include/smp/lock.h
@@ -25,7 +25,7 @@ typedef enum {
 } clh_qnode_state_t;
 
 typedef struct clh_qnode {
-    clh_qnode_state_t value;
+    volatile clh_qnode_state_t value;
 
     PAD_TO_NEXT_CACHE_LN(sizeof(clh_qnode_state_t));
 } clh_qnode_t;

--- a/include/smp/lock.h
+++ b/include/smp/lock.h
@@ -34,7 +34,7 @@ typedef struct clh_qnode_p {
     clh_qnode_t *node;
     clh_qnode_t *next;
     /* This is the software IPI flag */
-    word_t ipi;
+    volatile void        *ipi;
 
     PAD_TO_NEXT_CACHE_LN(sizeof(clh_qnode_t *) +
                          sizeof(clh_qnode_t *) +
@@ -54,7 +54,7 @@ BOOT_CODE void clh_lock_init(void);
 
 static inline bool_t FORCE_INLINE clh_is_ipi_pending(word_t cpu)
 {
-    return big_kernel_lock.node_owners[cpu].ipi == 1;
+    return big_kernel_lock.node_owners[cpu].ipi != NULL;
 }
 
 static inline void *sel4_atomic_exchange(void *ptr, bool_t

--- a/src/arch/x86/smp/ipi.c
+++ b/src/arch/x86/smp/ipi.c
@@ -11,27 +11,19 @@
 
 #ifdef ENABLE_SMP_SUPPORT
 
-static IpiModeRemoteCall_t remoteCall;   /* the remote call being requested */
-
-static inline void init_ipi_args(IpiRemoteCall_t func,
-                                 word_t data1, word_t data2, word_t data3,
-                                 word_t mask)
+static void handleRemoteCall(bool_t irqPath)
 {
-    remoteCall = (IpiModeRemoteCall_t)func;
-    ipi_args[0] = data1;
-    ipi_args[1] = data2;
-    ipi_args[2] = data3;
-
-    /* get number of cores involved in this IPI */
-    totalCoreBarrier = popcountl(mask);
-}
-
-static void handleRemoteCall(IpiModeRemoteCall_t call, word_t arg0,
-                             word_t arg1, word_t arg2, bool_t irqPath)
-{
+    cpu_id_t core = getCurrentCPUIndex();
     /* we gets spurious irq_remote_call_ipi calls, e.g. when handling IPI
      * in lock while hardware IPI is pending. Guard against spurious IPIs! */
-    if (clh_is_ipi_pending(getCurrentCPUIndex())) {
+    if (clh_is_ipi_pending(core)) {
+        struct ipi_args *args = (struct ipi_args *)big_kernel_lock.node_owners[core].ipi;
+        IpiRemoteCall_t call = args->remoteCall;
+        word_t arg0 = args->args[0];
+        word_t arg1 = args->args[1];
+        word_t arg2 = args->args[2];
+        word_t totalCoreBarrier = args->totalCoreBarrier;
+
         switch ((IpiRemoteCall_t)call) {
         case IpiRemoteCall_Stall:
             ipiStallCoreCallback(irqPath);
@@ -66,11 +58,11 @@ static void handleRemoteCall(IpiModeRemoteCall_t call, word_t arg0,
             break;
 #endif
         default:
-            Mode_handleRemoteCall(call, arg0, arg1, arg2);
+            Mode_handleRemoteCall((IpiModeRemoteCall_t)args->remoteCall, arg0, arg1, arg2);
             break;
         }
 
-        big_kernel_lock.node_owners[getCurrentCPUIndex()].ipi = 0;
+        big_kernel_lock.node_owners[core].ipi = NULL;
         ipi_wait(totalCoreBarrier);
     }
 }

--- a/src/smp/ipi.c
+++ b/src/smp/ipi.c
@@ -25,7 +25,7 @@ static inline void init_ipi_args(IpiRemoteCall_t func, word_t data0,
     /* Get number of cores involved in this IPI */
     ipi_args.totalCoreBarrier = popcountl(mask);
 
-#ifdef CONFIG_ARCH_AARCH64
+#ifdef CONFIG_ARCH_ARM
     /* This is to make sure if a write to ebig_kernel_lock.node_owners[target_core].ipi
      * is observed, the above writes are also observed by readers according the
      * address dependancy.


### PR DESCRIPTION
The struct ipi_args is introduced to group related IPI remote call data into one struct. The ipi field in struct clh_qnode_p is also changed to void *. When IPI remote call is initiated, the ipi_args is initialised first, and then the address of ipi_args is assigned to the ipi field. A dmb ishst is used to ensure the order of writes. On the reader side, the address of ipi_args is read from the ipi field first, then the fields of the ipi_args are accessed through the pointer, creating address dependencies. Thus, the reads are order without using a memory barrier regarding to the pointer.

RISC-V and x86 are also updated, but the required memory barrier for RISC-V is not added yet.

