### PR TITLE
manual: gracefully handle dangling references

### DIFF
--- a/manual/tools/parse_doxygen_xml.py
+++ b/manual/tools/parse_doxygen_xml.py
@@ -96,10 +96,11 @@ class Generator(object):
         return ""
 
     def ref_to_format(self, para, ref_dict):
-        """Convert a reference by id to a latex command by looking up refid in para"""
-        if len(ref_dict) > 0:
+        """Format a reference by id by looking up refid in para. Return escaped content if not found."""
+        try:
             return self.ref_format(para["refid"], ref_dict)
-        return ""
+        except KeyError:
+            return self.text_escape(para.contents[0])
 
     def nref_to_format(self, para, ref_dict):
         """Convert a reference by name to a latex command by looking up refid in para"""


### PR DESCRIPTION
Recent doxygen versions generate references for constants that are named in the text. Since we do not produce a constant table in the manual (neither markdown nor tex), these references point to nowhere and produce a KeyError in the ref_dict on lookup.

The corresponding xml nodes are of this form:
```
<ref kindref="member" refid="include_2sel4_2constants_8h_1a9a3...">seL4_TCBFlag</ref>
```
Ignore such dangling references and return the content (seL4_TCBFlag in the example) instead. Run text escape on the content to cover underscores etc in LaTeX.

Does not produce a warning since we expect this to be normal behaviour.