### PR TITLE
gic_v3: Remove non-existent register bit

### DIFF
--- a/include/arch/arm/arch/machine/gic_v3.h
+++ b/include/arch/arm/arch/machine/gic_v3.h
@@ -31,7 +31,6 @@
 #define GIC_VCPU_MAX_NUM_LR 16
 
 /* Register bits */
-#define GICD_CTL_ENABLE 0x1
 #define GICD_CTLR_RWP                BIT(31)
 #define GICD_CTLR_ARE_NS             BIT(4)
 #define GICD_CTLR_ENABLE_G1NS         BIT(1)

--- a/src/arch/arm/machine/gic_v3.c
+++ b/src/arch/arm/machine/gic_v3.c
@@ -168,7 +168,7 @@ BOOT_CODE static void dist_init(void)
     }
 
     /* Turn on the distributor */
-    gic_dist->ctlr = GICD_CTL_ENABLE | GICD_CTLR_ARE_NS | GICD_CTLR_ENABLE_G1NS | GICD_CTLR_ENABLE_G0;
+    gic_dist->ctlr = GICD_CTLR_ARE_NS | GICD_CTLR_ENABLE_G1NS | GICD_CTLR_ENABLE_G0;
     gicv3_dist_wait_for_rwp();
 
     /* Route all global IRQs to this CPU */


### PR DESCRIPTION
Was an alias of GICD_CTLR_ENABLE_G0.