### PR TITLE
treewide: typo fixes

### DIFF
--- a/include/api/debug.h
+++ b/include/api/debug.h
@@ -70,7 +70,7 @@ static inline void debug_printUserState(void)
 {
     tcb_t *tptr = NODE_STATE(ksCurThread);
     printf("Current thread: %s\n", TCB_PTR_DEBUG_PTR(tptr)->tcbName);
-    printf("Next instruction adress: %lx\n", getRestartPC(tptr));
+    printf("Next instruction address: %lx\n", getRestartPC(tptr));
     printf("Stack:\n");
     Arch_userStackTrace(tptr);
 }

--- a/include/arch/arm/arch/32/mode/fastpath/fastpath.h
+++ b/include/arch/arm/arch/32/mode/fastpath/fastpath.h
@@ -136,7 +136,7 @@ static inline void NORETURN FORCE_INLINE fastpath_restore(word_t badge, word_t m
             /* Pop user registers, preserving r0 and r1 */
             "add sp, sp, #8     \n"
             "pop {r2-r12}       \n"
-            /* Retore the user stack pointer */
+            /* Restore the user stack pointer */
             "pop {lr}           \n"
             "msr sp_usr, lr     \n"
             /* prepare the exception return lr */

--- a/include/arch/arm/arch/32/mode/machine.h
+++ b/include/arch/arm/arch/32/mode/machine.h
@@ -240,7 +240,7 @@ static void arm_save_thread_id(tcb_t *thread)
     /* TPIDRURW is writeable from EL0 but not with globals frame. */
     setRegister(thread, TPIDRURW, readTPIDRURW());
     /* This register is read only from userlevel, but could still be updated
-     * if the thread is running in a higher priveleged level with a VCPU attached.
+     * if the thread is running in a higher privilege level with a VCPU attached.
      */
     setRegister(thread, TPIDRURO, readTPIDRURO());
 }

--- a/include/arch/arm/arch/32/mode/machine/fpu.h
+++ b/include/arch/arm/arch/32/mode/machine/fpu.h
@@ -109,7 +109,7 @@ static inline void saveFpuState(user_fpu_state_t *dest)
     dest->fpexc = fpexc;
 
     if (config_set(CONFIG_ARM_HYPERVISOR_SUPPORT)) {
-        /* before touching the regsiters, we need to set the EN bit */
+        /* before touching the registers, we need to set the EN bit */
         setEnFPEXC();
     }
 

