### PR TITLE
Update links after seL4 website re-org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ In addition to our general [contribution guidelines][1], the kernel has addition
     + unless there is a concrete reason, if so please state that reason in the commit message.
 * Try to keep commits small for ease of reviewing.
 
-[1]: https://docs.sel4.systems/Contributing
+[1]: https://sel4.systems/Contribute
 
 ## Build/Test
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -24,8 +24,8 @@ of the kernel, and does *not* fall under the heading of "derived work".
 Syscall headers are provided under BSD.
 
 For a longer explanation of how the seL4 license does or does not affect
-your own code see also [this blog post][3].
+your own code see also [the seL4 website][3].
 
 [1]: https://spdx.org
 [2]: https://spdx.org/licenses/Linux-syscall-note.html
-[3]: https://microkerneldude.wordpress.com/2019/12/09/what-does-sel4s-license-imply/
+[3]: https://sel4.systems/Legal/license.html

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ This repository is usually not used in isolation, but as part of the build
 system in a larger project.
 
   [1]: http://sel4.systems/
-  [2]: https://docs.sel4.systems/projects/sel4/frequently-asked-questions
-  [3]: https://docs.sel4.systems/processes/contributing.html
+  [2]: https://sel4.systems/About/FAQ.html
+  [3]: https://sel4.systems/Contribute/
   [4]: https://zenodo.org/badge/DOI/10.5281/zenodo.591727.svg
   [5]: https://sel4.systems/Info/Docs/seL4-manual-latest.pdf
   [6]: https://docs.sel4.systems/Resources#setting-up-your-machine
@@ -45,7 +45,7 @@ seL4 Basics
 ---------------
 
 - [Tutorials](https://docs.sel4.systems/Tutorials)
-- [Documentation](https://docs.sel4.systems/projects/sel4/documentation)
+- [Documentation](https://sel4.systems/Learn/)
 - [seL4 libraries](https://docs.sel4.systems/projects/user_libs)
 - [seL4Test](https://docs.sel4.systems/projects/sel4test/)
 - [Debugging guide](https://docs.sel4.systems/projects/sel4-tutorials/debugging-guide)
@@ -62,9 +62,9 @@ Community
   - [seL4 Announce](https://lists.sel4.systems/postorius/lists/announce.sel4.systems)
   - [seL4 Devel](https://lists.sel4.systems/postorius/lists/devel.sel4.systems)
 
-See the [contact] links on the seL4 website for the full list.
+See also the [contact] links on the seL4 website.
 
-[contact]: https://sel4.systems/contact
+[contact]: https://sel4.systems/contact.html
 
 Reporting security vulnerabilities
 ----------------------------------
@@ -99,7 +99,7 @@ Status
 
 A list of releases and current project status can be found under [seL4 releases][7].
 
-- [Roadmap](https://docs.sel4.systems/projects/roadmap): new features in development
+- [Roadmap](https://sel4.systems/roadmap.html): new features in development
 - [Hardware Support](https://docs.sel4.systems/Hardware): information about hardware platform ports
 - [Kernel Features](https://docs.sel4.systems/projects/sel4/status): information about available
   kernel features


### PR DESCRIPTION
For most of these redirects are in place, but it is better to use the correct ones directly.

Also replaces the blog link with the (now) official licensing page that summarises it.
