### PR TITLE
libsel4: fix riscv ASIDcontrol param descriptions

### DIFF
--- a/libsel4/arch_include/riscv/interfaces/object-api-arch.xml
+++ b/libsel4/arch_include/riscv/interfaces/object-api-arch.xml
@@ -239,9 +239,9 @@
             <param dir="in" name="untyped" type="seL4_Untyped"
             description="Capability to an untyped memory object that will become the pool. Must be 4K bytes."/>
             <param dir="in" name="root" type="seL4_CNode"
-            description="CPtr to the CNode that forms the root of the destination CSpace. Must be at a depth of 32."/>
+            description="CPtr to the CNode that forms the root of the destination CSpace. Must be at a depth equivalent to the wordsize."/>
             <param dir="in" name="index" type="seL4_Word"
-            description="CPtr to the CNode that forms the root of the destination CSpace. Must be at a depth of 32."/>
+            description="CPtr to the destination slot. Resolved from the root of the destination CSpace."/>
             <param dir="in" name="depth" type="seL4_Uint8"
             description="Number of bits of index to resolve to find the destination slot."/>
             <error name="seL4_DeleteFirst">


### PR DESCRIPTION
Nowhere else in the documentation uses the phrase

    "Must be a depth of 32"

which also seems incorrect for 64-bit riscv.

Also, the index parameter had the same description as root, which is incorrect.