### PR TITLE
riscv32,llvm: Disable floating point by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,7 +27,7 @@ description indicates whether it is SOURCE-COMPATIBLE, BINARY-COMPATIBLE, or BRE
 
 * Added `zynqmp` and `rpi4` to the set of verified AArch64 configs.
 * riscv: Change default cmake options KernelRiscvExtF and KernelRiscvExtD from OFF to ON.
-  Except for RISCV32 with LLVM clang enabled will default KernelRiscvExtD to OFF.
+  Except for RISCV32 with LLVM clang enabled will default both to OFF.
 
 ### Platforms
 

--- a/src/arch/riscv/config.cmake
+++ b/src/arch/riscv/config.cmake
@@ -15,16 +15,21 @@ config_string(
     DEPENDS "KernelArchRiscV"
 )
 
+set(_KernelRiscvExtD ON)
+set(_KernelRiscvExtF ON)
+if(LLVM_TOOLCHAIN AND KernelSel4ArchRiscV32)
+    # Versions of clang we support can't compile for D double width floating
+    # point. But we've found that having F but not D still leads to errors with
+    # code that assumes if any floating point is enabled, both F and D are enabled.
+    set(_KernelRiscvExtD OFF)
+    set(_KernelRiscvExtF OFF)
+endif()
+
 config_option(
     KernelRiscvExtF RISCV_EXT_F "RISC-V extension for single-precision floating-point"
-    DEFAULT ON
+    DEFAULT ${_KernelRiscvExtF}
     DEPENDS "KernelArchRiscV"
 )
-
-set(_KernelRiscvExtD ON)
-if(LLVM_TOOLCHAIN AND KernelSel4ArchRiscV32)
-    set(_KernelRiscvExtD OFF)
-endif()
 
 config_option(
     KernelRiscvExtD RISCV_EXT_D "RISC-V extension for double-precision floating-point"


### PR DESCRIPTION
Change the default llvm configuration for riscv32 to disable floating point due to limited clang compiler support