### PR TITLE
thread_ctrl: Remove unused flags

### DIFF
--- a/include/object/tcb.h
+++ b/include/object/tcb.h
@@ -220,11 +220,6 @@ enum thread_control_flag {
     thread_control_update_ipc_buffer = 0x2,
     thread_control_update_space = 0x4,
     thread_control_update_mcp = 0x8,
-#ifdef CONFIG_KERNEL_MCS
-    thread_control_update_sc = 0x10,
-    thread_control_update_fault = 0x20,
-    thread_control_update_timeout = 0x40,
-#endif
 };
 #endif
 


### PR DESCRIPTION
This is seemingly dead code leftover from: https://github.com/seL4/seL4/commit/c428f320b76dd271206711e6f6203d06f7b2c289.