### PR TITLE
github: point proof tests to Isabelle ts-2024

### DIFF
--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -45,6 +45,7 @@ jobs:
         L4V_FEATURES: ${{ matrix.features }}
         session: ${{ matrix.session }}
         manifest: ${{ matrix.features == 'MCS' && 'mcs.xml' || 'default.xml' }}
+        isa_branch: ts-2024
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
We're currently using AWS Arm VMs, and vanilla Isabelle2024 ships a Z3 version that does not work on Arm. Using the ts-2024 branch fixes this until we have upgraded everything to Isabelle2025.