### PR TITLE
boot: check for size_bits=0 before calculating BIT(size_bits)

### DIFF
--- a/include/kernel/boot.h
+++ b/include/kernel/boot.h
@@ -58,7 +58,7 @@ void create_domain_cap(cap_t root_cnode_cap);
 cap_t create_ipcbuf_frame_cap(cap_t root_cnode_cap, cap_t pd_cap, vptr_t vptr);
 word_t calculate_extra_bi_size_bits(word_t extra_size);
 void populate_bi_frame(node_id_t node_id, word_t num_nodes, vptr_t ipcbuf_vptr,
-                       word_t extra_bi_size_bits);
+                       word_t extra_bi_size);
 void create_bi_frame_cap(cap_t root_cnode_cap, cap_t pd_cap, vptr_t vptr);
 
 #ifdef CONFIG_KERNEL_MCS

--- a/src/arch/arm/kernel/boot.c
+++ b/src/arch/arm/kernel/boot.c
@@ -416,7 +416,7 @@ static BOOT_CODE bool_t try_init_kernel(
     word_t extra_bi_size_bits = calculate_extra_bi_size_bits(extra_bi_size);
     v_region_t it_v_reg = {
         .start = ui_v_reg.start,
-        .end   = extra_bi_frame_vptr + BIT(extra_bi_size_bits)
+        .end   = extra_bi_frame_vptr + (extra_bi_size_bits > 0 ? BIT(extra_bi_size_bits) : 0)
     };
     if (it_v_reg.end >= USER_TOP) {
         /* Variable arguments for printf() require well defined integer types to

--- a/src/arch/riscv/kernel/boot.c
+++ b/src/arch/riscv/kernel/boot.c
@@ -276,7 +276,7 @@ static BOOT_CODE bool_t try_init_kernel(
     word_t extra_bi_size_bits = calculate_extra_bi_size_bits(extra_bi_size);
     v_region_t it_v_reg = {
         .start = ui_v_reg.start,
-        .end   = extra_bi_frame_vptr + BIT(extra_bi_size_bits)
+        .end   = extra_bi_frame_vptr + (extra_bi_size_bits > 0 ? BIT(extra_bi_size_bits) : 0)
     };
     if (it_v_reg.end >= USER_TOP) {
         /* Variable arguments for printf() require well defined integer types

--- a/src/arch/x86/kernel/boot.c
+++ b/src/arch/x86/kernel/boot.c
@@ -142,7 +142,7 @@ BOOT_CODE bool_t init_sys_state(
 
     /* The region of the initial thread is the user image + ipcbuf and boot info */
     it_v_reg.start = ui_v_reg.start;
-    it_v_reg.end = ROUND_UP(extra_bi_frame_vptr + BIT(extra_bi_size_bits), PAGE_BITS);
+    it_v_reg.end = ROUND_UP(extra_bi_frame_vptr + (extra_bi_size_bits > 0 ? BIT(extra_bi_size_bits) : 0), PAGE_BITS);
 #ifdef CONFIG_IOMMU
     /* calculate the number of io pts before initialising memory */
     if (!vtd_init_num_iopts(num_drhu)) {
@@ -176,7 +176,7 @@ BOOT_CODE bool_t init_sys_state(
     populate_bi_frame(0, ksNumCPUs, ipcbuf_vptr, extra_bi_size);
     region_t extra_bi_region = {
         .start = rootserver.extra_bi,
-        .end = rootserver.extra_bi + BIT(extra_bi_size_bits)
+        .end = rootserver.extra_bi + (extra_bi_size_bits > 0 ? BIT(extra_bi_size_bits) : 0)
     };
 
     /* populate vbe info block */

--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -327,6 +327,15 @@ BOOT_CODE void create_bi_frame_cap(cap_t root_cnode_cap, cap_t pd_cap, vptr_t vp
     write_slot(SLOT_PTR(pptr_of_cap(root_cnode_cap), seL4_CapBootInfoFrame), cap);
 }
 
+/**
+ * the size_bits we return is 0 for extra_size = 0
+ * and if it is non-zero the bits are always >= seL4_PageBits
+ * this is relied on in a few places, and gives us code of the form
+ *
+ *     extra_bi_size_bits > 0 ? BIT(extra_bi_size_bits) : 0
+ *
+ * which handles the 0-size case.
+ */
 BOOT_CODE word_t calculate_extra_bi_size_bits(word_t extra_size)
 {
     if (extra_size == 0) {


### PR DESCRIPTION
This would previously create regions that were off-by-1 on the upper end with addresses such as 0x40001. This seems to have been fine, and just created an extra unnecessary memory region covering the extra bootinfo memory. But at the same time this was inconsistent with e.g. calculate_rootserver_size() which contained the check:

  size += extra_bi_size_bits > 0 ? BIT(extra_bi_size_bits) : 0;

and this created issues when I was experimenting with some boot code changes as the bootinfo size accounting was inconsistent.