### PR TITLE
document&rename breakpoint_stack (arm32), remove it (riscv/arm64)

### DIFF
--- a/src/arch/arm/32/head.S
+++ b/src/arch/arm/32/head.S
@@ -153,9 +153,12 @@ BEGIN_FUNC(_start)
 
     /* Hyp kernel always run in Hyp mode. */
 #ifndef CONFIG_ARM_HYPERVISOR_SUPPORT
-    /* Initialise ABORT stack pointer */
+    /* Initialise ABORT stack pointer.
+     * For ARM, the `sp' register is banked between PMODEs, so we configure
+     * a stack for when we take a exception (see traps.S, where we then switch
+     * modes and load the real kernel stack). */
     cps #PMODE_ABORT
-    ldr sp, =_breakpoint_stack_top
+    ldr sp, =_abort_stack_top
     cps #PMODE_SUPERVISOR
 #endif
 

--- a/src/arch/arm/32/traps.S
+++ b/src/arch/arm/32/traps.S
@@ -132,6 +132,8 @@ END_FUNC(arm_prefetch_abort_exception)
 BEGIN_FUNC(arm_data_abort_exception)
     /* Full save/restore, documented in arm_swi_syscall */
     srsia #PMODE_SUPERVISOR
+    /* This also loads the Supervisor mode's banked registers, switching away
+     * from the ABORT stack pointer. See also heads.S where it is set up. */
     cps #PMODE_SUPERVISOR
     stmdb sp, {r0-lr}^
 

--- a/src/arch/arm/common_arm.lds
+++ b/src/arch/arm/common_arm.lds
@@ -64,10 +64,12 @@ SECTIONS
         *(.bss)
         *(COMMON) /* fallback in case '-fno-common' is not used */
 
-        /* 4k breakpoint stack */
-        _breakpoint_stack_bottom = .;
+#if defined(CONFIG_ARCH_AARCH32) && !defined(CONFIG_ARM_HYPERVISOR_SUPPORT)
+        /* 4k abort stack, needed for PMODE_ABORT on ARM32 */
+        _abort_stack_bottom = .;
         . = . + 4K;
-        _breakpoint_stack_top = .;
+        _abort_stack_top = .;
+#endif
 
         /* large data such as the globals frame and global PD */
         *(.bss.aligned)

--- a/src/arch/riscv/common_riscv.lds
+++ b/src/arch/riscv/common_riscv.lds
@@ -87,11 +87,6 @@ SECTIONS
         *(.bss)
         *(COMMON) /* fallback in case '-fno-common' is not used */
 
-        /* 4k breakpoint stack */
-        _breakpoint_stack_bottom = .;
-        . = . + 4K;
-        _breakpoint_stack_top = .;
-
         /* large data such as the globals frame and global PD */
         *(.bss.aligned)
 #if defined(CONFIG_PLAT_ROCKETCHIP_ZCU102)


### PR DESCRIPTION
For ARM:

Essentially, the `sp' register is banked between different PMODEs.

https://developer.arm.com/documentation/den0013/d/ARM-Processor-Modes-and-Registers/Registers

We initialise a stack that we will begin on when handling an exception.

For RISC-V:
Presumably this was copied from the ARM linker script without knowing why it was there, as no RISC-V code references it.