### PR TITLE
Fix Star64 cell size in DTS overlay

### DIFF
--- a/src/plat/star64/overlay-star64.dts
+++ b/src/plat/star64/overlay-star64.dts
@@ -28,11 +28,11 @@
      * - OpenSBI: 128 KiB (= 0x20000) with PMP protection
      */
     reserved-memory {
-        #address-cells = <0x01>;
-        #size-cells = <0x01>;
+        #address-cells = <0x02>;
+        #size-cells = <0x02>;
         ranges;
         sbi@40000000 {
-            reg = <0x40000000 0x200000>;
+            reg = <0x0 0x40000000 0x0 0x200000>;
             no-map;
         };
     };


### PR DESCRIPTION
Star64 already has a defined `address-cells` and `size-cells` in `star64.dts` so we should be consistent with that.