### PR TITLE
github: deploy mcs verification manifest

### DIFF
--- a/.github/workflows/preprocess-deploy.yml
+++ b/.github/workflows/preprocess-deploy.yml
@@ -32,11 +32,24 @@ jobs:
     strategy:
       matrix:
         arch: [ARM, ARM_HYP, AARCH64, RISCV64, X64]
-        # no MCS here, auto-updating mcs.xml should be a separate job.
+        # no MCS here, see separate preprocess-mcs.
     steps:
     - uses: seL4/ci-actions/preprocess@master
       with:
         L4V_ARCH: ${{ matrix.arch }}
+
+  preprocess-mcs:
+    name: Preprocess (MCS)
+    needs: code
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [RISCV64]
+    steps:
+    - uses: seL4/ci-actions/preprocess@master
+      with:
+        L4V_ARCH: ${{ matrix.arch }}
+        L4V_FEATURES: "MCS"
 
   deploy:
     name: Deploy manifest
@@ -48,5 +61,19 @@ jobs:
       with:
         xml: ${{ needs.code.outputs.xml }}
         preprocess: 'true'
+      env:
+        GH_SSH: ${{ secrets.CI_SSH }}
+
+  deploy-mcs:
+    name: Deploy MCS manifest
+    needs: [code, preprocess-mcs]
+    if: ${{ github.repository_owner == 'seL4' }}
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: seL4/ci-actions/l4v-deploy@master
+      with:
+        xml: ${{ needs.code.outputs.xml }}
+        preprocess: 'true'
+        manifest: mcs-devel.xml
       env:
         GH_SSH: ${{ secrets.CI_SSH }}


### PR DESCRIPTION
Deploy the MCS verification manifest for versions that have no MCS preprocess differences. These may be different from non-MCS preprocess outcomes, and since the MCS verification is on a branch, we can deploy it separately.

C verification on MCS has progressed enough that we want to do this automatically now, as we do for the master branch.