### PR TITLE
mcs: refactor finaliseCap to ease verification

### DIFF
--- a/include/object/schedcontext.h
+++ b/include/object/schedcontext.h
@@ -64,6 +64,10 @@ void schedContext_donate(sched_context_t *sc, tcb_t *to);
 void schedContext_bindNtfn(sched_context_t *sc, notification_t *ntfn);
 /* unbind scheduling context from a notification */
 void schedContext_unbindNtfn(sched_context_t *sc);
+/* unbind notification from a scheduling context */
+void schedContextMaybeUnbindNtfn(notification_t *ntfnPtr);
+/* unbind scheduling context from a reply */
+void schedContext_unbindReply(sched_context_t *sc);
 
 time_t schedContext_updateConsumed(sched_context_t *sc);
 void schedContext_completeYieldTo(tcb_t *yielder);

--- a/src/object/schedcontext.c
+++ b/src/object/schedcontext.c
@@ -143,10 +143,7 @@ static exception_t invokeSchedContext_Unbind(sched_context_t *sc)
 {
     schedContext_unbindAllTCBs(sc);
     schedContext_unbindNtfn(sc);
-    if (sc->scReply) {
-        sc->scReply->replyNext = call_stack_new(0, false);
-        sc->scReply = NULL;
-    }
+    schedContext_unbindReply(sc);
     return EXCEPTION_NONE;
 }
 
@@ -375,6 +372,25 @@ void schedContext_unbindNtfn(sched_context_t *sc)
     if (sc && sc->scNotification) {
         notification_ptr_set_ntfnSchedContext(sc->scNotification, SC_REF(0));
         sc->scNotification = NULL;
+    }
+}
+
+void schedContextMaybeUnbindNtfn(notification_t *ntfnPtr)
+{
+    sched_context_t *boundSchedContext;
+    boundSchedContext = (sched_context_t *)notification_ptr_get_ntfnSchedContext(ntfnPtr);
+
+    if (boundSchedContext) {
+        schedContext_unbindNtfn(boundSchedContext);
+    }
+}
+
+void schedContext_unbindReply(sched_context_t *sc)
+{
+    if (sc && sc->scReply) {
+        assert(call_stack_get_isHead(sc->scReply->replyNext));
+        sc->scReply->replyNext = call_stack_new(0, false);
+        sc->scReply = NULL;
     }
 }
 


### PR DESCRIPTION
This in particular introduces the function
schedContext_unbindReply, which is used within
finaliseCap, as well as invokeSchedContext_Unbind.