### PR TITLE
manual: markdown generation tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ manual/manual.pdf
 manual/stage
 manual/doxygen-output
 manual/generated
+manual/generated_markdown
 
 # Emacs backups
 *~

--- a/manual/tools/parse_doxygen_xml.py
+++ b/manual/tools/parse_doxygen_xml.py
@@ -7,7 +7,7 @@
 
 """
 Script for generating latex from doxygen-generated xml files.
-The generatetd latex files are compatible with the seL4 manual.
+The generated latex files are compatible with the seL4 manual.
 """
 import argparse
 import sys
@@ -585,7 +585,7 @@ def generate_general_syscall_doc(generator, input_file_name, level, ref_dict):
     """
     Takes a path to a file containing doxygen-generated xml,
     and return a string containing latex suitable for inclusion
-    in the sel4 manual.
+    in the seL4 manual.
     """
 
     dir_name = os.path.dirname(input_file_name)
@@ -612,7 +612,6 @@ def generate_general_syscall_doc(generator, input_file_name, level, ref_dict):
             return "No methods."
 
         for member in elements:
-            manual_node = member.manual
             details, params, errors, ret = generator.parse_detailed_desc(member, ref_dict)
             output += generator.generate_api_doc(level, member, params, ret, details, errors)
         return output

--- a/manual/tools/parse_doxygen_xml.py
+++ b/manual/tools/parse_doxygen_xml.py
@@ -503,9 +503,15 @@ Type | Name | Description
             """ % param_string
         return ""
 
+    def make_nbsp(self, string):
+        """Make all spaces non-breaking"""
+
+        # Use unicode non-breaking space. HTML &nbsp; is not valid in all Markdown flavours.
+        return string.replace(" ", "\u00a0")
+
     def generate_param_string(self, param_info, param_name):
         return "`%(type)s` | `%(name)s` | %(desc)s\n" % {
-            "type": self.get_text(param_info["type"], escape=False),
+            "type": self.make_nbsp(self.get_text(param_info["type"], escape=False)),
             "name": self.get_text(param_name, escape=False),
             "desc": self.todo_if_empty(param_info.get("desc", "").strip()),
         }

--- a/manual/tools/parse_doxygen_xml.py
+++ b/manual/tools/parse_doxygen_xml.py
@@ -350,12 +350,12 @@ class LatexGenerator(Generator):
         return "\\param{void}{}{}"
 
     def generate_errors(self, error_string):
-        """
+        r"""
         Wraps the errors in an \errortable
         """
 
         if error_string:
-            return "\errortable{%s}" % error_string
+            return "\\errortable{%s}" % error_string
         return ""
 
     def generate_error_string(self, error_info, error_name):
@@ -415,15 +415,15 @@ class MarkdownGenerator(Generator):
 
     # Dict mapping characters to their escape sequence in markdown
     ESCAPE_PATTERNS = {
-        "`": "\`",
-        "#": "\#",
-        "_": "\_",
-        "*": "\*",
-        "[": "\[",
-        "]": "\]",
-        "-": "\-",
-        "+": "\+",
-        "!": "\!",
+        "`": r"\`",
+        "#": r"\#",
+        "_": r"\_",
+        "*": r"\*",
+        "[": r"\[",
+        "]": r"\]",
+        "-": r"\-",
+        "+": r"\+",
+        "!": r"\!",
     }
 
     def get_parse_table(self):


### PR DESCRIPTION
- fix python string escape warnings
- minor python lints and typos
- use non-breaking space for types in markdown tables

The latter avoids breaking `seL4_Word *` into two lines in tables. Uses unicode `0u000A`, because `&nbsp;` does not always get rendered correctly and `0u000A` is just passed through.