### PR TITLE
cleanup: use rootSlot to give a name to excapref0

### DIFF
--- a/src/object/untyped.c
+++ b/src/object/untyped.c
@@ -28,7 +28,7 @@ exception_t decodeUntypedInvocation(word_t invLabel, word_t length, cte_t *slot,
 {
     word_t newType, userObjSize, nodeIndex;
     word_t nodeDepth, nodeOffset, nodeWindow;
-    cte_t *rootSlot UNUSED;
+    cte_t *rootSlot;
     exception_t status;
     cap_t nodeCap;
     lookupSlot_ret_t lu_ret;
@@ -61,7 +61,6 @@ exception_t decodeUntypedInvocation(word_t invLabel, word_t length, cte_t *slot,
     nodeDepth   = getSyscallArg(3, buffer);
     nodeOffset  = getSyscallArg(4, buffer);
     nodeWindow  = getSyscallArg(5, buffer);
-
     rootSlot = current_extra_caps.excaprefs[0];
 
     /* Is the requested object type valid? */
@@ -112,9 +111,9 @@ exception_t decodeUntypedInvocation(word_t invLabel, word_t length, cte_t *slot,
 
     /* Lookup the destination CNode (where our caps will be placed in). */
     if (nodeDepth == 0) {
-        nodeCap = current_extra_caps.excaprefs[0]->cap;
+        nodeCap = rootSlot->cap;
     } else {
-        cap_t rootCap = current_extra_caps.excaprefs[0]->cap;
+        cap_t rootCap = rootSlot->cap;
         lu_ret = lookupTargetSlot(rootCap, nodeIndex, nodeDepth);
         if (lu_ret.status != EXCEPTION_NONE) {
             userError("Untyped Retype: Invalid destination address.");


### PR DESCRIPTION
Non-functional change. This will probably affect verification, so definitely not expecting this to be merged anytime soon.

But it was very weird we had this rootSlot argument mark as UNUSED, and it took me a bit to realise exactly what excaprefs[0] was supposed to be.