### PR TITLE
Bump minimum CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.16.0)
 include(CheckCCompilerFlag)
 
 include(${CMAKE_CURRENT_LIST_DIR}/configs/seL4Config.cmake)

--- a/config.cmake
+++ b/config.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 config_option(
     KernelIsMCS KERNEL_MCS "Use the MCS kernel configuration, which is not verified."

--- a/gcc.cmake
+++ b/gcc.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 set(CMAKE_SYSTEM_NAME Generic)
 # For a generic system this is unused, so define it to something that will be

--- a/include/32/mode/config.cmake
+++ b/include/32/mode/config.cmake
@@ -4,6 +4,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 add_bf_source_old("Kernel32" "shared_types.bf" "libsel4/mode_include/32" "sel4")

--- a/include/64/mode/config.cmake
+++ b/include/64/mode/config.cmake
@@ -4,6 +4,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 add_bf_source_old("Kernel64" "shared_types.bf" "libsel4/mode_include/64" "sel4")

--- a/libsel4/CMakeLists.txt
+++ b/libsel4/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 project(libsel4 C)
 

--- a/llvm.cmake
+++ b/llvm.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 set(CMAKE_SYSTEM_NAME Generic)
 # For a generic system this is unused, so define it to something that will be

--- a/src/arch/arm/32/config.cmake
+++ b/src/arch/arm/32/config.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 add_sources(
     DEP "KernelSel4ArchAarch32"

--- a/src/arch/arm/64/config.cmake
+++ b/src/arch/arm/64/config.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 add_sources(
     DEP "KernelSel4ArchAarch64"

--- a/src/arch/arm/armv/armv7-a/config.cmake
+++ b/src/arch/arm/armv/armv7-a/config.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 add_sources(
     DEP "KernelArchArmV7a"

--- a/src/arch/arm/armv/armv8-a/config.cmake
+++ b/src/arch/arm/armv/armv8-a/config.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 add_sources(
     DEP "KernelArchArmV8a"

--- a/src/arch/arm/config.cmake
+++ b/src/arch/arm/config.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 if(KernelSel4ArchAarch32)
     set_property(TARGET kernel_config_target APPEND PROPERTY TOPLEVELTYPES pde_C)

--- a/src/arch/riscv/config.cmake
+++ b/src/arch/riscv/config.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 config_string(
     KernelPTLevels PT_LEVELS "Number of page \

--- a/src/arch/x86/32/config.cmake
+++ b/src/arch/x86/32/config.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 add_sources(
     DEP "KernelSel4ArchIA32"

--- a/src/arch/x86/64/config.cmake
+++ b/src/arch/x86/64/config.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 add_sources(
     DEP "KernelSel4ArchX86_64"

--- a/src/arch/x86/config.cmake
+++ b/src/arch/x86/config.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 if(KernelArchX86)
     set_property(TARGET kernel_config_target APPEND PROPERTY TOPLEVELTYPES pde_C)
@@ -72,8 +72,8 @@ config_option(
 config_string(
     KernelCacheLnSz CACHE_LN_SZ "Define cache line size for the current architecture"
     DEFAULT 64
-    DEPENDS "KernelArchX86" UNDEF_DISABLED
-    UNQUOTE
+    DEPENDS "KernelArchX86"
+    UNDEF_DISABLED UNQUOTE
 )
 
 config_option(
@@ -226,11 +226,11 @@ config_choice(
 
 config_string(
     KernelMultibootGFXDepth MULTIBOOT_GRAPHICS_MODE_DEPTH
-    "The bits per pixel of the linear graphics mode ot request. Value of zero indicates \
+    "The bits per pixel of the linear graphics mode to request. Value of zero indicates \
     no preference."
     DEFAULT 32
-    DEPENDS "KernelMultibootGFXModeLinear" UNDEF_DISABLED
-    UNQUOTE
+    DEPENDS "KernelMultibootGFXModeLinear"
+    UNDEF_DISABLED UNQUOTE
 )
 
 config_string(
@@ -239,8 +239,8 @@ config_string(
     number of pixels. For a text mode this is the number of characters, value of zero \
     indicates no preference."
     DEFAULT 0
-    DEPENDS "KernelMultibootGFXModeText OR KernelMultibootGFXModeLinear" UNDEF_DISABLED
-    UNQUOTE
+    DEPENDS "KernelMultibootGFXModeText OR KernelMultibootGFXModeLinear"
+    UNDEF_DISABLED UNQUOTE
 )
 config_string(
     KernelMultibootGFXHeight MULTIBOOT_GRAPHICS_MODE_HEIGHT
@@ -248,8 +248,8 @@ config_string(
     number of pixels. For a text mode this is the number of characters, value of zero \
     indicates no preference."
     DEFAULT 0
-    DEPENDS "KernelMultibootGFXModeText OR KernelMultibootGFXModeLinear" UNDEF_DISABLED
-    UNQUOTE
+    DEPENDS "KernelMultibootGFXModeText OR KernelMultibootGFXModeLinear"
+    UNDEF_DISABLED UNQUOTE
 )
 
 config_option(

--- a/src/config.cmake
+++ b/src/config.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 add_sources(
     CFILES

--- a/src/drivers/config.cmake
+++ b/src/drivers/config.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 macro(register_driver compatibility_strings match_strings)
     foreach(match_string IN ITEMS ${match_strings})

--- a/src/drivers/serial/config.cmake
+++ b/src/drivers/serial/config.cmake
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 register_driver(
     compatibility_strings "brcm,bcm2835-aux-uart"

--- a/src/drivers/smmu/config.cmake
+++ b/src/drivers/smmu/config.cmake
@@ -4,6 +4,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 register_driver(compatibility_strings "arm,mmu-500" PREFIX src/drivers/smmu CFILES "smmuv2.c")

--- a/src/drivers/timer/config.cmake
+++ b/src/drivers/timer/config.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 register_driver(
     compatibility_strings "ti,am335x-timer"

--- a/src/plat/allwinnerA20/config.cmake
+++ b/src/plat/allwinnerA20/config.cmake
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
-
 declare_platform(allwinnerA20 KernelPlatformAllwinnerA20 PLAT_ALLWINNERA20 KernelSel4ArchAarch32)
 
 if(KernelPlatformAllwinnerA20)

--- a/src/plat/am335x/config.cmake
+++ b/src/plat/am335x/config.cmake
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
-
 declare_platform(am335x KernelPlatformAM335X PLAT_AM335X KernelSel4ArchAarch32)
 set(c_configs PLAT_AM335X_BONEBLACK PLAT_AM335X_BONEBLUE PLAT_AM335X_BONE)
 set(

--- a/src/plat/apq8064/config.cmake
+++ b/src/plat/apq8064/config.cmake
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
-
 declare_platform(apq8064 KernelPlatformAPQ8064 PLAT_APQ8064 KernelSel4ArchAarch32)
 
 if(KernelPlatformAPQ8064)

--- a/src/plat/ariane/config.cmake
+++ b/src/plat/ariane/config.cmake
@@ -5,8 +5,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
-
 declare_platform(ariane KernelPlatformAriane PLAT_ARIANE KernelArchRiscV)
 
 if(KernelPlatformAriane)

--- a/src/plat/bcm2711/config.cmake
+++ b/src/plat/bcm2711/config.cmake
@@ -5,8 +5,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
-
 declare_platform(bcm2711 KernelPlatformRpi4 PLAT_BCM2711 KernelArchARM)
 
 if(KernelPlatformRpi4)

--- a/src/plat/bcm2837/config.cmake
+++ b/src/plat/bcm2837/config.cmake
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
-
 declare_platform(bcm2837 KernelPlatformRpi3 PLAT_BCM2837 KernelArchARM)
 
 if(KernelPlatformRpi3)

--- a/src/plat/cheshire/config.cmake
+++ b/src/plat/cheshire/config.cmake
@@ -6,8 +6,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
-
 declare_platform(cheshire KernelPlatformCheshire PLAT_CHESHIRE KernelArchRiscV)
 
 if(KernelPlatformCheshire)

--- a/src/plat/exynos4/config.cmake
+++ b/src/plat/exynos4/config.cmake
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
-
 declare_platform(exynos4 KernelPlatformExynos4 PLAT_EXYNOS4 KernelSel4ArchAarch32)
 
 if(KernelPlatformExynos4)

--- a/src/plat/exynos5/config.cmake
+++ b/src/plat/exynos5/config.cmake
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
-
 # We introduce a variable to hold this long expression to prevent the
 # code styler from line-wrapping the declare_platform() statement.  We
 # want to keep that on one line so the `griddle` tool (or humans) can

--- a/src/plat/fvp/config.cmake
+++ b/src/plat/fvp/config.cmake
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
-
 declare_platform(fvp KernelPlatformFVP PLAT_FVP KernelSel4ArchAarch64)
 
 if(KernelPlatformFVP)

--- a/src/plat/hifive/config.cmake
+++ b/src/plat/hifive/config.cmake
@@ -5,8 +5,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
-
 declare_platform(hifive KernelPlatformHifive PLAT_HIFIVE KernelSel4ArchRiscV64)
 
 if(KernelPlatformHifive)

--- a/src/plat/hikey/config.cmake
+++ b/src/plat/hikey/config.cmake
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
-
 declare_platform(hikey KernelPlatformHikey PLAT_HIKEY KernelArchARM)
 
 if(KernelPlatformHikey)

--- a/src/plat/imx6/config.cmake
+++ b/src/plat/imx6/config.cmake
@@ -5,8 +5,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
-
 declare_platform(imx6 KernelPlatImx6 PLAT_IMX6 KernelSel4ArchAarch32)
 
 # disable platform specific settings by default in cache, will be enabled below

--- a/src/plat/imx7/config.cmake
+++ b/src/plat/imx7/config.cmake
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
-
 declare_platform(imx7 KernelPlatImx7 PLAT_IMX7_SABRE KernelSel4ArchAarch32)
 
 if(KernelPlatImx7)

--- a/src/plat/imx8m-evk/config.cmake
+++ b/src/plat/imx8m-evk/config.cmake
@@ -5,8 +5,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
-
 declare_platform(imx8mq-evk KernelPlatformImx8mq-evk PLAT_IMX8MQ_EVK KernelArchARM)
 declare_platform(imx8mm-evk KernelPlatformImx8mm-evk PLAT_IMX8MM_EVK KernelArchARM)
 declare_platform(imx8mp-evk KernelPlatformImx8mp-evk PLAT_IMX8MP_EVK KernelArchARM)

--- a/src/plat/imx93/config.cmake
+++ b/src/plat/imx93/config.cmake
@@ -3,9 +3,6 @@
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #
-
-cmake_minimum_required(VERSION 3.7.2)
-
 declare_platform(imx93 KernelPlatformIMX93 PLAT_IMX93 KernelArchARM)
 
 if(KernelPlatformIMX93)

--- a/src/plat/maaxboard/config.cmake
+++ b/src/plat/maaxboard/config.cmake
@@ -5,8 +5,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
-
 declare_platform(maaxboard KernelPlatformMaaxboard PLAT_MAAXBOARD KernelArchARM)
 
 if(KernelPlatformMaaxboard)

--- a/src/plat/odroidc2/config.cmake
+++ b/src/plat/odroidc2/config.cmake
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
-
 declare_platform(odroidc2 KernelPlatformOdroidc2 PLAT_ODROIDC2 KernelSel4ArchAarch64)
 
 if(KernelPlatformOdroidc2)

--- a/src/plat/odroidc4/config.cmake
+++ b/src/plat/odroidc4/config.cmake
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
-
 declare_platform(odroidc4 KernelPlatformOdroidc4 PLAT_ODROIDC4 KernelSel4ArchAarch64)
 
 if(KernelPlatformOdroidc4)
@@ -13,7 +11,7 @@ if(KernelPlatformOdroidc4)
     set(KernelArmCortexA55 ON)
     set(KernelArchArmV8a ON)
     config_set(KernelARMPlatform ARM_PLAT odroidc4)
-    set(KernelArmMachFeatureModifiers "+crc" CACHE INTERNAL "")
+    set(KernelArmMachFeatureModifiers "+fp+simd+crc" CACHE INTERNAL "")
     list(APPEND KernelDTSList "tools/dts/odroidc4.dts" "src/plat/odroidc4/overlay-odroidc4.dts")
     # MAX_IRQ is based on the section 7.10.2 of the S905X3 SoC manual
     declare_default_headers(

--- a/src/plat/omap3/config.cmake
+++ b/src/plat/omap3/config.cmake
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
-
 declare_platform(omap3 KernelPlatformOMAP3 PLAT_OMAP3 KernelSel4ArchAarch32)
 
 if(KernelPlatformOMAP3)

--- a/src/plat/pc99/config.cmake
+++ b/src/plat/pc99/config.cmake
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
-
 declare_platform(pc99 KernelPlatPC99 PLAT_PC99 KernelArchX86)
 
 if(KernelPlatPC99)

--- a/src/plat/polarfire/config.cmake
+++ b/src/plat/polarfire/config.cmake
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
-
 declare_platform(polarfire KernelPlatformPolarfire PLAT_POLARFIRE KernelSel4ArchRiscV64)
 
 if(KernelPlatformPolarfire)

--- a/src/plat/qemu-arm-virt/config.cmake
+++ b/src/plat/qemu-arm-virt/config.cmake
@@ -5,8 +5,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
-
 declare_platform(qemu-arm-virt KernelPlatformQEMUArmVirt PLAT_QEMU_ARM_VIRT KernelArchARM)
 
 set(qemu_user_top 0xa0000000)

--- a/src/plat/qemu-riscv-virt/config.cmake
+++ b/src/plat/qemu-riscv-virt/config.cmake
@@ -5,8 +5,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
-
 declare_platform(qemu-riscv-virt KernelPlatformQEMURiscVVirt PLAT_QEMU_RISCV_VIRT KernelArchRiscV)
 
 if(KernelPlatformQEMURiscVVirt)

--- a/src/plat/quartz64/config.cmake
+++ b/src/plat/quartz64/config.cmake
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
-
 declare_platform(quartz64 KernelPlatformQuartz64 PLAT_QUARTZ64 KernelSel4ArchAarch64)
 
 if(KernelPlatformQuartz64)

--- a/src/plat/rocketchip/config.cmake
+++ b/src/plat/rocketchip/config.cmake
@@ -6,8 +6,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
-
 declare_platform(rocketchip KernelPlatformRocketchip PLAT_ROCKETCHIP KernelArchRiscV)
 
 set(c_configs PLAT_ROCKETCHIP_BASE PLAT_ROCKETCHIP_ZCU102)

--- a/src/plat/rockpro64/config.cmake
+++ b/src/plat/rockpro64/config.cmake
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
-
 declare_platform(rockpro64 KernelPlatformRockpro64 PLAT_ROCKPRO64 KernelSel4ArchAarch64)
 
 if(KernelPlatformRockpro64)

--- a/src/plat/spike/config.cmake
+++ b/src/plat/spike/config.cmake
@@ -6,8 +6,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
-
 declare_platform(spike KernelPlatformSpike PLAT_SPIKE KernelArchRiscV)
 
 if(KernelPlatformSpike)

--- a/src/plat/star64/config.cmake
+++ b/src/plat/star64/config.cmake
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
-
 declare_platform(star64 KernelPlatformStar64 PLAT_STAR64 KernelArchRiscV)
 
 if(KernelPlatformStar64)

--- a/src/plat/tk1/config.cmake
+++ b/src/plat/tk1/config.cmake
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
-
 declare_platform(tk1 KernelPlatformTK1 PLAT_TK1 "KernelSel4ArchAarch32 OR KernelSel4ArchArmHyp")
 
 if(KernelPlatformTK1)

--- a/src/plat/tqma8xqp1gb/config.cmake
+++ b/src/plat/tqma8xqp1gb/config.cmake
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
-
 declare_platform(tqma8xqp1gb KernelPlatformTqma8xqp1gb PLAT_TQMA8XQP1GB KernelArchARM)
 
 if(KernelPlatformTqma8xqp1gb)

--- a/src/plat/tx1/config.cmake
+++ b/src/plat/tx1/config.cmake
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
-
 declare_platform(tx1 KernelPlatformTx1 PLAT_TX1 KernelSel4ArchAarch64)
 
 if(KernelPlatformTx1)

--- a/src/plat/tx2/config.cmake
+++ b/src/plat/tx2/config.cmake
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
-
 declare_platform(tx2 KernelPlatformTx2 PLAT_TX2 KernelSel4ArchAarch64)
 
 if(KernelPlatformTx2)

--- a/src/plat/zynq7000/config.cmake
+++ b/src/plat/zynq7000/config.cmake
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
-
 declare_platform(zynq7000 KernelPlatformZynq7000 PLAT_ZYNQ7000 KernelSel4ArchAarch32)
 
 if(KernelPlatformZynq7000)

--- a/src/plat/zynqmp/config.cmake
+++ b/src/plat/zynqmp/config.cmake
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
-
 declare_platform(zynqmp KernelPlatformZynqmp PLAT_ZYNQMP KernelArchARM)
 
 set(c_configs PLAT_ZYNQMP_ZCU102 PLAT_ZYNQMP_ULTRA96 PLAT_ZYNQMP_ULTRA96V2)

--- a/tools/flags.cmake
+++ b/tools/flags.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 # Set the cmake compilation flags with kernel base flags
 # This allows, for example, user compilation to ensure they are building for the same

--- a/tools/helpers.cmake
+++ b/tools/helpers.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.8.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 # Wrapper function around find_file that generates a fatal error if it isn't found
 # Is equivalent to find_file except that it adds CMAKE_CURRENT_SOURCE_DIR as a path and sets

--- a/tools/internal.cmake
+++ b/tools/internal.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 # File for helpers that are very specific to the kernel
 


### PR DESCRIPTION
Compatibility with versions <3.10 is going away.
As it happens, we're not using any CMake features that have changed between 3.7 and 3.16, so bump the lowest version to 3.16.

Also remove the minimum version statement from the platform config files --- they're all very simple files that are version independent; and the version is checked elsewhere anyway.