--- a/include/arch/arm/arch/32/mode/machine/registerset.h
+++ b/include/arch/arm/arch/32/mode/machine/registerset.h
@@ -191,16 +191,16 @@ typedef struct debug_register_pair {
  * the size of the untyped needed for a TCB when watchpoint handling is
  * involved.
  */
-#define EXLUSIVE_WATCHPOINT_PADING 6
-#define EXLUSIVE_WATCHPOINT_PADDED \
-    (seL4_NumExclusiveWatchpoints > EXLUSIVE_WATCHPOINT_PADING) \
+#define EXCLUSIVE_WATCHPOINT_PADDING 6
+#define EXCLUSIVE_WATCHPOINT_PADDED \
+    (seL4_NumExclusiveWatchpoints > EXCLUSIVE_WATCHPOINT_PADDING) \
         ? seL4_NumExclusiveWatchpoints \
-        : EXLUSIVE_WATCHPOINT_PADING
+        : EXCLUSIVE_WATCHPOINT_PADDING
 
 typedef struct user_breakpoint_state {
     /* We don't use context comparisons. */
     debug_register_pair_t breakpoint[seL4_NumExclusiveBreakpoints],
-                          watchpoint[EXLUSIVE_WATCHPOINT_PADDED];
+                          watchpoint[EXCLUSIVE_WATCHPOINT_PADDED];
     uint32_t used_breakpoints_bf;
     word_t n_instructions;
     bool_t single_step_enabled;

--- a/include/arch/arm/arch/32/mode/object/structures.bf
+++ b/include/arch/arm/arch/32/mode/object/structures.bf
@@ -8,7 +8,7 @@
 -- Default base size: uint32_t
 base 32
 
--- Including the common structures_32.bf is neccessary because
+-- Including the common structures_32.bf is necessary because
 -- we need the structures to be visible here when building
 -- the capType
 #include <object/structures_32.bf>

--- a/include/arch/arm/arch/64/mode/hardware.h
+++ b/include/arch/arm/arch/64/mode/hardware.h
@@ -219,8 +219,8 @@
    overflow without going into address ranges that are non-canonical.  These static
    asserts check that the kernel config won't lead to UTs being created that aren't
    representable. */
-compile_assert(ut_max_less_than_cannonical, CONFIG_PADDR_USER_DEVICE_TOP <= BIT(47));
+compile_assert(ut_max_less_than_canonical, CONFIG_PADDR_USER_DEVICE_TOP <= BIT(47));
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
-compile_assert(ut_max_is_cannonical, (PPTR_BASE + CONFIG_PADDR_USER_DEVICE_TOP) <= BIT(48));
+compile_assert(ut_max_is_canonical, (PPTR_BASE + CONFIG_PADDR_USER_DEVICE_TOP) <= BIT(48));
 #endif
 #endif

--- a/include/arch/arm/arch/64/mode/machine/registerset.h
+++ b/include/arch/arm/arch/64/mode/machine/registerset.h
@@ -46,7 +46,7 @@
 #define ID_AA64PFR0_EL1_ASIMD   20     // HWCap for Advanced SIMD
 
 /* CPACR_EL1 register */
-#define CPACR_EL1_FPEN          20     // FP regiters access
+#define CPACR_EL1_FPEN          20     // FP registers access
 
 /*
  * We cannot allow async aborts in the verified kernel, but they are useful

--- a/include/arch/arm/arch/64/mode/object/structures.bf
+++ b/include/arch/arm/arch/64/mode/object/structures.bf
@@ -13,7 +13,7 @@ base 64(48,1)
 #endif
 #define BF_CANONICAL_RANGE 48
 
--- Including the common structures_64.bf is neccessary because
+-- Including the common structures_64.bf is necessary because
 -- we need the structures to be visible here when building
 -- the capType
 #include <object/structures_64.bf>

--- a/include/arch/arm/arch/machine.h
+++ b/include/arch/arm/arch/machine.h
@@ -63,7 +63,7 @@ static inline void arch_pause(void)
 }
 #endif /* ENABLE_SMP_SUPPORT */
 
-/* Update the value of the actual regsiter to hold the expected value */
+/* Update the value of the actual register to hold the expected value */
 static inline exception_t Arch_setTLSRegister(word_t tls_base)
 {
     /* This register is saved and restored on kernel exit and entry so

--- a/include/arch/arm/arch/machine/debug.h
+++ b/include/arch/arm/arch/machine/debug.h
@@ -224,7 +224,7 @@ static inline syscall_error_t Arch_decodeConfigureSingleStepping(tcb_t *t,
 
         /* The following code relates to checking that the specified breakpoint is suitable to
             for being used for conguring single stepping. AARCH64 does not need to use breakpoints
-            to simulate single stepping, so these checks can be ommited. */
+            to simulate single stepping, so these checks can be omitted. */
 #ifdef CONFIG_ARCH_AARCH32
         type = seL4_InstructionBreakpoint;
         bp_num = t->tcbArch.tcbContext.breakpointState.single_step_hw_bp_num;
@@ -278,7 +278,7 @@ static inline syscall_error_t Arch_decodeSetBreakpoint(tcb_t *t,
         }
     } else if (type == seL4_InstructionBreakpoint) {
         if (bp_num >= seL4_NumExclusiveBreakpoints) {
-            userError("Debug: invalid instruction breakpoint nunber %u.", bp_num);
+            userError("Debug: invalid instruction breakpoint number %u.", bp_num);
             ret.type = seL4_RangeError;
             ret.rangeErrorMin = 0;
             ret.rangeErrorMax = seL4_NumExclusiveWatchpoints - 1;

--- a/include/arch/arm/armv/armv7-a/armv/vcpu.h
+++ b/include/arch/arm/armv/armv7-a/armv/vcpu.h
@@ -779,7 +779,7 @@ static inline void vcpu_enable(vcpu_t *vcpu)
      *
      * In the case above, the fpuState.fpexc of VM0 saves the value written
      * by the VM1, but the vcpu->fpexc of VM0 still contains the correct
-     * value when VM0 is disabed (vcpu_disable) or saved (vcpu_save).
+     * value when VM0 is disabled (vcpu_disable) or saved (vcpu_save).
      *
      *
      */

--- a/include/arch/riscv/arch/32/mode/object/structures.bf
+++ b/include/arch/riscv/arch/32/mode/object/structures.bf
@@ -10,7 +10,7 @@
 ---- Default base size: uint32_t
 base 32
 
--- Including the common structures.bf is neccessary because
+-- Including the common structures.bf is necessary because
 -- we need the structures to be visible here when building
 -- the capType
 #include <object/structures_32.bf>

--- a/include/arch/riscv/arch/64/mode/object/structures.bf
+++ b/include/arch/riscv/arch/64/mode/object/structures.bf
@@ -15,7 +15,7 @@ base 64(39,1)
 #error "Only PT_LEVELS == 3 is currently supported on RISCV64"
 #endif
 
--- Including the common structures.bf is neccessary because
+-- Including the common structures.bf is necessary because
 -- we need the structures to be visible here when building
 -- the capType
 #include <object/structures_64.bf>

--- a/include/arch/riscv/arch/sbi.h
+++ b/include/arch/riscv/arch/sbi.h
@@ -114,7 +114,7 @@ static inline void sbi_send_ipi(word_t hart_mask)
      *           reworking parts of the kernel.
      *       - The legacy SBI interface is deprecated. Passing pointers with
      *           virtual addresses has several practical drawbacks or corner
-     *           cases, these outweight the gain of being able to address all
+     *           cases, these outweigh the gain of being able to address all
      *           harts in one call. The new interface uses a window concept and
      *           passes plain values.
      *       - Using pointers to local variables is perfectly fine in C, but

--- a/include/arch/x86/arch/32/mode/object/structures.bf
+++ b/include/arch/x86/arch/32/mode/object/structures.bf
@@ -9,7 +9,7 @@
 ---- Default base size: uint32_t
 base 32
 
--- Including the common structures_32.bf is neccessary because
+-- Including the common structures_32.bf is necessary because
 -- we need the structures to be visible here when building
 -- the capType
 #include <object/structures_32.bf>
@@ -258,7 +258,7 @@ block vm_attributes {
 
 ---- IA32 specific object types
 
--- GDT entries (Segment Desciptors)
+-- GDT entries (Segment Descriptors)
 
 block gdt_null {
     padding                         19
@@ -323,7 +323,7 @@ tagged_union gdt_entry desc_type {
     tag gdt_code    6
 }
 
--- IDT entries (Gate Desciptors)
+-- IDT entries (Gate Descriptors)
 
 block task_gate {
     padding                         16

--- a/include/arch/x86/arch/64/mode/object/structures.bf
+++ b/include/arch/x86/arch/64/mode/object/structures.bf
@@ -10,7 +10,7 @@
 base 64(48,1)
 #define BF_CANONICAL_RANGE 48
 
--- Including the common structures.bf is neccessary because
+-- Including the common structures.bf is necessary because
 -- we need the structures to be visible here when building
 -- the capType
 #include <object/structures_64.bf>
@@ -279,7 +279,7 @@ block vm_attributes {
 
 ---- x86-64 specific object types
 
--- GDT entries (Segment Desciptors)
+-- GDT entries (Segment Descriptors)
 
 block gdt_null {
     padding                         19
@@ -344,7 +344,7 @@ tagged_union gdt_entry seg_type {
     tag gdt_code    11
 }
 
--- IDT entries (Gate Desciptors)
+-- IDT entries (Gate Descriptors)
 
 block task_gate {
     padding                         32

--- a/include/arch/x86/arch/64/mode/object/structures.h
+++ b/include/arch/x86/arch/64/mode/object/structures.h
@@ -28,7 +28,7 @@ compile_assert(gdt_idt_ptr_packed,
 compile_assert(unsigned_long_size_64,
                sizeof(unsigned long) == 8)
 
-compile_assert(unsinged_int_size_32,
+compile_assert(unsigned_int_size_32,
                sizeof(unsigned int) == 4)
 
 compile_assert(uint64_t_size_64,

--- a/include/arch/x86/arch/object/structures.bf
+++ b/include/arch/x86/arch/object/structures.bf
@@ -254,7 +254,7 @@ block vmx_ept_vpid_cap_msr {
 -- This is the layout of the data exit qualification register
 -- when the exit reason (as read from the data exit reason)
 -- register is 'control register'
-block vmx_data_exit_qualification_control_regster {
+block vmx_data_exit_qualification_control_register {
     field data          16
     padding             4
     field reg           4

--- a/include/arch/x86/arch/object/vcpu.h
+++ b/include/arch/x86/arch/object/vcpu.h
@@ -251,7 +251,7 @@ enum vcpu_gp_register {
     VCPU_R15,
 #endif
     n_vcpu_gp_register,
-    /* We need to define a sentinal value to detect ESP that is strictly distinct
+    /* We need to define a sentinel value to detect ESP that is strictly distinct
      * from any of our other GP register indexes, so put that here */
     VCPU_ESP,
 };

--- a/include/kernel/sporadic.h
+++ b/include/kernel/sporadic.h
@@ -91,7 +91,7 @@ static inline bool_t refill_full(sched_context_t *sc)
     return refill_size(sc) == sc->scRefillMax;
 }
 
-/* @return true if the ciruclar buffer only contains 1 used slot */
+/* @return true if the circular buffer only contains 1 used slot */
 static inline bool_t refill_single(sched_context_t *sc)
 {
     return sc->scRefillHead == sc->scRefillTail;

--- a/include/machine/debug.h
+++ b/include/machine/debug.h
@@ -41,7 +41,7 @@ void setBreakpoint(tcb_t *t,
  * @param vaddr[out] Address that the breakpoint is set to trigger on.
  * @param type[out] Type of operation that will trigger the breakpoint.
  * @param size[out] operand size that will trigger the breakpoint.
- * @param rw[out] Access type (read/write) that will trigger thr breakpoint.
+ * @param rw[out] Access type (read/write) that will trigger the breakpoint.
  * @param uds If NULL, this function call will read directly from the hardware
  *            registers.
  *            If non-NULL, 'uds' is assumed to be a pointer to a debug register

--- a/include/machine/interrupt.h
+++ b/include/machine/interrupt.h
@@ -16,7 +16,7 @@
  * kernel to track irq state. An irq_t is also used to interface with an
  * interrupt controller driver using the functions below.
  * For most configurations an irq_t is a word_t type and the irq_t values
- * directly map to harware irq numbers and are also used as indexes into the
+ * directly map to hardware irq numbers and are also used as indexes into the
  * kernel's irq cnode that it uses for tracking state.
  * However on SMP configurations where there can be multiple irq_t identifiers
  * for a single hardware irq number, such as when there are core local interrupts,
@@ -114,7 +114,7 @@ static inline void deactivateInterrupt(irq_t irq);
 /**
  * Called when getActiveIRQ returns irqInvalid while the kernel is handling an
  * interrupt entry. An implementation is not required to do anything here, but
- * can report the spurious IRQ or try prevent it from reoccuring.
+ * can report the spurious IRQ or try prevent it from reoccurring.
  */
 static inline void handleSpuriousIRQ(void);
 

--- a/include/object/structures.h
+++ b/include/object/structures.h
@@ -296,7 +296,7 @@ struct tcb {
     /* Previous and next pointers for scheduler queues , 2 words */
     struct tcb *tcbSchedNext;
     struct tcb *tcbSchedPrev;
-    /* Preivous and next pointers for endpoint and notification queues, 2 words */
+    /* Previous and next pointers for endpoint and notification queues, 2 words */
     struct tcb *tcbEPNext;
     struct tcb *tcbEPPrev;
 

--- a/include/plat/pc99/plat/machine/acpi.h
+++ b/include/plat/pc99/plat/machine/acpi.h
@@ -48,7 +48,7 @@ typedef struct acpi_rsdt {
     uint32_t entry[1];
 } PACKED acpi_rsdt_t;
 
-/* Attemps to initialize acpi by searching for a valid RSDP block. If found a copy is placed in rsdp_data
+/* Attempts to initialize acpi by searching for a valid RSDP block. If found a copy is placed in rsdp_data
  * and true is returned, otherwise the contents of rsdp_data are undefined and false is returned. */
 bool_t acpi_init(acpi_rsdp_t *rsdp_data);
 

--- a/libsel4/arch_include/x86/interfaces/object-api-arch.xml
+++ b/libsel4/arch_include/x86/interfaces/object-api-arch.xml
@@ -955,7 +955,7 @@ contain the mapping"/>
             </description>
             <return>
                 A <texttt text='seL4_X86_VCPU_WriteVMCS_t'/> struct that contains a
-                <texttt text='seL4_Word writen'/>, which holds the final value written with the <texttt text='vmwrite'/> instruction,
+                <texttt text='seL4_Word written'/>, which holds the final value written with the <texttt text='vmwrite'/> instruction,
                 and <texttt text='int error'/>. <docref>See <autoref label='sec:errors'/> for a description
                 of the message register and tag contents upon error.</docref>
             </return>

--- a/libsel4/include/sel4/assert.h
+++ b/libsel4/include/sel4/assert.h
@@ -9,7 +9,7 @@
  *
  * These are unconditional, there are conditional versions of
  * these in debug_assert.h and are name seL4_DebugAssert and
- * sl4_DebugCompileTimeAsssert.
+ * seL4_DebugCompileTimeAssert.
  */
 
 #pragma once

--- a/libsel4/include/sel4/syscalls.h
+++ b/libsel4/include/sel4/syscalls.h
@@ -381,7 +381,7 @@ seL4_VMEnter(seL4_Word *sender);
  * reserved for that purpose on the given platform.
  *
  * Each platform has a specific register reserved for tracking the
- * base address of the TLS region (as sepcified in the ELF standard) in
+ * base address of the TLS region (as specified in the ELF standard) in
  * a manner compatible with the TLS method used with that architecture.
  *
  * @param tls_base The new base address to store in the register.

--- a/libsel4/sel4_arch_include/x86_64/interfaces/object-api-sel4-arch.xml
+++ b/libsel4/sel4_arch_include/x86_64/interfaces/object-api-sel4-arch.xml
@@ -136,7 +136,7 @@
         </description>
         <return>
           A <texttt text='seL4_X86_VCPU_WriteMSR_t'/> struct that contains a
-          <texttt text='seL4_Word writen'/>, which holds the final value written with the <texttt text='wrmsr'/> instruction,
+          <texttt text='seL4_Word written'/>, which holds the final value written with the <texttt text='wrmsr'/> instruction,
           and <texttt text='int error'/>. <docref>See <autoref label='sec:errors'/> for a description
           of the message register and tag contents upon error.</docref>
         </return>

--- a/libsel4/tools/syscall_stub_gen_rs.py
+++ b/libsel4/tools/syscall_stub_gen_rs.py
@@ -9,7 +9,7 @@
 #
 
 # This script is intended to work as a Rust-specific copy of syscall_stub_gen.py
-# Use it with sel4-sys crate to allow Rust applications inteface with the seL4 API.
+# Use it with sel4-sys crate to allow Rust applications interface with the seL4 API.
 
 from argparse import ArgumentParser
 import sys

--- a/manual/parts/threads.tex
+++ b/manual/parts/threads.tex
@@ -562,7 +562,7 @@ is currently configured (if any) for single-stepping will be the implicit
 \texttt{bp\_num} argument in a single-step debug fault reply.
 
 % The description for skipping num_instructions had an off-by-one error
-% I.e. num_instruction = 1 does not skip any instructions between stopps
+% I.e. num_instruction = 1 does not skip any instructions between stops
 % num_instruction = 2 "skips" 1 instruction, but executes 2 instructions before stopping
 
 The kernel's single-stepping, also supports executing a certain number of

--- a/src/arch/arm/32/c_traps.c
+++ b/src/arch/arm/32/c_traps.c
@@ -40,7 +40,7 @@ void VISIBLE NORETURN restore_user_context(void)
             "mov sp, %[cur_thread_reg] \n"
             /* Pop user registers */
             "pop {r0-r12}              \n"
-            /* Retore the user stack pointer */
+            /* Restore the user stack pointer */
             "pop {lr}                  \n"
             "msr sp_usr, lr            \n"
             /* prepare the exception return lr */

--- a/src/arch/arm/32/kernel/vspace.c
+++ b/src/arch/arm/32/kernel/vspace.c
@@ -179,8 +179,8 @@ BOOT_CODE void map_kernel_frame(paddr_t paddr, pptr_t vaddr, vm_rights_t vm_righ
 #else /* CONFIG_ARM_HYPERVISOR_SUPPORT */
     armHSGlobalPT[idx] =
         pteS1_pteS1_small_new(
-            0, /* Executeable */
-            0, /* Executeable at PL1 */
+            0, /* Executable */
+            0, /* Executable at PL1 */
             0, /* Not contiguous */
             paddr,
             0, /* global */
@@ -404,7 +404,7 @@ static BOOT_CODE void map_it_frame_cap(cap_t pd_cap, cap_t frame_cap, bool_t exe
                   );
 #else
     *targetSlot = pte_pte_small_new(
-                      0, /* Executeable */
+                      0, /* Executable */
                       0, /* Not contiguous */
                       addrFromPPtr(frame),
                       1, /* AF -- always set */
@@ -563,7 +563,7 @@ BOOT_CODE void activate_kernel_vspace(void)
        that everything we've written (particularly the kernel page tables)
        is committed. */
     cleanInvalidateL1Caches();
-    /* Setup the memory attributes: We use 2 indicies (cachable/non-cachable) */
+    /* Setup the memory attributes: We use 2 indices (cachable/non-cacheable) */
     setHMAIR((ATTRINDX_NONCACHEABLE << 0) | (ATTRINDX_CACHEABLE << 8), 0);
     setCurrentHypPD(addrFromKPPtr(armHSGlobalPGD));
     invalidateHypTLB();
@@ -744,7 +744,7 @@ static resolve_ret_t resolveVAddr(pde_t *pd, vptr_t vaddr)
         }
 #else
         if (pde_pde_section_ptr_get_contiguous_hint(pde)) {
-            /* Entires are represented as 16 contiguous sections. We need to mask
+            /* Entries are represented as 16 contiguous sections. We need to mask
                to get the super section frame base */
             ret.frameBase &= ~MASK(pageBitsForSize(ARMSuperSection));
             ret.frameSize = ARMSuperSection;

--- a/src/arch/arm/32/machine/capdl.c
+++ b/src/arch/arm/32/machine/capdl.c
@@ -468,7 +468,7 @@ void obj_tcb_print_vtable(tcb_t *tcb)
                 }
 #else
                 if (pde_pde_section_ptr_get_contiguous_hint(pde)) {
-                    /* Entires are represented as 16 contiguous sections. We need to mask
+                    /* Entries are represented as 16 contiguous sections. We need to mask
                     to get the super section frame base */
                     ret.frameBase &= ~MASK(pageBitsForSize(ARMSuperSection));
                     ret.frameSize = ARMSuperSection;

--- a/src/arch/arm/64/kernel/vspace.c
+++ b/src/arch/arm/64/kernel/vspace.c
@@ -88,7 +88,7 @@ struct findVSpaceForASID_ret {
 typedef struct findVSpaceForASID_ret findVSpaceForASID_ret_t;
 
 /* Stage-1 access permissions:
- * AP[2:1]  higer EL        EL0
+ * AP[2:1]  higher EL        EL0
  *   00       rw            None
  *   01       rw            rw
  *   10       r             None
@@ -193,7 +193,7 @@ vm_rights_t CONST maskVMRights(vm_rights_t vm_rights, seL4_CapRights_t cap_right
 /* ==================== BOOT CODE STARTS HERE ==================== */
 
 /* The 54th bit is defined as UXN (unprivileged execute-never) for stage 1
- * of any tranlsation regime for which stage 1 translation can support
+ * of any translation regime for which stage 1 translation can support
  * two VA ranges. This field applies only to execution at EL0. A value
  * of 0 indicates that this control permits execution.
  *

--- a/src/arch/arm/64/machine/capdl.c
+++ b/src/arch/arm/64/machine/capdl.c
@@ -35,7 +35,7 @@ static void arm64_cap_pd_print_slots(pte_t *pudSlot, vptr_t vptr);
 static void arm64_cap_pud_print_slots(void *pgdSlot_or_vspace, vptr_t vptr);
 
 /* Stage-1 access permissions:
- * AP[2:1]  higer EL        EL0
+ * AP[2:1]  higher EL        EL0
  *   00       rw            None
  *   01       rw            rw
  *   10       r             None

--- a/src/arch/arm/64/machine/debug.c
+++ b/src/arch/arm/64/machine/debug.c
@@ -111,7 +111,7 @@ BOOT_CODE bool_t Arch_initHardwareBreakpoints(void)
     /* Ensure that all the breakpoint and watchpoint registers are initially disabled */
     disableAllBpsAndWps();
 
-    /* Ensure that single stepping is initally disabled */
+    /* Ensure that single stepping is initially disabled */
     MRS("MDSCR_EL1", mdscr);
     mdscr &= ~MDSCR_SS;
     MSR("MDSCR_EL1", mdscr);

--- a/src/arch/arm/machine/cache.c
+++ b/src/arch/arm/machine/cache.c
@@ -40,7 +40,7 @@ void cleanInvalidateCacheRange_RAM(vptr_t start, vptr_t end, paddr_t pstart)
     /* Now clean and invalidate the L2 range */
     plat_cleanInvalidateL2Range(pstart, pstart + (end - start));
 
-    /* Finally clean and invalidate the L1 range. The extra clean is only strictly neccessary
+    /* Finally clean and invalidate the L1 range. The extra clean is only strictly necessary
      * in a multiprocessor environment to prevent a write being lost if another core is
      * attempting a store at the same time. As the range should already be clean asking
      * it to clean again should not affect performance */

--- a/src/arch/arm/machine/gic_v2.c
+++ b/src/arch/arm/machine/gic_v2.c
@@ -180,7 +180,7 @@ BOOT_CODE void cpu_initLocalIRQController(void)
 * 25-24: target lister filter
 * 0b00 - send the ipi to the CPU interfaces specified in the CPU target list
 * 0b01 - send the ipi to all CPU interfaces except the cpu interface.
-*        that requrested teh ipi
+*        that requested the ipi
 * 0b10 - send the ipi only to the CPU interface that requested the IPI.
 * 0b11 - reserved
 *.

--- a/src/arch/arm/machine/gic_v3.c
+++ b/src/arch/arm/machine/gic_v3.c
@@ -210,7 +210,7 @@ BOOT_CODE static void gicr_locate_interface(void)
 
             /*
              * GICR_WAKER should be Read-all-zeros in Non-secure world
-             * and we expect redistributors to be alread awoken by an earlier loader.
+             * and we expect redistributors to be already awoken by an earlier loader.
              * However if we get a value back then something is probably wrong.
              */
             val = gic_rdist_map[core_id]->waker;

--- a/src/arch/arm/object/iospace.c
+++ b/src/arch/arm/object/iospace.c
@@ -98,7 +98,7 @@ BOOT_CODE seL4_SlotRegion create_iospace_caps(cap_t root_cnode_cap)
     int num_smmu = plat_smmu_init();
 
     if (num_smmu == 0) {
-        printf("SMMU init failuer\n");
+        printf("SMMU init failure\n");
         return S_REG_EMPTY;
     }
 

--- a/src/arch/arm/object/smmu.c
+++ b/src/arch/arm/object/smmu.c
@@ -375,7 +375,7 @@ void smmu_cb_delete_vspace(word_t cb, asid_t asid)
 {
     /* Deleting the vspace cap stored in context bank's CNode, causing:
      * -reset the relationship between context bank and vspace's ASID
-     * -disabe the context bank as its vspace no longer exists*/
+     * -disable the context bank as its vspace no longer exists*/
     smmuStateCBAsidTable[cb] = ASID_INVALID;
     decreaseASIDBindCB(asid);
     smmu_cb_disable(cb, asid);
@@ -386,7 +386,7 @@ void invalidateSMMUTLBByASID(asid_t asid, word_t bind_cb)
     /* Due to the requirement of one vspace (ASID) can be shared by
      * multiple threads and drivers, there is no obvious way to
      * directly locate all context banks associated with a given ASID without a
-     * serch. Another possible solution is representing all context banks in
+     * search. Another possible solution is representing all context banks in
      * bitmaps, which also requires a search. This operation can only be triggered
      * by ASID invalidation or similar operations, hence the performance is not a major issue.*/
     for (int cb = 0; cb < SMMU_MAX_CB && bind_cb; cb++) {
@@ -399,7 +399,7 @@ void invalidateSMMUTLBByASID(asid_t asid, word_t bind_cb)
 
 void invalidateSMMUTLBByASIDVA(asid_t asid, vptr_t vaddr, word_t bind_cb)
 {
-    /* Implemeneted in the same way as invalidateSMMUTLBByASID */
+    /* Implemented in the same way as invalidateSMMUTLBByASID */
     for (int cb = 0; cb < SMMU_MAX_CB && bind_cb; cb++) {
         if (unlikely(smmuStateCBAsidTable[cb] == asid)) {
             smmu_tlb_invalidate_cb_va(cb, asid, vaddr);

--- a/src/arch/riscv/kernel/vspace.c
+++ b/src/arch/riscv/kernel/vspace.c
@@ -765,7 +765,7 @@ static exception_t decodeRISCVPageTableInvocation(word_t label, word_t length,
     lookupPTSlot_ret_t lu_ret = lookupPTSlot(lvl1pt, vaddr);
 
     /* if there is already something mapped (valid is set) or we have traversed far enough
-     * that a page table is not valid to map then tell the user that they ahve to delete
+     * that a page table is not valid to map then tell the user that they have to delete
      * something before they can put a PT here */
     if (lu_ret.ptBitsLeft == seL4_PageBits || pte_ptr_get_valid(lu_ret.ptSlot)) {
         userError("RISCVPageTableMap: All objects mapped at this address");

--- a/src/arch/x86/64/c_traps.c
+++ b/src/arch/x86/64/c_traps.c
@@ -264,7 +264,7 @@ void VISIBLE NORETURN restore_user_context(void)
             /* if we are using the SKIM window then we are trying to hide kernel state from
              * the user in the case of Meltdown where the kernel region is effectively readable
              * by the user. To prevent a storage channel across threads through the irq stack,
-             * which is idirectly controlled by the user, we need to clear the stack. We perform
+             * which is indirectly controlled by the user, we need to clear the stack. We perform
              * this here since when we return *from* an interrupt we must use this stack and
              * cannot clear it. This means if we restore from interrupt, then enter from a syscall
              * and switch to a different thread we must either on syscall entry, or before leaving

--- a/src/arch/x86/64/traps.S
+++ b/src/arch/x86/64/traps.S
@@ -20,7 +20,7 @@
  * The RSP is aligned to a 16-byte boundary before pushing the stack frame.
  * In x86-64 mode, when stacks are switched as part of a 64-bit mode privilege-level
  * change, a new SS descriptor is not loaded. x86-64 mode loads only an inner-level
- * RSP from the TSS. The new SS selector is forced to NULL and the SS selctor's RPL
+ * RSP from the TSS. The new SS selector is forced to NULL and the SS selector's RPL
  * field is set to the new CPL. The old SS and RSP are saved on the new stack.
  *
  * Stack Usage with Privilege-Level Change
@@ -36,13 +36,13 @@
  * ES, DS and SS segment registers are not used in 64-bit mode, their
  * fields (base, limit and attribute) in segment descriptor registers
  * are ignored. Some forms of segment load instructions are also invalid.
- * Address caculations that reference the DS, ES or SS segments are treated
+ * Address calculations that reference the DS, ES or SS segments are treated
  * as if the segment base is zero. Mode change does not change the contents
  * of the segment registers or associated descriptor register. These registers
- * are also not changed during 64-bit mode exectuion, unless explicit
+ * are also not changed during 64-bit mode execution, unless explicit
  * segment loads are performed.
  *
- * In order to setup compability mode for an application, segment-load
+ * In order to setup compatibility mode for an application, segment-load
  * instructions (mov to Sreg, pop Sreg) work normally in 64-bit mode. An
  * entry is read from the system descriptor table (GDT or LDT) and is loaded
  * in the hidden portion of the segment descriptor. The descriptor-register

--- a/src/arch/x86/config.cmake
+++ b/src/arch/x86/config.cmake
@@ -206,7 +206,7 @@ config_choice(
     KERNEL_FSGS_BASE
     "There are three ways to to set FS/GS base addresses: \
     IA32_FS/GS_GDT, IA32_FS/GS_BASE_MSR, and fsgsbase instructions. \
-    IA32_FS/GS_GDT and IA32_FS/GS_BASE_MSR are availble for 32-bit. \
+    IA32_FS/GS_GDT and IA32_FS/GS_BASE_MSR are available for 32-bit. \
     IA32_FS/GS_BASE_MSR and fsgsbase instructions are available for 64-bit."
     "inst;KernelFSGSBaseInst;FSGSBASE_INST;KernelSel4ArchX86_64"
     "gdt;KernelFSGSBaseGDT;FSGSBASE_GDT;KernelSel4ArchIA32"

--- a/src/arch/x86/kernel/boot.c
+++ b/src/arch/x86/kernel/boot.c
@@ -226,7 +226,7 @@ BOOT_CODE bool_t init_sys_state(
         extra_bi_offset += 4;
     }
 
-    /* provde a chunk for any leftover padding in the extended boot info */
+    /* provide a chunk for any leftover padding in the extended boot info */
     seL4_BootInfoHeader padding_header;
     padding_header.id = SEL4_BOOTINFO_HEADER_PADDING;
     padding_header.len = (extra_bi_region.end - extra_bi_region.start) - extra_bi_offset;

--- a/src/arch/x86/kernel/boot_sys.c
+++ b/src/arch/x86/kernel/boot_sys.c
@@ -411,7 +411,7 @@ static BOOT_CODE bool_t try_boot_sys(void)
         return false;
     }
 
-    /* check if kernel configuration matches platform requirments */
+    /* check if kernel configuration matches platform requirements */
     if (!acpi_fadt_scan(&boot_state.acpi_rsdp)) {
         return false;
     }

--- a/src/arch/x86/machine/breakpoint.c
+++ b/src/arch/x86/machine/breakpoint.c
@@ -392,7 +392,7 @@ static void setBpVaddrContext(tcb_t *t, uint16_t bp_num, word_t vaddr)
  *
  * @param uds Arch TCB register context structure.
  * @param bp_num Hardware breakpoint ID.
- * @param vaddr USerspace virtual address on which you'd like this breakpoing
+ * @param vaddr USerspace virtual address on which you'd like this breakpoint
  *        to trigger.
  * @param types One of the seL4_BreakpointType values.
  * @param size positive integer indicating the byte-range size that should

--- a/src/arch/x86/machine/cpu_identification.c
+++ b/src/arch/x86/machine/cpu_identification.c
@@ -125,7 +125,7 @@ bool_t x86_cpuid_initialize(void)
     /* First determine which vendor manufactured the CPU. */
     x86_cpuid_fill_vendor_string(ci);
 
-    /* Need both eax and ebx ouput values. */
+    /* Need both eax and ebx output values. */
     eax.words[0] = x86_cpuid_eax(1, 0);
     ebx.words[0] = x86_cpuid_ebx(1, 0);
 

--- a/src/arch/x86/object/interrupt.c
+++ b/src/arch/x86/object/interrupt.c
@@ -29,7 +29,7 @@ void Arch_irqStateInit(void)
 }
 
 /* for x86, the IRQIssueIRQHandler is only allowed to
- * issue a hander for IRQ 0-15, the isa IRQs.
+ * issue a handler for IRQ 0-15, the isa IRQs.
  * Use getIRQHandlerIOAPIC and getIRQHandlerMSI for
  * the IRQs >= 16. Additionally these IRQs only exist
  * if using the legacy PIC interrupt
@@ -151,7 +151,7 @@ exception_t Arch_decodeIRQControlInvocation(word_t invLabel, word_t length, cte_
         word_t pci_func = getSyscallArg(4, buffer);
         word_t handle = getSyscallArg(5, buffer);
         x86_irq_state_t irqState;
-        /* until we support msi interrupt remaping through vt-d we ignore the
+        /* until we support msi interrupt remapping through vt-d we ignore the
          * vector and trust the user */
 
         if (pci_bus > PCI_BUS_MAX) {

--- a/src/arch/x86/object/vcpu.c
+++ b/src/arch/x86/object/vcpu.c
@@ -137,7 +137,7 @@ static void vmptrld(void *vmcs_ptr)
         : "cc"
     );
     /* The usage of vmptrld should be correct by construction. As there is no
-     * capacity to propogate errors where vmptrld is used we will do our best
+     * capacity to propagate errors where vmptrld is used we will do our best
      * to detect bugs in debug builds by asserting */
     assert(!error);
 }
@@ -298,7 +298,7 @@ static bool_t BOOT_CODE init_vtx_fixed_values(bool_t useTrueMsrs)
     /* Check for VPID support */
     if (!(secondary_control_low & BIT(5))) {
         vmx_feature_vpid = 0;
-        printf("vt-x: VPIDs are not supported. Expect performance degredation\n");
+        printf("vt-x: VPIDs are not supported. Expect performance degradation\n");
     } else {
         vmx_feature_vpid = 1;
         secondary_control_mask |= BIT(5);
@@ -316,7 +316,7 @@ static bool_t BOOT_CODE init_vtx_fixed_values(bool_t useTrueMsrs)
     /* Check for external interrupt exiting */
     if (!(exit_control_low & BIT(15))) {
         vmx_feature_ack_on_exit = 0;
-        printf("vt-x: Interrupt ack on exit not supported. Expect performance degredation\n");
+        printf("vt-x: Interrupt ack on exit not supported. Expect performance degradation\n");
     } else {
         vmx_feature_ack_on_exit = 1;
         exit_control_mask |= BIT(15);
@@ -1337,18 +1337,18 @@ exception_t handleVmexit(void)
              * on cr0_mask meant that the VCPU owner did not claim ownership of the the task switch bit
              * however we may have temporarily claimed ownership for the purposes of FPU switching.
              * At this point we could still have a false positive, as the guest could be attempted to
-             * manipulate bits that are not task switch, so we still have to be careful and propogate
+             * manipulate bits that are not task switch, so we still have to be careful and propagate
              * all or some of an attempted write */
             qualification = vmread(VMX_DATA_EXIT_QUALIFICATION);
-            vmx_data_exit_qualification_control_regster_t qual;
+            vmx_data_exit_qualification_control_register_t qual;
             qual.words[0] = qualification;
             /* We only care about some of the exit qualification cases, we handle them here
              * and will deliver any others through to fault handler */
-            switch (vmx_data_exit_qualification_control_regster_get_access_type(qual)) {
+            switch (vmx_data_exit_qualification_control_register_get_access_type(qual)) {
             case VMX_EXIT_QUAL_TYPE_MOV_CR: {
                 /* check for cr0 */
-                if (vmx_data_exit_qualification_control_regster_get_cr(qual) == 0) {
-                    vcpu_gp_register_t source = crExitRegs[vmx_data_exit_qualification_control_regster_get_reg(qual)];
+                if (vmx_data_exit_qualification_control_register_get_cr(qual) == 0) {
+                    vcpu_gp_register_t source = crExitRegs[vmx_data_exit_qualification_control_register_get_reg(qual)];
                     word_t value;
                     if (source == VCPU_ESP) {
                         /* ESP is the only register that is is not part of the general purpose
@@ -1380,7 +1380,7 @@ exception_t handleVmexit(void)
                 return EXCEPTION_NONE;
             }
             case VMX_EXIT_QUAL_TYPE_LMSW: {
-                uint16_t value = vmx_data_exit_qualification_control_regster_get_data(qual);
+                uint16_t value = vmx_data_exit_qualification_control_register_get_data(qual);
                 /* First unset the task switch bit in cr0 */
                 NODE_STATE(ksCurThread)->tcbArch.tcbVCPU->cr0 &= ~CR0_TASK_SWITCH;
                 /* now set it to the value we were given */
@@ -1446,7 +1446,7 @@ void VMCheckBoundNotification(tcb_t *tcb)
 {
     /* We want to check if the VM we are currently running has received
      * a message on its bound notification object. This check is done
-     * in c_traps when we first peform a SysVMEnter, but we could presently
+     * in c_traps when we first perform a SysVMEnter, but we could presently
      * be running a VM and another core may have placed a message on the
      * endpoint
      */
@@ -1592,7 +1592,7 @@ static inline vpid_t nextVPID(vpid_t vpid)
 static void invalidateVPID(vpid_t vpid)
 {
     vcpu_t *vcpu = x86KSVPIDTable[vpid];
-    /* clear the IO bitmap as when we sever the VPID asignment we lose
+    /* clear the IO bitmap as when we sever the VPID assignment we lose
      * the ability for the references in IO port capabilities to invalidate */
     memset(vcpu->io, ~0, sizeof(vcpu->io));
     /* invalidate the VPID context */

--- a/src/drivers/smmu/smmuv2.c
+++ b/src/drivers/smmu/smmuv2.c
@@ -23,11 +23,11 @@
 #define TRANS_PAGES_16KB       (1 << 4)
 #define TRANS_PAGES_64KB       (1 << 5)
 
-/*the default vritual address bits for partition TTBR0 and TTBR1*/
+/*the default virtual address bits for partition TTBR0 and TTBR1*/
 #define SMMU_VA_DEFAULT_BITS      48
 
 struct  smmu_feature {
-    bool_t stream_match;              /*stream match register funtionality included*/
+    bool_t stream_match;              /*stream match register functionality included*/
     bool_t trans_op;                  /*address translation operations supported*/
     bool_t cotable_walk;              /*coherent translation table walk*/
     bool_t broadcast_tlb;             /*broadcast TLB maintenance*/
@@ -92,7 +92,7 @@ static void smmu_tlb_sync(pptr_t base, uint32_t sync, uint32_t status)
 
 static inline uint32_t smmu_obs_size_to_bits(uint32_t size)
 {
-    /*coverting the output bus address size into address bit, defined in
+    /*converting the output bus address size into address bit, defined in
     IDx registers*/
     switch (size) {
     case 0:
@@ -111,7 +111,7 @@ static inline uint32_t smmu_obs_size_to_bits(uint32_t size)
 }
 static inline uint32_t smmu_ubs_size_to_bits(uint32_t size)
 {
-    /*coverting the upstream address size into address bit, defined in
+    /*converting the upstream address size into address bit, defined in
     IDx registers*/
     switch (size) {
     case 0:
@@ -135,17 +135,17 @@ BOOT_CODE static void smmu_mapping_init(void)
 {
     /*Creating mapping for the rest of SMMU address space.
      * the code assumes registers in each SMMU page are located in a 4K page
-     * even though the alignement of the (physical) pages can be 64K.
+     * even though the alignment of the (physical) pages can be 64K.
      * We make this assumption to compact the SMMU virtual address window.*/
 
     /* This is a temporary solution. A correct solution should be adjust
-     * the virutal address space layout of the kernel, leaving enough virtual
+     * the virtual address space layout of the kernel, leaving enough virtual
      * address space to SMMU windows. For example, SMMU on TX2 requires a 8M space
      * in total, including those empty areas resulted from the 64K alignment.
      * Also, kernel requires device space to be configured statically. To
      * support populate device space using HW config, we need to modify
      * kernel_frame_t and map_kernel_frame, allowing devices mapped in a
-     * seperate page table using HW config.*/
+     * separate page table using HW config.*/
 
     /*the current implementation has been only tested on the TX2 platform*/
 
@@ -211,7 +211,7 @@ BOOT_CODE static void smmu_config_prob(void)
     } else {
         smmu_dev_knowledge.supported_fmt |= NO_AARCH32_FMT;
     }
-    /*number of context fault intrrupts
+    /*number of context fault interrupts
     * However, in smmuv2, each context bank has dedicated interrupt pin
     * hence no requirement to specify implemented interrupts here.*/
     smmu_dev_knowledge.num_cfault_ints = IDR0_NUMIRPT_VAL(reg & IDR0_NUMIRPT);
@@ -243,7 +243,7 @@ BOOT_CODE static void smmu_config_prob(void)
     smmu_dev_knowledge.num_s2_cbanks = IDR1_NUMS2CB_VAL(reg & IDR1_NUMS2CB);
     /*total num of context banks*/
     smmu_dev_knowledge.num_cbanks = reg & IDR1_NUMCB;
-    /*calcuate the context bank base*/
+    /*calculate the context bank base*/
     smmu_dev_knowledge.cb_base = SMMU_CB_BASE_PADDR(
                                      SMMU_GLOBAL_SIZE(smmu_dev_knowledge.smmu_num_pages, smmu_dev_knowledge.smmu_page_size));
 
@@ -282,7 +282,7 @@ BOOT_CODE  static void smmu_dev_reset(void)
     pptr_t cb_bank_ptr;
     uint32_t major;
 
-    /*clear the fault syndrom registers*/
+    /*clear the fault syndrome registers*/
     smmu_write_reg32(SMMU_GR0_PPTR, SMMU_sGFSYNR0, reg);
     smmu_write_reg32(SMMU_GR0_PPTR, SMMU_sGFSYNR1, reg);
     /*clear the global FSR by writing back the read value*/
@@ -293,7 +293,7 @@ BOOT_CODE  static void smmu_dev_reset(void)
     reg = S2CR_PRIVCFG_SET(S2CR_PRIVCFG_DEFAULT);
     reg |= S2CR_TYPE_SET(S2CR_TYPE_CB);
 
-    /*the number of stream-to-context is realted to the stream indexing method*/
+    /*the number of stream-to-context is related to the stream indexing method*/
     if (smmu_dev_knowledge.stream_match) {
         /*stream matching*/
         for (int i = 0; i < smmu_dev_knowledge.num_stream_map_groups; i++) {
@@ -330,7 +330,7 @@ BOOT_CODE  static void smmu_dev_reset(void)
         cb_bank_ptr = SMMU_CBn_BASE_PPTR(i);
         /*disable context banks and clear the context bank fault registers*/
         smmu_write_reg32(cb_bank_ptr, SMMU_CBn_SCTLR, 0);
-        /*clear the syndrom register*/
+        /*clear the syndrome register*/
         smmu_write_reg64(cb_bank_ptr, SMMU_CBn_FAR, 0ULL);
         smmu_write_reg32(cb_bank_ptr, SMMU_CBn_FSR, CBn_FSR_CLEAR_ALL);
         /*special init requested by the smmu-500: start*/
@@ -349,7 +349,7 @@ BOOT_CODE  static void smmu_dev_reset(void)
     /*enable global fault reporting*/
     reg |= CR0_GFRE | CR0_GFIE | CR0_GCFGFRE | CR0_GCFGFIE;
     /*raise fault for any transaction that does not match to
-    any stream mapping table entires*/
+    any stream mapping table entries*/
     reg |= CR0_USFCFG;
     /*raise fault for stream match conflict*/
     reg |= CR0_SMCFCFG;
@@ -418,9 +418,9 @@ static void smmu_config_stage1(struct smmu_table_config *cfg,
         reg |= CBn_TCR_ORGN0_SET(CBn_TCR_GN_NCACHE);
         reg |= CBn_TCR_IRGN0_SET(CBn_TCR_GN_NCACHE);
     }
-    /*page size is configed as 4k*/
+    /*page size is configured as 4k*/
     reg |= CBn_TCR_TG0_SET(CBn_TCR_TG_4K);
-    /*the TTBR0 size, caculated according to the aarch64 formula*/
+    /*the TTBR0 size, calculated according to the aarch64 formula*/
     reg |= CBn_TCR_T0SZ_SET(64 - SMMU_VA_DEFAULT_BITS);
     /*disable (speculative) page table walks through TTBR1*/
     reg |= CBn_TCR_EPD1_DIS;
@@ -474,7 +474,7 @@ void smmu_cb_assign_vspace(word_t cb, vspace_root_t *vspace, asid_t asid)
     /* For the stage 2 translation, the VMID space is designed as a private
      * space, its value is equal to the context bank index. Using private VMID
      * space avoids synchronising with vspace management on VMID reallocations.
-     * Also, VMID used by SMMU need to be vaild all time once device transactions
+     * Also, VMID used by SMMU need to be valid all time once device transactions
      * are enabled. To maintain the TLB coherency, we introduces a set of mechanism
       * that connects vspace to context banks linked via ASID. */
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
@@ -514,8 +514,8 @@ void smmu_cb_assign_vspace(word_t cb, vspace_root_t *vspace, asid_t asid)
     smmu_write_reg32(SMMU_GR1_PPTR, SMMU_CBARn(cb), reg);
     /*TCR*/
     smmu_write_reg32(SMMU_CBn_BASE_PPTR(cb), SMMU_CBn_TCR, smmu_stage_table_config.tcr[0]);
-    /* stage 1 transaltion requires both ttbr 1 and ttbr 0
-     * stage 2 transaltion requires ttbr 0*/
+    /* stage 1 translation requires both ttbr 1 and ttbr 0
+     * stage 2 translation requires ttbr 0*/
 #ifndef CONFIG_ARM_HYPERVISOR_SUPPORT
     /*TCR2 is required by stage 1 only*/
     smmu_write_reg32(SMMU_CBn_BASE_PPTR(cb), SMMU_CBn_TCR2, smmu_stage_table_config.tcr[1]);

--- a/src/fastpath/fastpath.c
+++ b/src/fastpath/fastpath.c
@@ -683,7 +683,7 @@ void NORETURN fastpath_signal(word_t cptr, word_t msgInfo)
         ntfn_queue_dequeue_fp(dest, ntfnPtr);
     }
 
-    /* Wake up the signalled thread and tranfer badge */
+    /* Wake up the signalled thread and transfer badge */
     setRegister(dest, badgeRegister, badge);
     thread_state_ptr_set_tsType_np(&dest->tcbState, ThreadState_Running);
 

--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -706,7 +706,7 @@ BOOT_CODE static bool_t provide_untyped_cap(
 /**
  * Create untyped caps for a region of kernel-virtual memory.
  *
- * Takes care of alignement, size and potentially wrapping memory regions. It is fine to provide a
+ * Takes care of alignment, size and potentially wrapping memory regions. It is fine to provide a
  * region with end < start if the memory is device memory.
  *
  * If the region start is not aligned to seL4_MinUntypedBits, the part up to the next aligned
@@ -834,7 +834,7 @@ BOOT_CODE void bi_finalise(void)
 {
 
     if (rootserver.paging.start != rootserver.paging.end) {
-        printf("WARNING: internal book keeping errror. Less pagetables allocated than predicted: "
+        printf("WARNING: internal book keeping error. Less pagetables allocated than predicted: "
                "%ld page tables allocated but not used.\n", (rootserver.paging.end - rootserver.paging.start) >> seL4_PageTableBits);
     }
 

--- a/src/object/schedcontext.c
+++ b/src/object/schedcontext.c
@@ -310,7 +310,7 @@ void schedContext_bindTCB(sched_context_t *sc, tcb_t *tcb)
         SCHED_ENQUEUE(tcb);
         rescheduleRequired();
         // TODO -- at some stage we should take this call out of any TCB invocations that
-        // alter capabilities, so that we can do a direct switch. The prefernce here is to
+        // alter capabilities, so that we can do a direct switch. The preference here is to
         // remove seL4_SetSchedParams from using ThreadControl. It's currently out of scope for
         // verification work, so the work around is to use rescheduleRequired()
         //possibleSwitchTo(tcb);

--- a/src/object/tcb.c
+++ b/src/object/tcb.c
@@ -59,7 +59,7 @@ static inline void addToBitmap(word_t cpu, word_t dom, word_t prio)
 
     NODE_STATE_ON_CORE(ksReadyQueuesL1Bitmap[dom], cpu) |= BIT(l1index);
     /* we invert the l1 index when accessed the 2nd level of the bitmap in
-       order to increase the liklihood that high prio threads l2 index word will
+       order to increase the likelihood that high prio threads l2 index word will
        be on the same cache line as the l1 index word - this makes sure the
        fastpath is fastest for high prio threads */
     NODE_STATE_ON_CORE(ksReadyQueuesL2Bitmap[dom][l1index_inverted], cpu) |= BIT(prio & MASK(wordRadix));

--- a/src/plat/allwinnerA20/machine/l2cache.c
+++ b/src/plat/allwinnerA20/machine/l2cache.c
@@ -26,7 +26,7 @@ void initL2Cache(void)
      * Set the L2EN bit in the Auxially Control Register.
      *
      * We assume the C bit is already set in the system control register (from
-     * head.S), and that the L2 Cache Auxilliary Control Register is correct
+     * head.S), and that the L2 Cache Auxiliary Control Register is correct
      * (as per reset).
      */
     writeACR(readACR() | 0x2);

--- a/src/plat/am335x/machine/l2cache.c
+++ b/src/plat/am335x/machine/l2cache.c
@@ -26,7 +26,7 @@ void initL2Cache(void)
      * Set the L2EN bit in the Auxially Control Register.
      *
      * We assume the C bit is already set in the system control register (from
-     * head.S), and that the L2 Cache Auxilliary Control Register is correct
+     * head.S), and that the L2 Cache Auxiliary Control Register is correct
      * (as per reset).
      */
     writeACR(readACR() | 0x2);

--- a/src/plat/hikey/config.cmake
+++ b/src/plat/hikey/config.cmake
@@ -51,8 +51,8 @@ set_property(CACHE KernelArmHikeyPrefetcherStride PROPERTY STRINGS "2;3")
 
 config_string(
     KernelArmHikeyPrefetcherNPFSTRM ARM_HIKEY_PREFETCHER_NPFSTRM
-    "Number of indepedent prefetch streams \
-    Number of indepedent prefetch streams. Allowed values are 1 to 4.\
+    "Number of independent prefetch streams \
+    Number of independent prefetch streams. Allowed values are 1 to 4.\
     2 is the reset value"
     DEFAULT 2
     DEPENDS "KernelPlatformHikey;NOT KernelDebugDisablePrefetchers" DEFAULT_DISABLED 0

--- a/src/plat/omap3/machine/l2cache.c
+++ b/src/plat/omap3/machine/l2cache.c
@@ -26,7 +26,7 @@ void initL2Cache(void)
      * Set the L2EN bit in the Auxially Control Register.
      *
      * We assume the C bit is already set in the system control register (from
-     * head.S), and that the L2 Cache Auxilliary Control Register is correct
+     * head.S), and that the L2 Cache Auxiliary Control Register is correct
      * (as per reset).
      */
     writeACR(readACR() | 0x2);

--- a/src/plat/qemu-arm-virt/overlay-qemu-arm-virt32.dts
+++ b/src/plat/qemu-arm-virt/overlay-qemu-arm-virt32.dts
@@ -14,7 +14,7 @@
          * address space (4 GiB) only, even if LPAE allows using a
          * 40-bit physical address space. For now, reserving any memory
          * starting at 0xffffffff is the easiest way to cope with
-         * platform configurations having pyhsical memory of exactly
+         * platform configurations having physical memory of exactly
          * 4 GiB or above. The long-term fix is improving the seL4 build
          * scripts to be aware of the 4 GiB limitation and never create
          * any regions above. Furthermore, a way needs to be found to

--- a/src/plat/qemu-riscv-virt/overlay-qemu-riscv-virt32.dts
+++ b/src/plat/qemu-riscv-virt/overlay-qemu-riscv-virt32.dts
@@ -14,7 +14,7 @@
          * address space (4 GiB) only, even if SV32 allows using a
          * 34-bit physical address space. For now, reserving any memory
          * starting at 0xffffffff is the easiest way to cope with
-         * platform configurations having pyhsical memory of exactly
+         * platform configurations having physical memory of exactly
          * 4 GiB or above. The long-term fix is improving the seL4 build
          * scripts to be aware of the 4 GiB limitation and never create
          * any regions above. Furthermore, a way needs to be found to

--- a/src/smp/ipi.c
+++ b/src/smp/ipi.c
@@ -71,7 +71,7 @@ void ipiStallCoreCallback(bool_t irqPath)
         /* We get here either without grabbing the lock from normal interrupt path or from
          * inside the lock while waiting to grab the lock for handling pending interrupt.
          * In latter case, we return to the 'clh_lock_acquire' to grab the lock and
-         * handle the pending interrupt. Its valid as interrups are async events! */
+         * handle the pending interrupt. Its valid as interrupts are async events! */
         SCHED_ENQUEUE_CURRENT_TCB;
         switchToIdleThread();
 #ifdef CONFIG_KERNEL_MCS

--- a/tools/bitfield_gen.py
+++ b/tools/bitfield_gen.py
@@ -2243,7 +2243,7 @@ class TaggedUnion:
         # where the 3rd and 4th lsbs signify whether the field should be
         # interpreted using a 4-bit mask (if 00, 01, or 10) or as an 8 or 16 bit
         # mask (if 11). And, in the latter case, the 8th lsb signifies whether
-        # to intrepret it as an 8 bit field (if 0) or a 16 bit field (if 1).
+        # to interpret it as an 8 bit field (if 0) or a 16 bit field (if 1).
         #
         # In this example we have:
         #   4-bit class:  classmask = 0b00001100

--- a/tools/condition.py
+++ b/tools/condition.py
@@ -55,7 +55,7 @@ def expr_to_bool(expr, values) -> bool:
                 return False
         return True
     elif expr.tagName == "or":
-        for chlid in expr.childNodes:
+        for child in expr.childNodes:
             if expr_to_bool(child, values):
                 return True
         return False

--- a/tools/cpp_gen.sh
+++ b/tools/cpp_gen.sh
@@ -6,7 +6,7 @@
 #
 
 #
-# Concatinate files together, adding in appropriate "#line" directives.
+# Concatenate files together, adding in appropriate "#line" directives.
 #
 
 while [ $# -ge 1 ]; do

--- a/tools/helpers.cmake
+++ b/tools/helpers.cmake
@@ -92,7 +92,7 @@ endfunction(cppfile)
 # Function to generate a custom command to process a bitfield file. The input
 # (pbf_path) is either a .bf file or, if you used pre-processor directives, a
 # pre-processed .bf file. As this invokes a python tool that places a file
-# in the current working directory a unqiue 'work_dir' needs to be provided
+# in the current working directory a unique 'work_dir' needs to be provided
 # for this command to execute in
 # This function is not intended to be used directly, rather one of its wrappers
 # that is specialized to generate a specific kind of output should be used

--- a/tools/invocation_json_gen.py
+++ b/tools/invocation_json_gen.py
@@ -19,7 +19,7 @@ def parse_args():
     parser.add_argument('--invocations', type=argparse.FileType('r'),
                         help='Location of XML file with invocation definitions', required=True)
     parser.add_argument('--arch_invocations', type=argparse.FileType('r'),
-                        help='Location of XML file with arch invocation defintions', required=True)
+                        help='Location of XML file with arch invocation definitions', required=True)
     parser.add_argument('--sel4_arch_invocations', type=argparse.FileType('r'),
                         help='Location of XML file with seL4 arch invocation definitions', required=True)
     parser.add_argument('--dest', type=argparse.FileType('w+'),


### PR DESCRIPTION
I got tired of seeing typos so I ran a spellchecker (`typos`) over the codebase and these are the spelling mistakes that it complained about (and were actually typos).

Is this necessary? Probably not...