### PR TITLE
Add SBI region to accessible device memory range in platform_gen

### DIFF
--- a/tools/hardware/config.py
+++ b/tools/hardware/config.py
@@ -90,16 +90,13 @@ class RISCVConfig(Config):
         ''' Currently the RISC-V port expects physBase to be the address that the
         bootloader is loaded at. To be generalised in the future. '''
         ret = sorted(regions)
-        extra_reserved = set()
 
         physBase = ret[0].base
 
-        resv = Region(ret[0].base, self.get_bootloader_reserve())
-        extra_reserved.add(resv)
         ret[0].base += self.get_bootloader_reserve()
         ret[0].size -= self.get_bootloader_reserve()
 
-        return ret, extra_reserved, physBase
+        return ret, set(), physBase
 
     def get_device_page_bits(self) -> int:
         ''' Get page size in bits for mapping devices for this arch '''


### PR DESCRIPTION
Closes: https://github.com/seL4/seL4/issues/1197

In RISC-V, the first 2MiB of RAM is reserved as the SBI region. When exporting accessible memory ranges, this is currently dealt with in `config/hardware_gen.py` by excluding range from normal memory and putting it in a special reserved region that is analagous to a device used by seL4. However, it is not actually reserved by seL4 and IS accessible as device untyped to users despite being missing from the platform_gen.json/platform_gen.yaml files, which causes problems for Microkit as it's simulation of the boot untypeds does not correspond with reality. This patch adds the SBI region to the accessible device memory ranges to correctly match the implementation. 

Edit: After this patch, the resulting platform_gen.yaml looks like (of note, the third region ends at 0x80200000 instead of 0x80000000):

```yaml
devices:
- end: 0x2000000
  start: 0x0
- end: 0xc000000
  start: 0x2200000
- end: 0x80200000
  start: 0xc600000
- end: 0x8000000000
  start: 0x100000000
memory:
- end: 0x100000000
  start: 0x80200000
  ```