### PR TITLE
CMake: Avoid rebuilds by diffing generated headers

### DIFF
--- a/tools/config_gen.py
+++ b/tools/config_gen.py
@@ -25,16 +25,20 @@ def main():
         "--write-c",
         metavar="OUT_FILE",
         dest="out_file_c",
+        nargs="?",
         type=argparse.FileType("w"),
-        default=sys.stdout,
+        const=sys.stdout,
+        default=None,
         help="Output C header file.",
     )
     parser.add_argument(
         "--write-json",
         metavar="OUT_FILE",
         dest="out_file_json",
+        nargs="?",
         type=argparse.FileType("w"),
-        default=sys.stdout,
+        const=sys.stdout,
+        default=None,
         help="Output JSON file.",
     )
     args = parser.parse_args()

--- a/tools/config_gen.py
+++ b/tools/config_gen.py
@@ -22,11 +22,18 @@ def main():
         help="Input YAML file.",
     )
     parser.add_argument(
+        "--skip-unchanged",
+        dest="skip_unchanged",
+        action="store_true",
+        help="Only write output file if new content is different"
+    )
+    parser.add_argument(
         "--write-c",
         metavar="OUT_FILE",
         dest="out_file_c",
         nargs="?",
-        type=argparse.FileType("w"),
+        # Use a+ mode to open in read/write mode without truncating existing contents
+        type=argparse.FileType("a+"),
         const=sys.stdout,
         default=None,
         help="Output C header file.",
@@ -36,25 +43,25 @@ def main():
         metavar="OUT_FILE",
         dest="out_file_json",
         nargs="?",
-        type=argparse.FileType("w"),
+        type=argparse.FileType("a+"),
         const=sys.stdout,
         default=None,
         help="Output JSON file.",
     )
     args = parser.parse_args()
     generate(args.in_file_yaml, out_file_c=args.out_file_c,
-             out_file_json=args.out_file_json)
+             out_file_json=args.out_file_json, skip_unchanged=args.skip_unchanged)
 
 
-def generate(in_file_yaml, out_file_c=None, out_file_json=None):
+def generate(in_file_yaml, out_file_c=None, out_file_json=None, skip_unchanged=False):
     config = yaml.safe_load(in_file_yaml)
     if out_file_c is not None:
-        generate_c(config, out_file_c)
+        generate_c(config, out_file_c, skip_unchanged)
     if out_file_json is not None:
-        generate_json(config, out_file_json)
+        generate_json(config, out_file_json, skip_unchanged)
 
 
-def generate_c(config, out_file):
+def generate_c(config, out_file, skip_unchanged):
     header_contents = "#pragma once\n\n"
 
     for key, value in config.items():
@@ -76,11 +83,24 @@ def generate_c(config, out_file):
 
         header_contents += f"{entry}\n"
 
-    out_file.write(header_contents)
+    write_file_lazy(out_file, header_contents, skip_unchanged)
 
 
-def generate_json(config, out_file):
-    json.dump(config, out_file, indent=4)
+def generate_json(config, out_file, skip_unchanged):
+    json_contents = json.dumps(config, indent=4)
+    write_file_lazy(out_file, json_contents, skip_unchanged)
+
+
+def write_file_lazy(out_file, content, skip_unchanged):
+    if out_file == sys.stdout:
+        out_file.write(content)
+        return
+
+    out_file.seek(0)
+    if not skip_unchanged or out_file.read() != content:
+        out_file.seek(0)
+        out_file.truncate()
+        out_file.write(content)
 
 
 if __name__ == "__main__":

--- a/tools/helpers.cmake
+++ b/tools/helpers.cmake
@@ -552,7 +552,7 @@ function(add_config_library prefix configure_template)
 
     execute_process(
         COMMAND
-            "${PYTHON3}" "${CONFIG_GEN_PATH}" "${config_yaml_file}" --write-c
+            "${PYTHON3}" "${CONFIG_GEN_PATH}" "${config_yaml_file}" --skip-unchanged --write-c
             "${config_header_file}" --write-json "${config_json_file}"
         RESULT_VARIABLE error
     )


### PR DESCRIPTION
With the current implementation of add_config_library, the config_gen Python script is called on to regenerate the config header and json files every time CMake is configured. Since many targets rely on these files, it practically forces the entire project to be rebuilt whenever CMake is reconfigured, even if the project has already been configured and no settings have changed.

This change makes it so the generated header and json files get saved to temporary locations, and only override the final header and json files if the contents are different, thus avoiding a timestamp update and rebuild if they are the same. The temporary files are deleted after. This is all done at configure time (see #1105 for why).