### PR TITLE
yieldTo: respect kernel reply protocol

### DIFF
--- a/include/object/schedcontext.h
+++ b/include/object/schedcontext.h
@@ -9,7 +9,7 @@
 #include <api/failures.h>
 #include <object/structures.h>
 
-exception_t decodeSchedContextInvocation(word_t label, cap_t cap, word_t *buffer);
+exception_t decodeSchedContextInvocation(word_t label, sched_context_t *sc, bool_t call);
 
 /* Bind a tcb and a scheduling context. This allows a tcb to enter the scheduler.
  * If the tcb is runnable, insert into scheduler

--- a/src/object/objecttype.c
+++ b/src/object/objecttype.c
@@ -777,7 +777,8 @@ exception_t decodeInvocation(word_t invLabel, word_t length,
             current_syscall_error.invalidCapNumber = 0;
             return EXCEPTION_SYSCALL_ERROR;
         }
-        return decodeSchedContextInvocation(invLabel, cap, buffer);
+        sched_context_t *sc = SC_PTR(cap_sched_context_cap_get_capSCPtr(cap));
+        return decodeSchedContextInvocation(invLabel, sc, call);
 #endif
     default:
         fail("Invalid cap type");

--- a/src/object/schedcontext.c
+++ b/src/object/schedcontext.c
@@ -251,7 +251,7 @@ static exception_t decodeSchedContext_YieldTo(sched_context_t *sc, bool_t call)
 
     if (tcb->tcbPriority > NODE_STATE(ksCurThread)->tcbMCP) {
         userError("SchedContext_YieldTo: insufficient mcp (%lu) to yield to a thread with prio (%lu)",
-                  (unsigned long) NODE_STATE(ksCurThread)->tcbMCP, (unsigned long) tcb->tcbPriority);
+                  NODE_STATE(ksCurThread)->tcbMCP, tcb->tcbPriority);
         current_syscall_error.type = seL4_IllegalOperation;
         return EXCEPTION_SYSCALL_ERROR;
     }

--- a/src/object/schedcontext.c
+++ b/src/object/schedcontext.c
@@ -159,20 +159,32 @@ static inline void maybeStallSC(sched_context_t *sc)
 }
 #endif
 
-static inline void setConsumed(sched_context_t *sc, word_t *buffer)
+static inline void replyFromKernel_consumed(tcb_t *thread, time_t consumed)
 {
-    time_t consumed = schedContext_updateConsumed(sc);
-    word_t length = mode_setTimeArg(0, consumed, buffer, NODE_STATE(ksCurThread));
-    setRegister(NODE_STATE(ksCurThread), msgInfoRegister, wordFromMessageInfo(seL4_MessageInfo_new(0, 0, 0, length)));
+    word_t *buffer = lookupIPCBuffer(true, thread);
+    setRegister(thread, badgeRegister, 0);
+    word_t length = mode_setTimeArg(0, consumed, buffer, thread);
+    setRegister(thread, msgInfoRegister, wordFromMessageInfo(seL4_MessageInfo_new(0, 0, 0, length)));
 }
 
-static exception_t invokeSchedContext_Consumed(sched_context_t *sc, word_t *buffer)
+static inline void setConsumed(sched_context_t *sc, tcb_t *thread, bool_t write_msg)
 {
-    setConsumed(sc, buffer);
+    time_t consumed = schedContext_updateConsumed(sc);
+
+    if (write_msg) {
+        replyFromKernel_consumed(thread, consumed);
+    }
+}
+
+static exception_t invokeSchedContext_Consumed(sched_context_t *sc, bool_t call)
+{
+    setConsumed(sc, NODE_STATE(ksCurThread), call);
+
+    setThreadState(NODE_STATE(ksCurThread), ThreadState_Running);
     return EXCEPTION_NONE;
 }
 
-static exception_t invokeSchedContext_YieldTo(sched_context_t *sc, word_t *buffer)
+static exception_t invokeSchedContext_YieldTo(sched_context_t *sc, bool_t call)
 {
     if (sc->scYieldFrom) {
         schedContext_completeYieldTo(sc->scYieldFrom);
@@ -185,18 +197,21 @@ static exception_t invokeSchedContext_YieldTo(sched_context_t *sc, word_t *buffe
      * if the thread isSchedulable, it is ready and sufficient.*/
     schedContext_resume(sc);
 
-    bool_t return_now = true;
-    if (isSchedulable(sc->scTcb)) {
+    tcb_t *tcb = sc->scTcb;
+
+    bool_t return_now;
+    if (isSchedulable(tcb)) {
         if (SMP_COND_STATEMENT(sc->scCore != getCurrentCPUIndex() ||)
-            sc->scTcb->tcbPriority < NODE_STATE(ksCurThread)->tcbPriority) {
-            tcbSchedDequeue(sc->scTcb);
-            SCHED_ENQUEUE(sc->scTcb);
+            tcb->tcbPriority < NODE_STATE(ksCurThread)->tcbPriority) {
+            tcbSchedDequeue(tcb);
+            SCHED_ENQUEUE(tcb);
+            return_now = true;
         } else {
             NODE_STATE(ksCurThread)->tcbYieldTo = sc;
             sc->scYieldFrom = NODE_STATE(ksCurThread);
-            tcbSchedDequeue(sc->scTcb);
+            tcbSchedDequeue(tcb);
             tcbSchedEnqueue(NODE_STATE(ksCurThread));
-            tcbSchedEnqueue(sc->scTcb);
+            tcbSchedEnqueue(tcb);
             rescheduleRequired();
 
             /* we are scheduling the thread associated with sc,
@@ -204,16 +219,21 @@ static exception_t invokeSchedContext_YieldTo(sched_context_t *sc, word_t *buffe
              * until the caller is scheduled again */
             return_now = false;
         }
+    } else {
+        return_now = true;
     }
 
     if (return_now) {
-        setConsumed(sc, buffer);
+        setConsumed(sc, NODE_STATE(ksCurThread), call);
+        /* Only set to Running if there is a kernel reply message for the user.
+           Restart will create a default empty success message. */
+        setThreadState(NODE_STATE(ksCurThread), ThreadState_Running);
     }
 
     return EXCEPTION_NONE;
 }
 
