### PR TITLE
riscv: restructure map_kernel_window for clarity

### DIFF
--- a/include/arch/riscv/arch/64/mode/hardware.h
+++ b/include/arch/riscv/arch/64/mode/hardware.h
@@ -30,14 +30,16 @@
  *                   +-----------------------------+ 2^64
  *                   |        Kernel Devices       |
  *                -> +-------------------KDEV_BASE-+ 2^64 - 1GiB
- *                |  |         Kernel ELF          |
- *            ----|  +-------------KERNEL_ELF_BASE-+ --+ 2^64 - 2GiB + (KERNEL_ELF_PADDR_BASE % 1GiB)
+ *                |  |                             |
+ *                |  +--------------KERNEL_ELF_TOP-+
+ *            --->|  |         Kernel ELF          |
+ *            |   |  +-------------KERNEL_ELF_BASE-+ --+ 2^64 - 2GiB + (KERNEL_ELF_PADDR_BASE % 1GiB)
  *            |   |  |                             |
  *            |   -> +--------------------PPTR_TOP-+ --+ 2^64 - 2GiB
  * Shared 1GiB|      |                             |   |
  * table entry|      |           PSpace            |   |
  *            |      |  (direct kernel mappings)   |   +----+
- *            ------>|                             |   |    |
+ *            ------>|=============================|   |    |
  *                   |                             |   |    |
  *                   +-------------------PPTR_BASE-+ --+ 2^64 - 2^b
  *                   |                             |        |         +-------------------------+

--- a/include/arch/riscv/arch/model/statedata.h
+++ b/include/arch/riscv/arch/model/statedata.h
@@ -28,7 +28,7 @@ extern asid_pool_t *riscvKSASIDTable[BIT(asidHighBits)];
 extern pte_t kernel_root_pageTable[BIT(PT_INDEX_BITS)] VISIBLE;
 
 /* We need to introduce a level 1 page table in order to map OpenSBI into
-   a separate 2MiB page to avoid a PMP exception */
+   a separate 2MiB page to avoid a PMP exception. See map_kernel_window() */
 #if __riscv_xlen != 32
 extern pte_t kernel_image_level1_pt[BIT(PT_INDEX_BITS)];
 extern pte_t kernel_image_level1_dev_pt[BIT(PT_INDEX_BITS)];

--- a/src/arch/riscv/machine/hardware.c
+++ b/src/arch/riscv/machine/hardware.c
@@ -31,6 +31,13 @@ void setNextPC(tcb_t *thread, word_t v)
 
 BOOT_CODE void map_kernel_devices(void)
 {
+#if __riscv_xlen == 64
+    /* Map kernel device page table */
+    assert(IS_ALIGNED(KDEV_BASE, RISCV_GET_LVL_PGSIZE_BITS(0)));
+    kernel_root_pageTable[RISCV_GET_PT_INDEX(KDEV_BASE, 0)] =
+        pte_next(kpptr_to_paddr(kernel_image_level1_dev_pt), false);
+#endif
+
     /* If there are no kernel device frames at all, then kernel_device_frames is
      * NULL. Thus we can't use ARRAY_SIZE(kernel_device_frames) here directly,
      * but have to use NUM_KERNEL_DEVICE_FRAMES that is defined accordingly.


### PR DESCRIPTION
This should be functionally the same. It has taken me several hours to understand what this function was doing, so I thought I'd write out what's going on a bit more clearly.

What confused me especially is how we're mapping in the ELF, but then we're also mapping a full 1GiB worth of 2MiB pages, and it confused me why we needed that much. But it appears the rest of the memory does get re-used later, it's just we need to map the full region *in the physical window*.
