### PR TITLE
riscv: rename incorrect level2_pt -> level1_pt

### DIFF
--- a/include/arch/riscv/arch/model/statedata.h
+++ b/include/arch/riscv/arch/model/statedata.h
@@ -27,12 +27,11 @@ extern asid_pool_t *riscvKSASIDTable[BIT(asidHighBits)];
 /* Kernel Page Tables */
 extern pte_t kernel_root_pageTable[BIT(PT_INDEX_BITS)] VISIBLE;
 
-/* We need to introduce a level2 pagetable in order to map OpenSBI to a separate
- * page entry to avoid PMP exception. */
+/* We need to introduce a level 1 page table in order to map OpenSBI into
+   a separate 2MiB page to avoid a PMP exception */
 #if __riscv_xlen != 32
-extern pte_t kernel_image_level2_pt[BIT(PT_INDEX_BITS)];
-extern pte_t kernel_image_level2_dev_pt[BIT(PT_INDEX_BITS)];
+extern pte_t kernel_image_level1_pt[BIT(PT_INDEX_BITS)];
+extern pte_t kernel_image_level1_dev_pt[BIT(PT_INDEX_BITS)];
 #elif defined(CONFIG_KERNEL_LOG_BUFFER)
-extern pte_t kernel_image_level2_log_buffer_pt[BIT(PT_INDEX_BITS)];
+extern pte_t kernel_image_level1_log_buffer_pt[BIT(PT_INDEX_BITS)];
 #endif
-