-static exception_t decodeSchedContext_YieldTo(sched_context_t *sc, word_t *buffer)
+static exception_t decodeSchedContext_YieldTo(sched_context_t *sc, bool_t call)
 {
     if (sc->scTcb == NULL) {
         userError("SchedContext_YieldTo: cannot yield to an inactive sched context");
@@ -221,15 +241,17 @@ static exception_t decodeSchedContext_YieldTo(sched_context_t *sc, word_t *buffe
         return EXCEPTION_SYSCALL_ERROR;
     }
 
-    if (sc->scTcb == NODE_STATE(ksCurThread)) {
+    tcb_t *tcb = sc->scTcb;
+
+    if (tcb == NODE_STATE(ksCurThread)) {
         userError("SchedContext_YieldTo: cannot seL4_SchedContext_YieldTo on self");
         current_syscall_error.type = seL4_IllegalOperation;
         return EXCEPTION_SYSCALL_ERROR;
     }
 
-    if (sc->scTcb->tcbPriority > NODE_STATE(ksCurThread)->tcbMCP) {
+    if (tcb->tcbPriority > NODE_STATE(ksCurThread)->tcbMCP) {
         userError("SchedContext_YieldTo: insufficient mcp (%lu) to yield to a thread with prio (%lu)",
-                  (unsigned long) NODE_STATE(ksCurThread)->tcbMCP, (unsigned long) sc->scTcb->tcbPriority);
+                  (unsigned long) NODE_STATE(ksCurThread)->tcbMCP, (unsigned long) tcb->tcbPriority);
         current_syscall_error.type = seL4_IllegalOperation;
         return EXCEPTION_SYSCALL_ERROR;
     }
@@ -245,20 +267,18 @@ static exception_t decodeSchedContext_YieldTo(sched_context_t *sc, word_t *buffe
     }
 
     setThreadState(NODE_STATE(ksCurThread), ThreadState_Restart);
-    return invokeSchedContext_YieldTo(sc, buffer);
+    return invokeSchedContext_YieldTo(sc, call);
 }
 
-exception_t decodeSchedContextInvocation(word_t label, cap_t cap, word_t *buffer)
+exception_t decodeSchedContextInvocation(word_t label, sched_context_t *sc, bool_t call)
 {
-    sched_context_t *sc = SC_PTR(cap_sched_context_cap_get_capSCPtr(cap));
-
     SMP_COND_STATEMENT((maybeStallSC(sc));)
 
     switch (label) {
     case SchedContextConsumed:
         /* no decode */
         setThreadState(NODE_STATE(ksCurThread), ThreadState_Restart);
-        return invokeSchedContext_Consumed(sc, buffer);
+        return invokeSchedContext_Consumed(sc, call);
     case SchedContextBind:
         return decodeSchedContext_Bind(sc);
     case SchedContextUnbindObject:
@@ -273,7 +293,7 @@ exception_t decodeSchedContextInvocation(word_t label, cap_t cap, word_t *buffer
         setThreadState(NODE_STATE(ksCurThread), ThreadState_Restart);
         return invokeSchedContext_Unbind(sc);
     case SchedContextYieldTo:
-        return decodeSchedContext_YieldTo(sc, buffer);
+        return decodeSchedContext_YieldTo(sc, call);
     default:
         userError("SchedContext invocation: Illegal operation attempted.");
         current_syscall_error.type = seL4_IllegalOperation;
@@ -401,7 +421,9 @@ void schedContext_cancelYieldTo(tcb_t *tcb)
 void schedContext_completeYieldTo(tcb_t *yielder)
 {
     if (yielder && yielder->tcbYieldTo) {
-        setConsumed(yielder->tcbYieldTo, lookupIPCBuffer(true, yielder));
+        /* FIXME: this should only be true here if the original
+                  invocation we are completing was Call. */
+        setConsumed(yielder->tcbYieldTo, yielder, true);
         schedContext_cancelYieldTo(yielder);
     }
 }


### PR DESCRIPTION
This is a continuation of https://github.com/seL4/seL4/pull/846 which explicitly left out `setConsumed` until MCS verification got there. (Which is now).

Before:

- invokeSchedContext_Consumed and invokeSchedContext_YieldTo clobber the message info field in the reply from kernel, which results in a length 0 message.

- invokeSchedContext_Consumed and invokeSchedContext_YieldTo may crash the kernel for read-only IPC buffers

- invokeSchedContext_Consumed and invokeSchedContext_YieldTo generate a reply from kernel for syscalls that should not generate replies

- completeYieldTo does not set the badge register, which will contain whatever that previous syscall returned and not correctly indicate success/failure.

Instead:

- look up the IPC buffer again and check for write authority

- follow the kernel reply protocol, which includes only generating a message for `call`. This means, we need to pass the flag through from higher-level decode functions. This makes the `buffer` argument unnecessary.

- the thread state of the current thread must be Running when the invocation is successful. Because neither call can fail, we leave the thread state on Running instead of first setting Restart and then Running as we usually do.

- set the badge register