### PR TITLE
mcs: refactor reply functions to ease verification

### DIFF
--- a/include/kernel/thread.h
+++ b/include/kernel/thread.h
@@ -307,5 +307,12 @@ void awaken(void);
 /* Place the thread bound to this scheduling context in the release queue
  * of periodic threads waiting for budget recharge */
 void postpone(sched_context_t *sc);
+
+static inline void setThreadStateBlockedOnReply(tcb_t *tptr, reply_t *reply)
+{
+    thread_state_ptr_set_tsType(&tptr->tcbState, ThreadState_BlockedOnReply);
+    thread_state_ptr_set_replyObject(&tptr->tcbState, REPLY_REF(reply));
+    scheduleTCB(tptr);
+}
 #endif
 


### PR DESCRIPTION
The outermost if statement can be removed in reply_pop because reply_pop is called only in reply_remove, which includes an explicit check for this condition.

The new inline function setThreadStateBlockedOnReply is used within reply_push.