### PR TITLE
boot: use explicit atomics and memory ordering

### DIFF
--- a/src/arch/riscv/kernel/boot.c
+++ b/src/arch/riscv/kernel/boot.c
@@ -27,7 +27,7 @@
  * spinning until the primary core has initialized all kernel structures and
  * then set it to 1.
  */
-BOOT_BSS static volatile _Atomic word_t node_boot_lock;
+BOOT_BSS static word_t node_boot_lock;
 #endif
 
 BOOT_BSS static region_t res_reg[NUM_RESERVED_REGIONS];
@@ -153,15 +153,13 @@ BOOT_CODE static void init_plat(void)
 #ifdef ENABLE_SMP_SUPPORT
 BOOT_CODE static bool_t try_init_kernel_secondary_core(word_t hart_id, word_t core_id)
 {
-    while (!node_boot_lock);
-
-    fence_r_rw();
+    while (!__atomic_load_n(&node_boot_lock, __ATOMIC_SEQ_CST));
 
     init_cpu();
     NODE_LOCK_SYS;
 
     clock_sync_test();
-    ksNumCPUs++;
+    __atomic_fetch_add(&ksNumCPUs, 1, __ATOMIC_RELEASE);
     init_core_state(SchedulerAction_ResumeCurrentThread);
     ifence_local();
     return true;
@@ -169,21 +167,25 @@ BOOT_CODE static bool_t try_init_kernel_secondary_core(word_t hart_id, word_t co
 
 BOOT_CODE static void release_secondary_cores(void)
 {
-    assert(0 == node_boot_lock); /* Sanity check for a proper lock state. */
-    node_boot_lock = 1;
+    word_t locked = __atomic_exchange_n(&node_boot_lock, 1, __ATOMIC_SEQ_CST);
+    /* Sanity check for a proper lock state. */
+    assert(!locked);
     /* At this point in time the primary core (executing this code) already uses
      * the seL4 MMU/cache setup. However, the secondary cores are still using
      * the elfloader's MMU/cache setup, and thus the update of node_boot_lock
      * may not be visible there if the setups differ. Currently, the mappings
-     * match, so a barrier is all that is needed.
+     * match, and a atomic store-release is used to synchronize with secondary
+     * CPUs' load-acquire to publish all preceding memory writes.
      */
-    fence_rw_rw();
 
-    while (ksNumCPUs != CONFIG_MAX_NUM_NODES) {
+    /* The load-acquire on ksNumCPUs is paired with secondary cores' store-relese
+     * to ensure they've all finished initialization, and we (BSP) observes all
+     * side-effects.
+     */
+    while (__atomic_load_n(&ksNumCPUs, __ATOMIC_ACQUIRE) != CONFIG_MAX_NUM_NODES) {
 #ifdef ENABLE_SMP_CLOCK_SYNC_TEST_ON_BOOT
-        NODE_STATE(ksCurTime) = getCurrentTime();
+        __atomic_store_n(&NODE_STATE(ksCurTime), getCurrentTime(), __ATOMIC_RELAXED);
 #endif
-        __atomic_thread_fence(__ATOMIC_ACQ_REL);
     }
 }
 #endif /* ENABLE_SMP_SUPPORT */

--- a/src/arch/x86/kernel/smp_sys.c
+++ b/src/arch/x86/kernel/smp_sys.c
@@ -67,8 +67,7 @@ BOOT_CODE void start_boot_aps(void)
         /* wait for current AP to boot up */
         while (smp_aps_index == current_ap_index) {
 #ifdef ENABLE_SMP_CLOCK_SYNC_TEST_ON_BOOT
-            NODE_STATE(ksCurTime) = getCurrentTime();
-            __atomic_thread_fence(__ATOMIC_ACQ_REL);
+            __atomic_store_n(&NODE_STATE(ksCurTime), getCurrentTime(), __ATOMIC_RELAXED);
 #endif
         }
     }


### PR DESCRIPTION
Use __atomic_(...) with explicit memory order for clarity; Avoid using
volatile keyword and arch-dependent fences, and fix race-condition
around ksNumCPUs. Specifically:

a. node_boot_lock in arm/riscv is still atomic, but w/ explicit memory
   order for load/store. Per the C language spec, load/store, --/++,
   compound assignment on _Atomic variable use memory_order_seq_cst
   memory ordering. Thus, use equivalent and explicit memory order w/
   built-in atomic functions for clarity. Whether the memory ordering
   can be relaxed to acquire-release is left for future discussion.

b. ksNumCPUs in arm/riscv is now atomic to avoid race and have proper
   memory order specified. It's in reverse to node_boot_lock: BSP will
   wait and observe all APs coming out of initialization and all the
   side-effects. Note that APs do not rendezvous (although we can make
   them do). This is the same as before. The memory order chosen is
   acquire-release. Whether this is enough needs further reasoning, but
   it's at least much stricter than before, where we didn't have any
   memory ordering.

c. ksCurTime in all arch is now atomic w/ relaxed ordering in load/store
   This is because the read side in clock_sync_test is reading it purely
   for time check. There's no message passing or synchronization. Thus,
   given that C and all HW arch already provide coherence ordering for
   single atomic variable, it can be used with relaxed ordering. The
   previous use of acquire/release fences doesn't do anything, because,
   again, we are not synchronizing through ksCurTime + fence. I assume
   the original intent is to publish/grab the new values of ksCurTime
   as quickly as we can, but fence doesn't provide that functionality
   and actually we have no way of expediting the process.

Note:
1. For arm, the __atomic_thread_fence(__ATOMIC_ACQ_REL) at line 327 of
   src/arch/riscv/kernel/boot.c is kept as-is. After a discussion with
   Kurt Wu, this fence might accidentally provide more memory barriers
   than what the comment says. E.g., it lowers to a "dmb ish" on arm64
   with GCC 14.2. I'm leaving it there for further reasoning.

2. For x86, there's potential data race with smp_aps_index (volatile),
   and perhaps memory ordering issues. These issues could be masked by
   the fact the x86 has a very strict memory model. I leave the cleanup
   and reasoning of x86/boot code to future discussion and patches.

3. For riscv, GCC generates fences that also fence I/O. Refer to:
   "Use more conservative fences on RISC-V", Link:
   https://github.com/riscvarchive/riscv-gcc/pull/55
   Whether this is going to change (relaxed) in the future is unknown.
   Also this is a implementation (GCC) specific behavior. We should
   consider adding explicit I/O fences for correctness.

Signed-off-by: Bo Gan <ganboing@gmail.com>