### PR TITLE
configs: mark Ultra96v2 as supported by the proofs

### DIFF
--- a/configs/AARCH64_ultra96v2_verified.cmake
+++ b/configs/AARCH64_ultra96v2_verified.cmake
@@ -1,0 +1,11 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2025, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/include/AARCH64_verified_include.cmake)
+
+set(KernelPlatform "zynqmp" CACHE STRING "")
+set(KernelARMPlatform "ultra96v2" CACHE STRING "")


### PR DESCRIPTION
(Had forgotten to add this one in the last batch).

Expecting style check to fail for x bit as usual for the verified configs.