### PR TITLE
Fix cmake regex to work with qemu version 10

### DIFF
--- a/src/plat/qemu-arm-virt/config.cmake
+++ b/src/plat/qemu-arm-virt/config.cmake
@@ -107,7 +107,7 @@ if(KernelPlatformQEMUArmVirt)
                 string(
                     REGEX
                         MATCH
-                        "[0-9](\\.[0-9])+"
+                        "[0-9]+(\\.[0-9]+)+"
                         QEMU_VERSION
                         "${QEMU_STDOUT_MESSAGE}"
                 )

--- a/src/plat/qemu-riscv-virt/config.cmake
+++ b/src/plat/qemu-riscv-virt/config.cmake
@@ -44,7 +44,7 @@ if(KernelPlatformQEMURiscVVirt)
                 string(
                     REGEX
                         MATCH
-                        "[0-9](\\.[0-9])+"
+                        "[0-9]+(\\.[0-9]+)+"
                         QEMU_VERSION
                         "${QEMU_STDOUT_MESSAGE}"
                 )


### PR DESCRIPTION
The build currently fails for arm / riscv using qemu version 10, because the cmake script incorrectly skips the first digit - so it thinks qemu 10.0.0 is actually version 0.0.0:

```
$ ../init-build.sh -DPLATFORM=qemu-arm-virt -DSIMULATION=TRUE  -DCMAKE_TOOLCHAIN_FILE=~/gnu-aarch64.cmake
loading initial cache file /Users/seph/3rdparty/sel4test/projects/sel4test/settings.cmake
-- ARM_CPU not set, defaulting to cortex-a53
-- Extracting device tree from QEMU
-- qemu found at qemu-system-aarch64
CMake Error at /Users/seph/3rdparty/sel4test/kernel/src/plat/qemu-arm-virt/config.cmake:116 (message):
  Error: need at least QEMU version 3.1.0, found '0.0.0'
```

See #1462 for more details.

This change to the version regex allows qemu version number fields to have multiple digits.

Fixes #1462.