### PR TITLE
aarch64,vspace: move PUD/PGD typedefs to deprecated code

### DIFF
--- a/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/deprecated.h
+++ b/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/deprecated.h
@@ -28,6 +28,10 @@
 #define seL4_PUDBits 13
 #define seL4_PUDIndexBits 10
 #define seL4_ARM_PageUpperDirectoryObject seL4_ARM_VSpaceObject
+#define seL4_ARM_PageUpperDirectory seL4_ARM_VSpace
+
+/* this was previously defined always, so keep that here for consistency */
+#define seL4_ARM_PageGlobalDirectory seL4_CPtr
 
 #else
 
@@ -38,6 +42,7 @@
 #define seL4_PUDBits 12
 #define seL4_PUDIndexBits 9
 #define seL4_ARM_PageGlobalDirectoryObject seL4_ARM_VSpaceObject
+#define seL4_ARM_PageGlobalDirectory seL4_ARM_VSpace
 #define seL4_ARM_PageUpperDirectoryObject seL4_ARM_PageTableObject
 #define seL4_ARM_PageUpperDirectory seL4_ARM_PageTable;
 #define seL4_ARM_PageUpperDirectory_Map seL4_ARM_PageTable_Map

--- a/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/types.h
+++ b/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/types.h
@@ -8,10 +8,6 @@
 
 #include <sel4/simple_types.h>
 
-typedef seL4_CPtr seL4_ARM_PageUpperDirectory;
-typedef seL4_CPtr seL4_ARM_PageGlobalDirectory;
-/* whether the VSpace refers to a PageUpperDirectory or PageGlobalDirectory directly
- * depends on the physical address size */
 typedef seL4_CPtr seL4_ARM_VSpace;
 
 typedef struct seL4_UserContext_ {


### PR DESCRIPTION
This was missed in cb8ee83f0cd2268b1d6b1cd5ca30b031db5896c4; their use was removed from syscall_stub_gen but their typedefs remained.

Fixes #1498.