### PR TITLE
arm,tls: Add config option KernelArmTLSReg

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,12 @@ description indicates whether it is SOURCE-COMPATIBLE, BINARY-COMPATIBLE, or BRE
   `set(KernelArmDisableWFIWFETraps ON)`
   to your project settings to get the same configuration as before if you are using `tqma8xqp1gb`.
 
+#### Arm
+
+* Added config option for selecting which thread ID register is used for Kernel TLS syscalls and invocations.
+  KernelArmTLSReg can be used to select either `tpidru` or `tpidruro` as the TLS register used for `seL4_TCB_SetTLSBase` and `seL4_SetTLSBase` operations.
+  This config option's default value is `tpidru` which is what the register that the kernel currently uses for the TLS register for aarch32 and aarch64 platforms.
+
 ### Upgrade Notes
 
 ---

--- a/include/arch/arm/arch/32/mode/machine/registerset.h
+++ b/include/arch/arm/arch/32/mode/machine/registerset.h
@@ -100,9 +100,13 @@ enum _register {
     /* user readable/writable thread ID register.
      * name comes from the ARM manual */
     TPIDRURW = 18,
-    TLS_BASE = TPIDRURW,
     /* user readonly thread ID register. */
     TPIDRURO = 19,
+#ifdef CONFIG_ARM_TLS_REG_TPIDRU
+    TLS_BASE = TPIDRURW,
+#elif defined(CONFIG_ARM_TLS_REG_TPIDRURO)
+    TLS_BASE = TPIDRURO,
+#endif
     n_contextRegisters = 20,
 };
 

--- a/include/arch/arm/arch/64/mode/machine/registerset.h
+++ b/include/arch/arm/arch/64/mode/machine/registerset.h
@@ -143,9 +143,13 @@ enum _register {
     /* user readable/writable thread ID register.
      * name comes from the ARM manual */
     TPIDR_EL0                   = 35,
-    TLS_BASE                    = TPIDR_EL0,
     /* user readonly thread ID register. */
     TPIDRRO_EL0                 = 36,
+#ifdef CONFIG_ARM_TLS_REG_TPIDRU
+    TLS_BASE = TPIDR_EL0,
+#elif defined(CONFIG_ARM_TLS_REG_TPIDRURO)
+    TLS_BASE = TPIDRRO_EL0,
+#endif
     n_contextRegisters          = 37,
 };
 

--- a/src/arch/arm/config.cmake
+++ b/src/arch/arm/config.cmake
@@ -218,6 +218,21 @@ config_option(
     DEPENDS "NOT KernelVerificationBuild; KernelSel4ArchAarch64"
 )
 
+config_choice(
+    KernelArmTLSReg
+    ARM_TLS_REG
+    "Which TLS register is used for Kernel TLS syscalls and invocations. \
+    The usual registers used by gnu-elf ABIs are: \
+    - on aarch32: tpidruro \
+    - on aarch64: tpidru."
+    "tpidru;KernelArmTLSRegTPIDRU;ARM_TLS_REG_TPIDRU;KernelArchARM"
+    "tpidruro;KernelArmTLSRegTPIDRURO;ARM_TLS_REG_TPIDRURO;KernelArchARM"
+)
+
+if(KernelArmTLSRegTPIDRURO)
+    set(KernelSetTLSBaseSelf ON)
+endif()
+
 if(KernelAArch32FPUEnableContextSwitch OR KernelSel4ArchAarch64)
     set(KernelHaveFPU ON)
 endif()


### PR DESCRIPTION
Make which user thread ID register used by the kernel for its TLS operations configurable. Either tpidru or tpidruro can be selected which map to architecture registers tpidru and tpidruro on aarch32 and tpidr_el0 and tpirrro_el0 on aarch64.

The default value of this option is tpidru to stay compatible with the kernel's current behaviour.

Addresses: #1216 