### PR TITLE
state: try to const-ify ksNumCPUs and ksCurDomain

### DIFF
--- a/include/model/statedata.h
+++ b/include/model/statedata.h
@@ -92,7 +92,11 @@ NODE_STATE_DECLARE(timestamp_t, benchmark_kernel_number_schedules);
 
 NODE_STATE_END(nodeState);
 
+#ifdef ENABLE_SMP_SUPPORT
 extern word_t ksNumCPUs;
+#else
+const word_t ksNumCPUs = 1;
+#endif
 
 #if defined ENABLE_SMP_SUPPORT && defined CONFIG_ARCH_ARM
 #define INT_STATE_ARRAY_SIZE ((CONFIG_MAX_NUM_NODES - 1) * NUM_PPI + maxIRQ + 1)
@@ -106,7 +110,13 @@ extern cte_t intStateIRQNode[];
 extern const dschedule_t ksDomSchedule[];
 extern const word_t ksDomScheduleLength;
 extern word_t ksDomScheduleIdx;
+
+#if CONFIG_NUM_DOMAINS > 1
 extern dom_t ksCurDomain;
+#else
+const dom_t ksCurDomain = 0;
+#endif
+
 #ifdef CONFIG_KERNEL_MCS
 extern ticks_t ksDomainTime;
 #else
@@ -130,4 +140,3 @@ extern paddr_t ksUserLogBuffer;
 #define MODE_NODE_STATE(_state)    MODE_NODE_STATE_ON_CORE(_state, getCurrentCPUIndex())
 #define ARCH_NODE_STATE(_state)    ARCH_NODE_STATE_ON_CORE(_state, getCurrentCPUIndex())
 #define NODE_STATE(_state)         NODE_STATE_ON_CORE(_state, getCurrentCPUIndex())
-

--- a/src/arch/arm/kernel/boot.c
+++ b/src/arch/arm/kernel/boot.c
@@ -607,7 +607,7 @@ static BOOT_CODE bool_t try_init_kernel(
         invalidateHypTLB();
     }
 
-    ksNumCPUs = 1;
+    SMP_COND_STATEMENT(ksNumCPUs = 1);
 
     /* initialize BKL before booting up other cores */
     SMP_COND_STATEMENT(clh_lock_init());

--- a/src/arch/riscv/kernel/boot.c
+++ b/src/arch/riscv/kernel/boot.c
@@ -437,7 +437,7 @@ static BOOT_CODE bool_t try_init_kernel(
     /* finalise the bootinfo frame */
     bi_finalise();
 
-    ksNumCPUs = 1;
+    SMP_COND_STATEMENT(ksNumCPUs = 1);
 
     SMP_COND_STATEMENT(clh_lock_init());
     SMP_COND_STATEMENT(release_secondary_cores());

--- a/src/arch/x86/kernel/boot_sys.c
+++ b/src/arch/x86/kernel/boot_sys.c
@@ -483,7 +483,7 @@ static BOOT_CODE bool_t try_boot_sys(void)
     }
 
     /* Total number of cores we intend to boot */
-    ksNumCPUs = boot_state.num_cpus;
+    SMP_COND_STATEMENT(ksNumCPUs = boot_state.num_cpus);
 
     printf("Starting node #0 with APIC ID %lu\n", boot_state.cpus[0]);
     if (!try_boot_sys_node(boot_state.cpus[0])) {
@@ -733,4 +733,3 @@ BOOT_CODE VISIBLE void boot_sys(
     schedule();
     activateThread();
 }
-

--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -541,7 +541,11 @@ BOOT_CODE tcb_t *create_initial_thread(cap_t root_cnode_cap, cap_t it_pd_cap, vp
 #endif
     setThreadState(tcb, ThreadState_Running);
 
+#if CONFIG_NUM_DOMAINS > 1
     ksCurDomain = ksDomSchedule[ksDomScheduleIdx].domain;
+#else
+    assert(ksDomSchedule[ksDomScheduleIdx].domain == ksCurDomain);
+#endif
 #ifdef CONFIG_KERNEL_MCS
     ksDomainTime = usToTicks(ksDomSchedule[ksDomScheduleIdx].length * US_IN_MS);
 #else

--- a/src/kernel/thread.c
+++ b/src/kernel/thread.c
@@ -309,7 +309,11 @@ static void nextDomain(void)
     NODE_STATE(ksReprogram) = true;
 #endif
     ksWorkUnitsCompleted = 0;
+#if CONFIG_NUM_DOMAINS > 1
     ksCurDomain = ksDomSchedule[ksDomScheduleIdx].domain;
+#else
+    assert(ksDomSchedule[ksDomScheduleIdx].domain == ksCurDomain);
+#endif
 #ifdef CONFIG_KERNEL_MCS
     ksDomainTime = usToTicks(ksDomSchedule[ksDomScheduleIdx].length * US_IN_MS);
 #else

--- a/src/model/statedata.c
+++ b/src/model/statedata.c
@@ -18,7 +18,7 @@
 SMP_STATE_DEFINE(smpStatedata_t, ksSMP[CONFIG_MAX_NUM_NODES] ALIGN(L1_CACHE_LINE_SIZE));
 
 /* Global count of how many cpus there are */
-word_t ksNumCPUs;
+SMP_STATE_DEFINE(word_t, ksNumCPUs);
 
 /* Pointer to the head of the scheduler queue for each priority */
 UP_STATE_DEFINE(tcb_queue_t, ksReadyQueues[NUM_READY_QUEUES]);
@@ -81,8 +81,10 @@ irq_state_t intStateIRQTable[INT_STATE_ARRAY_SIZE];
 cte_t intStateIRQNode[BIT(IRQ_CNODE_SLOT_BITS)] ALIGN(BIT(IRQ_CNODE_SLOT_BITS + seL4_SlotBits));
 compile_assert(irqCNodeSize, sizeof(intStateIRQNode) >= ((INT_STATE_ARRAY_SIZE) *sizeof(cte_t)));
 
+#if CONFIG_NUM_DOMAINS > 1
 /* Currently active domain */
 dom_t ksCurDomain;
+#endif
 
 /* Domain timeslice remaining */
 #ifdef CONFIG_KERNEL_MCS


### PR DESCRIPTION
This means that they do not need to be allocated storage, and the compiler can do constant folding as necessary (instead of the manual constant-folding previously done for ksCurDomain). This removes the exported symbols from the BSS segment, as they are no longer shared.