### PR TITLE
arm: guarantee write to GIC ICENABLERn is observed

### DIFF
--- a/src/arch/arm/machine/gic_v3.c
+++ b/src/arch/arm/machine/gic_v3.c
@@ -111,7 +111,7 @@ static uint32_t gicv3_do_wait_for_rwp(volatile uint32_t *ctlr_addr)
     return ret;
 }
 
-static void gicv3_dist_wait_for_rwp(void)
+void gicv3_dist_wait_for_rwp(void)
 {
     gicv3_do_wait_for_rwp(&gic_dist->ctlr);
 }


### PR DESCRIPTION
This is necessary, (even if not sufficient) to fix #612. At the moment we also aren't executing a DSB instruction to ensure completion of writes (see §12.1.6 of [1]). DSB instructions to *appear* to completely resolve #612, but more investigation is in progress to see if this is correct.

> Completion of a write to this register does not guarantee that the
> effects of the write are visible throughout the affinity hierarchy. To
> ensure an enable has been cleared, software must write to the register
> with bits set to 1 to clear the required enables. Software must then
> poll `GICD_CTLR.RWP`` until it has the value zero.
> --- §12.9.7, GICD_ICENABLER<n>, Interrupt Clear-Enable Registers. [1]

[1]: ARM Generic Interrupt Controller Architectural Specification (GICv3/v4)
     Issue G. https://www.scs.stanford.edu/~zyedidia/docs/arm/gic_v3.pdf

cc @Ivan-Velickovic 