### PR TITLE
rpi4,elfloader: select firmware node for smp boot

### DIFF
--- a/src/plat/bcm2711/overlay-rpi4.dts
+++ b/src/plat/bcm2711/overlay-rpi4.dts
@@ -10,6 +10,7 @@
 	chosen {
 		seL4,elfloader-devices =
 		    "serial1",
+		    &{/soc/firmware},
 		    &{/timer};
 
 		seL4,kernel-devices =

--- a/tools/hardware.yml
+++ b/tools/hardware.yml
@@ -224,8 +224,7 @@ devices:
   - compatible:
       - arm,psci-0.2
       - arm,psci-1.0
-  - compatible:
       - fsl,imx6q-src
       - fsl,imx6sx-src
-  - compatible:
       - xlnx,zynq-reset
+      - raspberrypi,bcm2835-firmware


### PR DESCRIPTION
Attach the firmware node so that the elfloader can perform smp boots.