### PR TITLE
boot: make clock sync test delta conditional

### DIFF
--- a/include/kernel/boot.h
+++ b/include/kernel/boot.h
@@ -145,6 +145,16 @@ word_t arch_get_n_paging(v_region_t it_veg);
 
 #ifdef ENABLE_SMP_CLOCK_SYNC_TEST_ON_BOOT
 BOOT_CODE void clock_sync_test(void);
+
+/* Delta (in us) allowed in the clock sync test in addition to getTimerPrecision().
+   On RISC-V, reading the clock goes via mmode. If mmode uses a big lock, that
+   can take considerable time */
+#ifdef CONFIG_ARCH_RISCV
+#define CLOCK_SYNC_DELTA 5
+#else
+#define CLOCK_SYNC_DELTA 1
+#endif
+
 #else
 #define clock_sync_test()
 #endif

--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -572,7 +572,7 @@ BOOT_CODE tcb_t *create_initial_thread(cap_t root_cnode_cap, cap_t it_pd_cap, vp
 BOOT_CODE void clock_sync_test(void)
 {
     ticks_t t, t0;
-    ticks_t margin = usToTicks(1) + getTimerPrecision();
+    ticks_t margin = usToTicks(CLOCK_SYNC_DELTA) + getTimerPrecision();
 
     assert(getCurrentCPUIndex() != 0);
     t = NODE_STATE_ON_CORE(ksCurTime, 0);


### PR DESCRIPTION
The clock sync test at boot keeps failing for the hifive board with time deltas as high as 5. We think this is because mmode might be taking a big lock for reading the time.

Add a macro for allowed delta and set it to a higher value for RISC-V.

Supersedes #1366. See also the comments/discussion there.