### PR TITLE
riscv: disable clock sync test on boot

### DIFF
--- a/include/kernel/boot.h
+++ b/include/kernel/boot.h
@@ -138,7 +138,7 @@ static inline BOOT_CODE pptr_t it_alloc_paging(void)
 /* return the amount of paging structures required to cover v_reg */
 word_t arch_get_n_paging(v_region_t it_veg);
 
-#if defined(CONFIG_DEBUG_BUILD) && defined(ENABLE_SMP_SUPPORT) && defined(CONFIG_KERNEL_MCS) && !defined(CONFIG_PLAT_QEMU_ARM_VIRT)
+#if defined(CONFIG_DEBUG_BUILD) && defined(ENABLE_SMP_SUPPORT) && defined(CONFIG_KERNEL_MCS) && !defined(CONFIG_PLAT_QEMU_ARM_VIRT) && !defined(CONFIG_ARCH_RISCV)
 /* Test whether clocks are synchronised across nodes */
 #define ENABLE_SMP_CLOCK_SYNC_TEST_ON_BOOT
 #endif


### PR DESCRIPTION
Timer reads go via mmode on RISC-V, and the hifive board regularly fails the clock sync test at boot because of that.

We could add a larger allowed delta, but the observed values so far are up to 5us, so it is questionable what we then know after the test if we do that. Disable for RISC-V instead.