### PR TITLE
cmake: clearly complain for invalid platforms

### DIFF
--- a/configs/seL4Config.cmake
+++ b/configs/seL4Config.cmake
@@ -199,9 +199,17 @@ foreach(file ${result})
     include("${file}")
 endforeach()
 
+config_choice(KernelPlatform PLAT "Select the platform" ${kernel_platforms})
+
 # Verify that, as a minimum any variables that are used
 # to find other build files are actually defined at this
-# point. This means at least: KernelArch KernelWordSize
+# point. This means at least: KernelPlatform KernelArch KernelWordSize
+
+if("${KernelPlatform}" STREQUAL "")
+    message(FATAL_ERROR "Variable 'KernelPlatform' is not set - is PLATFORM '${PLATFORM}' correct? \
+Valid platforms are '${KernelPlatform_all_strings}'"
+    )
+endif()
 
 if("${KernelArch}" STREQUAL "")
     message(FATAL_ERROR "Variable 'KernelArch' is not set.")
@@ -210,8 +218,6 @@ endif()
 if("${KernelWordSize}" STREQUAL "")
     message(FATAL_ERROR "Variable 'KernelWordSize' is not set.")
 endif()
-
-config_choice(KernelPlatform PLAT "Select the platform" ${kernel_platforms})
 
 # Now enshrine all the common variables in the config
 config_set(KernelArmCortexA7 ARM_CORTEX_A7 "${KernelArmCortexA7}")


### PR DESCRIPTION
Previously, this would error with a (confusing) warning since #546 about

    Variable 'KernelArch' is not set

sel4test/settings.cmake had some code which complained about an invalid platform, but it only ran if the kernel was found correctly:

    set(valid_platforms ${KernelPlatform_all_strings})
    set_property(CACHE PLATFORM PROPERTY STRINGS ${valid_platforms})
    if(NOT "${PLATFORM}" IN_LIST valid_platforms)
        message(FATAL_ERROR "Invalid PLATFORM selected: \"${PLATFORM}\"
    Valid platforms are: \"${valid_platforms}\"")
    endif()

Because of the CMake cache, if a correct platform was set, *then* an incorrect platform, you could see this error, as the KernelArch would be retained between builds in the cache. (Note: because of the cache, the error message within the kernel is not triggered if we go from a valid to an invalid platform. However the sel4test/settings.cmake one is).

- [ ] Do we want to fix this? Is the best way to copy the code in from sel4test/settings.cmake?

Previously:

- If no platform is specified:

	    sel4test/build$ ../init-build.sh
	    loading initial cache file sel4test/projects/sel4test/settings.cmake
	    -- Set platform details from PLATFORM=
	    --   KernelPlatform:
	    -- Found seL4: sel4test/kernel
	    CMake Error at sel4test/kernel/configs/seL4Config.cmake:185
	    Variable 'KernelArch' is not set.
	    Call Stack (most recent call first):
	    sel4test/kernel/FindseL4.cmake:21 (include)
	    settings.cmake:32 (sel4_configure_platform_settings)

- If an invalid platform is specified:

	    sel4test/build$ ../init-build.sh -DPLATFORM=Cheshire
	    loading initial cache file sel4test/projects/sel4test/settings.cmake
	    -- Set platform details from PLATFORM=Cheshire
	    --   KernelPlatform: Cheshire
	    -- Found seL4: sel4test/kernel
	    CMake Error at sel4test/kernel/configs/seL4Config.cmake:185
	    Variable 'KernelArch' is not set.
	    Call Stack (most recent call first):
	    sel4test/kernel/FindseL4.cmake:21 (include)
	    settings.cmake:32 (sel4_configure_platform_settings)

Now, it looks like:

- If no platform is specified:

	    sel4test/build$ ../init-build.sh
	    loading initial cache file sel4test/projects/sel4test/settings.cmake
	    -- Set platform details from PLATFORM=
	    --   KernelPlatform:
	    -- Found seL4: sel4test/kernel
	    CMake Error at sel4test/kernel/configs/seL4Config.cmake:180
	    Variable 'KernelPlatform' is not set - is PLATFORM '' correct? Valid
	    platforms are
	    'allwinnerA20;am335x;apq8064;ariane;bcm2711;bcm2837;cheshire;...'
	    Call Stack (most recent call first):
	    sel4test/kernel/FindseL4.cmake:21 (include)
	    settings.cmake:32 (sel4_configure_platform_settings)

- If an invalid platform is specified:

	    sel4test/build$ ../init-build.sh -DPLATFORM=Cheshire
	    loading initial cache file sel4test/projects/sel4test/settings.cmake
	    -- Set platform details from PLATFORM=Cheshire
	    --   KernelPlatform: Cheshire
	    -- Found seL4: sel4test/kernel
	    CMake Error at sel4test/kernel/configs/seL4Config.cmake:180
	    Variable 'KernelPlatform' is not set - is PLATFORM 'Cheshire'
	    correct? Valid platforms are 'allwinnerA20;am335x;apq8064;...'
	    Call Stack (most recent call first):
	    sel4test/kernel/FindseL4.cmake:21 (include)
	    settings.cmake:32 (sel4_configure_platform_settings)

- If a valid platform is specified:

	    sel4test/build$ ./init-build.sh -DPLATFORM=cheshire
	    loading initial cache file sel4test/projects/sel4test/settings.cmake
	    -- Set platform details from PLATFORM=cheshire
	    --   KernelPlatform: cheshire
	    -- Found seL4: sel4test/kernel
	    -- platform cheshire supports multiple architectures, none was given
	    --   defaulting to: riscv64
	    -- Found GCC with prefix riscv64-none-elf-