### PR TITLE
arm,riscv: eliminate idle_thread function prologue

### DIFF
--- a/include/arch/arm/armv/armv7-a/armv/machine.h
+++ b/include/arch/arm/armv/armv7-a/armv/machine.h
@@ -8,12 +8,6 @@
 
 #include <util.h>
 
-/* See idle_thread for an explanation as to why FORCE_INLINE is required here. */
-static inline void FORCE_INLINE wfi(void)
-{
-    asm volatile("wfi" ::: "memory");
-}
-
 static inline void dsb(void)
 {
     asm volatile("dsb" ::: "memory");

--- a/include/arch/arm/armv/armv8-a/64/armv/machine.h
+++ b/include/arch/arm/armv/armv8-a/64/armv/machine.h
@@ -6,11 +6,6 @@
 
 #pragma once
 
-static inline void wfi(void)
-{
-    asm volatile("wfi" ::: "memory");
-}
-
 static inline void dsb(void)
 {
     asm volatile("dsb sy" ::: "memory");
@@ -42,4 +37,3 @@ static inline void isb(void)
 #define SYSTEM_READ_WORD(reg, v)  MRS(reg, v)
 #define SYSTEM_WRITE_64(reg, v)   MSR(reg, v)
 #define SYSTEM_READ_64(reg, v)    MRS(reg, v)
-

--- a/include/kernel/thread.h
+++ b/include/kernel/thread.h
@@ -165,7 +165,7 @@ void Arch_switchToIdleThread(void);
 void Arch_configureIdleThread(tcb_t *tcb);
 void Arch_activateIdleThread(tcb_t *tcb);
 
-void idle_thread(void);
+void NORETURN idle_thread(void);
 
 void configureIdleThread(tcb_t *tcb);
 void activateThread(void);
@@ -316,4 +316,3 @@ static inline void setThreadStateBlockedOnReply(tcb_t *tptr, reply_t *reply)
     scheduleTCB(tptr);
 }
 #endif
-

--- a/src/arch/arm/32/config.cmake
+++ b/src/arch/arm/32/config.cmake
@@ -9,16 +9,15 @@ cmake_minimum_required(VERSION 3.16.0)
 add_sources(
     DEP "KernelSel4ArchAarch32"
     PREFIX src/arch/arm/32
-    CFILES
-        object/objecttype.c
-        machine/capdl.c
-        machine/registerset.c
-        machine/fpu.c
-        machine/debug.c
-        model/statedata.c
-        c_traps.c
-        idle.c
-        kernel/thread.c
-        kernel/vspace.c
+    CFILES object/objecttype.c
+           machine/capdl.c
+           machine/registerset.c
+           machine/fpu.c
+           machine/debug.c
+           model/statedata.c
+           c_traps.c
+           idle.c
+           kernel/thread.c
+           kernel/vspace.c
     ASMFILES head.S traps.S hyp_traps.S idle.S
 )

--- a/src/arch/arm/32/config.cmake
+++ b/src/arch/arm/32/config.cmake
@@ -20,5 +20,5 @@ add_sources(
         idle.c
         kernel/thread.c
         kernel/vspace.c
-    ASMFILES head.S traps.S hyp_traps.S
+    ASMFILES head.S traps.S hyp_traps.S idle.S
 )

--- a/src/arch/arm/32/idle.S
+++ b/src/arch/arm/32/idle.S
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2025, UNSW
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#include <machine/assembler.h>
+
+.code 32
+.section .text, "ax"
+
+BEGIN_FUNC(idle_thread)
+    1: wfi
+    b 1b
+END_FUNC(idle_thread)

--- a/src/arch/arm/32/idle.c
+++ b/src/arch/arm/32/idle.c
@@ -8,23 +8,6 @@
 #include <mode/machine.h>
 #include <api/debug.h>
 
-/*
- * The idle thread currently does not receive a stack pointer and so we rely on
- * optimisations for correctness here. More specifically, we assume:
- *  - Ordinary prologue/epilogue stack operations are optimised out
- *  - All nested function calls are inlined
- * Note that GCC does not correctly implement optimisation annotations on nested
- * functions, so FORCE_INLINE is required on the wfi declaration in this case.
- * Note that Clang doesn't obey FORCE_O2 and relies on the kernel being compiled
- * with optimisations enabled.
- */
-void FORCE_O2 idle_thread(void)
-{
-    while (1) {
-        wfi();
-    }
-}
-
 /** DONT_TRANSLATE */
 void NORETURN NO_INLINE VISIBLE halt(void)
 {

--- a/src/arch/arm/64/config.cmake
+++ b/src/arch/arm/64/config.cmake
@@ -20,5 +20,5 @@ add_sources(
         idle.c
         kernel/thread.c
         kernel/vspace.c
-    ASMFILES head.S traps.S
+    ASMFILES head.S traps.S idle.S
 )

--- a/src/arch/arm/64/config.cmake
+++ b/src/arch/arm/64/config.cmake
@@ -9,16 +9,15 @@ cmake_minimum_required(VERSION 3.16.0)
 add_sources(
     DEP "KernelSel4ArchAarch64"
     PREFIX src/arch/arm/64
-    CFILES
-        object/objecttype.c
-        machine/capdl.c
-        machine/registerset.c
-        machine/fpu.c
-        machine/debug.c
-        model/statedata.c
-        c_traps.c
-        idle.c
-        kernel/thread.c
-        kernel/vspace.c
+    CFILES object/objecttype.c
+           machine/capdl.c
+           machine/registerset.c
+           machine/fpu.c
+           machine/debug.c
+           model/statedata.c
+           c_traps.c
+           idle.c
+           kernel/thread.c
+           kernel/vspace.c
     ASMFILES head.S traps.S idle.S
 )

--- a/src/arch/arm/64/idle.S
+++ b/src/arch/arm/64/idle.S
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2025, UNSW
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#include <machine/assembler.h>
+
+.section .text, "ax"
+
+BEGIN_FUNC(idle_thread)
+    1: wfi
+    b 1b
+END_FUNC(idle_thread)

--- a/src/arch/arm/64/idle.c
+++ b/src/arch/arm/64/idle.c
@@ -8,13 +8,6 @@
 #include <mode/machine.h>
 #include <api/debug.h>
 
-void idle_thread(void)
-{
-    while (1) {
-        wfi();
-    }
-}
-
 /** DONT_TRANSLATE */
 void NORETURN NO_INLINE VISIBLE halt(void)
 {

--- a/src/arch/riscv/config.cmake
+++ b/src/arch/riscv/config.cmake
@@ -122,7 +122,7 @@ add_sources(
         object/objecttype.c
         object/tcb.c
         smp/ipi.c
-    ASMFILES head.S traps.S
+    ASMFILES head.S traps.S idle.S
 )
 
 add_bf_source_old("KernelArchRiscV" "structures.bf" "include/arch/riscv" "arch/object")

--- a/src/arch/riscv/config.cmake
+++ b/src/arch/riscv/config.cmake
@@ -38,7 +38,9 @@ config_option(
 )
 
 config_option(
-    KernelRiscvUseClintMtime RISCV_USE_CLINT_MTIME "When reading the timestamp \
+    KernelRiscvUseClintMtime
+    RISCV_USE_CLINT_MTIME
+    "When reading the timestamp \
     from the hardware, directly access the CLINT timer register (mtime) instead \
     of using the rdtime instruction. This is a performance optimization, but \
     only for platforms where executing the rdtime instruction results in a \
@@ -58,19 +60,37 @@ config_option(
 # even when the platform has sutiable inline assembly, we do not make these the
 # default.
 if(KernelWordSize EQUAL 32)
-    set(KernelClz32 ON CACHE BOOL "")
-    set(KernelCtz32 ON CACHE BOOL "")
+    set(KernelClz32
+        ON
+        CACHE BOOL ""
+    )
+    set(KernelCtz32
+        ON
+        CACHE BOOL ""
+    )
     if(KernelIsMCS)
         # Used for long division in timer calculations.
-        set(KernelClz64 ON CACHE BOOL "")
+        set(KernelClz64
+            ON
+            CACHE BOOL ""
+        )
     endif()
 elseif(KernelWordSize EQUAL 64)
-    set(KernelClz64 ON CACHE BOOL "")
-    set(KernelCtz64 ON CACHE BOOL "")
+    set(KernelClz64
+        ON
+        CACHE BOOL ""
+    )
+    set(KernelCtz64
+        ON
+        CACHE BOOL ""
+    )
 endif()
 
 if(KernelSel4ArchRiscV32)
-    set(KernelPTLevels 2 CACHE STRING "" FORCE)
+    set(KernelPTLevels
+        2
+        CACHE STRING "" FORCE
+    )
 endif()
 if(KernelPTLevels EQUAL 2)
     if(KernelSel4ArchRiscV32)
@@ -99,29 +119,31 @@ if(KernelRiscvExtF)
 endif()
 
 # This is not supported on RISC-V
-set(KernelHardwareDebugAPIUnsupported ON CACHE INTERNAL "")
+set(KernelHardwareDebugAPIUnsupported
+    ON
+    CACHE INTERNAL ""
+)
 
 add_sources(
     DEP "KernelArchRiscV"
     PREFIX src/arch/riscv
-    CFILES
-        c_traps.c
-        idle.c
-        api/faults.c
-        api/benchmark.c
-        kernel/boot.c
-        kernel/thread.c
-        kernel/vspace.c
-        machine/capdl.c
-        machine/hardware.c
-        machine/registerset.c
-        machine/io.c
-        machine/fpu.c
-        model/statedata.c
-        object/interrupt.c
-        object/objecttype.c
-        object/tcb.c
-        smp/ipi.c
+    CFILES c_traps.c
+           idle.c
+           api/faults.c
+           api/benchmark.c
+           kernel/boot.c
+           kernel/thread.c
+           kernel/vspace.c
+           machine/capdl.c
+           machine/hardware.c
+           machine/registerset.c
+           machine/io.c
+           machine/fpu.c
+           model/statedata.c
+           object/interrupt.c
+           object/objecttype.c
+           object/tcb.c
+           smp/ipi.c
     ASMFILES head.S traps.S idle.S
 )
 

--- a/src/arch/riscv/idle.S
+++ b/src/arch/riscv/idle.S
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2025, UNSW
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#include <machine/assembler.h>
+
+.section .text, "ax"
+
+BEGIN_FUNC(idle_thread)
+    1: wfi
+    j 1b
+END_FUNC(idle_thread)

--- a/src/arch/riscv/idle.c
+++ b/src/arch/riscv/idle.c
@@ -8,13 +8,6 @@
 #include <config.h>
 #include <arch/sbi.h>
 
-void idle_thread(void)
-{
-    while (1) {
-        asm volatile("wfi");
-    }
-}
-
 /** DONT_TRANSLATE */
 void VISIBLE NO_INLINE halt(void)
 {

--- a/src/arch/x86/config.cmake
+++ b/src/arch/x86/config.cmake
@@ -419,7 +419,7 @@ add_sources(
            machine/registerset.c
            benchmark/benchmark.c
            smp/ipi.c
-    ASMFILES multiboot.S
+    ASMFILES multiboot.S idle.S
 )
 
 add_bf_source_old("KernelArchX86" "structures.bf" "include/arch/x86" "arch/object")

--- a/src/arch/x86/idle.S
+++ b/src/arch/x86/idle.S
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2025, UNSW
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#include <machine/assembler.h>
+
+.section .text, "ax"
+.code32
+
+BEGIN_FUNC(idle_thread)
+    1: hlt
+    jmp 1b
+END_FUNC(idle_thread)

--- a/src/arch/x86/idle.c
+++ b/src/arch/x86/idle.c
@@ -7,23 +7,6 @@
 #include <config.h>
 #include <api/debug.h>
 
-/*
- * The idle thread does not have a dedicated stack and runs in
- * the context of the idle thread TCB. Make sure that the compiler
- * always eliminates the function prologue by declaring the
- * idle_thread with the naked attribute.
- */
-__attribute__((naked)) NORETURN void idle_thread(void)
-{
-    /* We cannot use for-loop or while-loop here because they may
-     * involve stack manipulations (the compiler will not allow
-     * them in a naked function anyway). */
-    asm volatile(
-        "1: hlt\n"
-        "jmp 1b"
-    );
-}
-
 /** DONT_TRANSLATE */
 void VISIBLE halt(void)
 {


### PR DESCRIPTION
Create idle.S assembly files for each platform, as GCC seems to refuse
to obey `__attribute__((naked))` on AArch64 (GCC 13.2.0) and bails out;
so we can't use the same method as on x86.

Similar to #510 but for all other platforms. The idle_thread runs
without a stack and so cannot handle the stack prologue. This should
hopefully make the kernel rely less on FORCE_INLINE for this as well.

Fixes #519 

---

Before idle_thread (not identical compilers; from the microkit sdk)

```
board/maaxboard/release/elf/sel4.elf:   file format elf64-littleaarch64

Disassembly of section .text:

0000008040011250 <idle_thread>:
8040011250: d503207f    wfi
8040011254: 17ffffff    b       0x8040011250 <idle_thread>
8040011258: d503201f    nop
804001125c: d503201f    nop
```
```
board/maaxboard/debug/elf/sel4.elf:     file format elf64-littleaarch64

Disassembly of section .text:

00000080400113f0 <idle_thread>:
80400113f0: d503207f    wfi
80400113f4: 17ffffff    b       0x80400113f0 <idle_thread>
80400113f8: d503201f    nop
80400113fc: d503201f    nop
```
```
board/cheshire/debug/elf/sel4.elf:      file format elf64-littleriscv

Disassembly of section .text:

ffffffff80203b04 <idle_thread>:
ffffffff80203b04: 10500073      wfi
ffffffff80203b08: bff5  j       0xffffffff80203b04 <idle_thread>
```

After:

```
mmicrokit-sdk-2.0.1-dev/board/maaxboard/debug/elf/sel4.elf:      file format elf64-littleaarch64

Disassembly of section .text:

00000080400113e8 <idle_thread>:
80400113e8: d503207f    wfi
80400113ec: 17ffffff    b       0x80400113e8 <idle_thread>
```
```
microkit-sdk-2.0.1-dev/board/maaxboard/release/elf/sel4.elf:    file format elf64-littleaarch64

Disassembly of section .text:

000000804001125c <idle_thread>:
804001125c: d503207f    wfi
8040011260: 17ffffff    b       0x804001125c <idle_thread>
                ...
```
```
microkit-sdk-2.0.1-dev/board/cheshire/debug/elf/sel4.elf:       file format elf64-littleriscv

Disassembly of section .text:

ffffffff80203b04 <idle_thread>:
ffffffff80203b04: 10500073      wfi
ffffffff80203b08: bff5  j       0xffffffff80203b04 <idle_thread>
```
```
microkit-sdk-2.0.1-dev/board/cheshire/release/elf/sel4.elf:     file format elf64-littleriscv

Disassembly of section .text:

ffffffff80203a82 <idle_thread>:
ffffffff80203a82: 10500073      wfi
ffffffff80203a86: bff5  j       0xffffffff80203a82 <idle_thread>
```

There's negligible difference to the assembly (aside from the `nop` which I don't think should matter).


~~An issue that was brought up previously was that risc-v sets the stack pointer for the idle thread. I wasn't sure of the correctness of removing this because it seems to use the stack pointer in traps.S to determine the current core. (for SMP)~~ => Nevermind I forgot it loads from csscratch the sp so it should be fine to set it as 0 I think; I'll leave that for later.