### PR TITLE
github: main l4v now on Isabelle2025

### DIFF
--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -45,7 +45,7 @@ jobs:
         L4V_FEATURES: ${{ matrix.features }}
         session: ${{ matrix.session }}
         manifest: ${{ matrix.features == 'MCS' && 'mcs.xml' || 'default.xml' }}
-        isa_branch: ts-2024
+        isa_branch: ${{ matrix.features == 'MCS' && 'ts-2024' || 'ts-2025' }}
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
set `ts-2025` for master branch l4v and leave on `ts-2024` for MCS until MCS is updated to Isabelle2025 as well.