--- a/src/arch/riscv/kernel/vspace.c
+++ b/src/arch/riscv/kernel/vspace.c
@@ -91,10 +91,10 @@ BOOT_CODE void map_kernel_frame(paddr_t paddr, pptr_t vaddr, vm_rights_t vm_righ
     kernel_root_pageTable[RISCV_GET_PT_INDEX(vaddr, 0)] = pte_next(paddr, true);
 #else
     if (vaddr >= KDEV_BASE) {
-        /* Map devices in 2nd-level page table */
+        /* Map devices in level 1 page table */
         paddr = ROUND_DOWN(paddr, RISCV_GET_LVL_PGSIZE_BITS(1));
         assert((paddr % RISCV_GET_LVL_PGSIZE(1)) == 0);
-        kernel_image_level2_dev_pt[RISCV_GET_PT_INDEX(vaddr, 1)] = pte_next(paddr, true);
+        kernel_image_level1_dev_pt[RISCV_GET_PT_INDEX(vaddr, 1)] = pte_next(paddr, true);
     } else {
         paddr = ROUND_DOWN(paddr, RISCV_GET_LVL_PGSIZE_BITS(0));
         assert((paddr % RISCV_GET_LVL_PGSIZE(0)) == 0);
@@ -134,19 +134,19 @@ BOOT_CODE VISIBLE void map_kernel_window(void)
     paddr += RISCV_GET_LVL_PGSIZE(0);
 #ifdef CONFIG_KERNEL_LOG_BUFFER
     kernel_root_pageTable[RISCV_GET_PT_INDEX(KS_LOG_PPTR, 0)] =
-        pte_next(kpptr_to_paddr(kernel_image_level2_log_buffer_pt), false);
+        pte_next(kpptr_to_paddr(kernel_image_level1_log_buffer_pt), false);
 #endif
 #else
     word_t index = 0;
     /* The kernel image is mapped twice, locating the two indexes in the
-     * root page table, pointing them to the same second level page table.
+     * root page table, pointing them to the same level 1 page table.
      */
     kernel_root_pageTable[RISCV_GET_PT_INDEX(KERNEL_ELF_PADDR_BASE + PPTR_BASE_OFFSET, 0)] =
-        pte_next(kpptr_to_paddr(kernel_image_level2_pt), false);
+        pte_next(kpptr_to_paddr(kernel_image_level1_pt), false);
     kernel_root_pageTable[RISCV_GET_PT_INDEX(pptr, 0)] =
-        pte_next(kpptr_to_paddr(kernel_image_level2_pt), false);
+        pte_next(kpptr_to_paddr(kernel_image_level1_pt), false);
     while (pptr < PPTR_TOP + RISCV_GET_LVL_PGSIZE(0)) {
-        kernel_image_level2_pt[index] = pte_next(paddr, true);
+        kernel_image_level1_pt[index] = pte_next(paddr, true);
         index++;
         pptr += RISCV_GET_LVL_PGSIZE(1);
         paddr += RISCV_GET_LVL_PGSIZE(1);
@@ -154,7 +154,7 @@ BOOT_CODE VISIBLE void map_kernel_window(void)
 
     /* Map kernel device page table */
     kernel_root_pageTable[RISCV_GET_PT_INDEX(KDEV_BASE, 0)] =
-        pte_next(kpptr_to_paddr(kernel_image_level2_dev_pt), false);
+        pte_next(kpptr_to_paddr(kernel_image_level1_dev_pt), false);
 #endif
 
     /* There should be free space where we put device mapping */
@@ -1225,12 +1225,12 @@ exception_t benchmark_arch_map_logBuffer(word_t frame_cptr)
 #if __riscv_xlen == 32
     paddr_t physical_address = ksUserLogBuffer;
     for (word_t i = 0; i < BIT(PT_INDEX_BITS); i += 1) {
-        kernel_image_level2_log_buffer_pt[i] = pte_next(physical_address, true);
+        kernel_image_level1_log_buffer_pt[i] = pte_next(physical_address, true);
         physical_address += BIT(PAGE_BITS);
     }
     assert(physical_address - ksUserLogBuffer == BIT(seL4_LargePageBits));
 #else
-    kernel_image_level2_dev_pt[RISCV_GET_PT_INDEX(KS_LOG_PPTR, 1)] = pte_next(ksUserLogBuffer, true);
+    kernel_image_level1_dev_pt[RISCV_GET_PT_INDEX(KS_LOG_PPTR, 1)] = pte_next(ksUserLogBuffer, true);
 #endif
 
     sfence();

--- a/src/arch/riscv/model/statedata.c
+++ b/src/arch/riscv/model/statedata.c
@@ -21,10 +21,10 @@ asid_pool_t *riscvKSASIDTable[BIT(asidHighBits)];
 pte_t kernel_root_pageTable[BIT(PT_INDEX_BITS)] ALIGN_BSS(BIT(seL4_PageTableBits));
 
 #if __riscv_xlen != 32
-pte_t kernel_image_level2_pt[BIT(PT_INDEX_BITS)] ALIGN_BSS(BIT(seL4_PageTableBits));
-pte_t kernel_image_level2_dev_pt[BIT(PT_INDEX_BITS)] ALIGN_BSS(BIT(seL4_PageTableBits));
+pte_t kernel_image_level1_pt[BIT(PT_INDEX_BITS)] ALIGN_BSS(BIT(seL4_PageTableBits));
+pte_t kernel_image_level1_dev_pt[BIT(PT_INDEX_BITS)] ALIGN_BSS(BIT(seL4_PageTableBits));
 #elif defined(CONFIG_KERNEL_LOG_BUFFER)
-pte_t kernel_image_level2_log_buffer_pt[BIT(PT_INDEX_BITS)] ALIGN_BSS(BIT(seL4_PageTableBits));
+pte_t kernel_image_level1_log_buffer_pt[BIT(PT_INDEX_BITS)] ALIGN_BSS(BIT(seL4_PageTableBits));
 #endif
 
 SMP_STATE_DEFINE(core_map_t, coreMap);


### PR DESCRIPTION
Since cdbae0b3b27c8a69f1b47074523177e428b0b95a, seL4 has used a 0-indexed naming for the levels of the page tables, starting from the root (0) and down to the lowest level (2), for CONFIG_PT_LEVELS=3.

However, the naming of the stored page table was never updated, leading to a variety of confusing code such as:

    kernel_image_level2_dev_pt[RISCV_GET_PT_INDEX(vaddr, 1)] = \
        pte_next(paddr, true);

When CONFIG_PT_LEVELS=4, the entries of the level 1 page table instead point to gigapages (1GiB) instead of megapages (2MiB). (Behaviour left unchanged).