### PR TITLE
Fix minimum CMake version in eswin config

### DIFF
--- a/src/plat/eswin/config.cmake
+++ b/src/plat/eswin/config.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.16.0)
 
 declare_platform(hifive-p550 KernelPlatformHifiveP550 PLAT_HIFIVE_P550 KernelArchRiscV)
 


### PR DESCRIPTION
I originally made the config before
6f2fe4626d827eb58e2fd954c2c16cefcb67fa61 so this patch gets rid of the warning for the eswin config.cmake.