### PR TITLE
asidpools: macro consistency

### DIFF
--- a/include/arch/arm/arch/32/mode/model/statedata.h
+++ b/include/arch/arm/arch/32/mode/model/statedata.h
@@ -12,7 +12,7 @@
 #include <util.h>
 #include <object/structures.h>
 
-extern asid_pool_t *armKSASIDTable[BIT(asidHighBits)] VISIBLE;
+extern asid_pool_t *armKSASIDTable[nASIDPools] VISIBLE;
 extern asid_t armKSHWASIDTable[BIT(hwASIDBits)] VISIBLE;
 extern hw_asid_t armKSNextASID VISIBLE;
 

--- a/include/arch/arm/arch/32/mode/object/structures.h
+++ b/include/arch/arm/arch/32/mode/object/structures.h
@@ -104,14 +104,13 @@ typedef struct asid_pool asid_pool_t;
 #define nASIDPools BIT(asidHighBits)
 
 #define ASID_LOW(a) (a & MASK(asidLowBits))
-#define ASID_HIGH(a) ((a >> asidLowBits) & MASK(asidHighBits))
+#define ASID_HIGH(a) ((a) >> asidLowBits)
 
 static inline cap_t CONST cap_small_frame_cap_set_capFMappedASID(cap_t cap, word_t asid)
 {
     cap = cap_small_frame_cap_set_capFMappedASIDLow(cap,
                                                     asid & MASK(asidLowBits));
-    return cap_small_frame_cap_set_capFMappedASIDHigh(cap,
-                                                      (asid >> asidLowBits) & MASK(asidHighBits));
+    return cap_small_frame_cap_set_capFMappedASIDHigh(cap, ASID_HIGH(asid));
 }
 
 static inline word_t CONST cap_small_frame_cap_get_capFMappedASID(cap_t cap)
@@ -124,8 +123,7 @@ static inline cap_t CONST cap_frame_cap_set_capFMappedASID(cap_t cap, word_t asi
 {
     cap = cap_frame_cap_set_capFMappedASIDLow(cap,
                                               asid & MASK(asidLowBits));
-    return cap_frame_cap_set_capFMappedASIDHigh(cap,
-                                                (asid >> asidLowBits) & MASK(asidHighBits));
+    return cap_frame_cap_set_capFMappedASIDHigh(cap, ASID_HIGH(asid));
 }
 
 static inline word_t CONST cap_frame_cap_get_capFMappedASID(cap_t cap)
@@ -432,3 +430,4 @@ static inline word_t PURE pte_ptr_get_pteType(pte_t *pte_ptr)
     }
 }
 #endif /* CONFIG_ARM_HYPERVISOR_SUPPORT */
+

--- a/include/arch/arm/arch/32/mode/object/structures.h
+++ b/include/arch/arm/arch/32/mode/object/structures.h
@@ -99,7 +99,6 @@ typedef struct asid_pool asid_pool_t;
 
 #define HW_ASID_SIZE_BITS 1
 
-#define ASID_POOL_INDEX_BITS seL4_ASIDPoolIndexBits
 #define ASID_BITS (asidHighBits+asidLowBits)
 
 #define nASIDPools BIT(asidHighBits)
@@ -433,4 +432,3 @@ static inline word_t PURE pte_ptr_get_pteType(pte_t *pte_ptr)
     }
 }
 #endif /* CONFIG_ARM_HYPERVISOR_SUPPORT */
-

--- a/include/arch/arm/arch/32/mode/object/structures.h
+++ b/include/arch/arm/arch/32/mode/object/structures.h
@@ -103,13 +103,12 @@ typedef struct asid_pool asid_pool_t;
 
 #define nASIDPools BIT(asidHighBits)
 
-#define ASID_LOW(a) (a & MASK(asidLowBits))
+#define ASID_LOW(a) ((a) & MASK(asidLowBits))
 #define ASID_HIGH(a) ((a) >> asidLowBits)
 
 static inline cap_t CONST cap_small_frame_cap_set_capFMappedASID(cap_t cap, word_t asid)
 {
-    cap = cap_small_frame_cap_set_capFMappedASIDLow(cap,
-                                                    asid & MASK(asidLowBits));
+    cap = cap_small_frame_cap_set_capFMappedASIDLow(cap, ASID_LOW(asid));
     return cap_small_frame_cap_set_capFMappedASIDHigh(cap, ASID_HIGH(asid));
 }
 
@@ -121,8 +120,7 @@ static inline word_t CONST cap_small_frame_cap_get_capFMappedASID(cap_t cap)
 
 static inline cap_t CONST cap_frame_cap_set_capFMappedASID(cap_t cap, word_t asid)
 {
-    cap = cap_frame_cap_set_capFMappedASIDLow(cap,
-                                              asid & MASK(asidLowBits));
+    cap = cap_frame_cap_set_capFMappedASIDLow(cap, ASID_LOW(asid));
     return cap_frame_cap_set_capFMappedASIDHigh(cap, ASID_HIGH(asid));
 }
 

--- a/include/arch/arm/arch/64/mode/kernel/vspace.h
+++ b/include/arch/arm/arch/64/mode/kernel/vspace.h
@@ -57,7 +57,7 @@ static inline exception_t performASIDPoolInvocation(asid_t asid, asid_pool_t *po
     cap = cap_vspace_cap_set_capVSIsMapped(cap, 1);
     vspaceCapSlot->cap = cap;
 
-    poolPtr->array[asid & MASK(asidLowBits)] = asid_map;
+    poolPtr->array[ASID_LOW(asid)] = asid_map;
     return EXCEPTION_NONE;
 }
 

--- a/include/arch/arm/arch/64/mode/model/statedata.h
+++ b/include/arch/arm/arch/64/mode/model/statedata.h
@@ -21,7 +21,7 @@
 #endif
 
 /* The top level asid mapping table */
-extern asid_pool_t *armKSASIDTable[BIT(asidHighBits)] VISIBLE;
+extern asid_pool_t *armKSASIDTable[nASIDPools] VISIBLE;
 
 /* This is the temporary userspace page table in kernel. It is required before running
  * user thread to avoid speculative page table walking with the wrong page table. */

--- a/include/arch/arm/arch/64/mode/object/structures.h
+++ b/include/arch/arm/arch/64/mode/object/structures.h
@@ -77,7 +77,7 @@ typedef pte_t pde_t;
 #define nASIDs     BIT(ASID_BITS)
 #define nASIDPools BIT(asidHighBits)
 
-#define ASID_LOW(a) (a & MASK(asidLowBits))
+#define ASID_LOW(a) ((a) & MASK(asidLowBits))
 #define ASID_HIGH(a) ((a) >> asidLowBits)
 
 static inline word_t CONST cap_get_archCapSizeBits(cap_t cap)

--- a/include/arch/arm/arch/64/mode/object/structures.h
+++ b/include/arch/arm/arch/64/mode/object/structures.h
@@ -73,7 +73,6 @@ typedef pte_t pde_t;
 #define ASID_POOL_REF(p)    ((word_t)p)
 
 
-#define ASID_POOL_INDEX_BITS seL4_ASIDPoolIndexBits
 #define ASID_BITS (asidHighBits+asidLowBits)
 #define nASIDs     BIT(ASID_BITS)
 #define nASIDPools BIT(asidHighBits)

--- a/include/arch/arm/arch/64/mode/object/structures.h
+++ b/include/arch/arm/arch/64/mode/object/structures.h
@@ -78,7 +78,7 @@ typedef pte_t pde_t;
 #define nASIDPools BIT(asidHighBits)
 
 #define ASID_LOW(a) (a & MASK(asidLowBits))
-#define ASID_HIGH(a) ((a >> asidLowBits) & MASK(asidHighBits))
+#define ASID_HIGH(a) ((a) >> asidLowBits)
 
 static inline word_t CONST cap_get_archCapSizeBits(cap_t cap)
 {

--- a/include/arch/riscv/arch/model/statedata.h
+++ b/include/arch/riscv/arch/model/statedata.h
@@ -22,7 +22,7 @@ NODE_STATE_BEGIN(archNodeState)
 NODE_STATE_DECLARE(word_t, ipiReschedulePending);
 NODE_STATE_END(archNodeState);
 
-extern asid_pool_t *riscvKSASIDTable[BIT(asidHighBits)];
+extern asid_pool_t *riscvKSASIDTable[nASIDPools];
 
 /* Kernel Page Tables */
 extern pte_t kernel_root_pageTable[BIT(PT_INDEX_BITS)] VISIBLE;

--- a/include/arch/riscv/arch/object/structures.h
+++ b/include/arch/riscv/arch/object/structures.h
@@ -31,7 +31,7 @@ typedef struct asid_pool asid_pool_t;
 #define ASID_BITS           (asidHighBits + asidLowBits)
 #define nASIDPools          BIT(asidHighBits)
 #define ASID_LOW(a)         (a & MASK(asidLowBits))
-#define ASID_HIGH(a)        ((a >> asidLowBits) & MASK(asidHighBits))
+#define ASID_HIGH(a)        ((a) >> asidLowBits)
 
 typedef struct arch_tcb {
     user_context_t tcbContext;

--- a/include/arch/riscv/arch/object/structures.h
+++ b/include/arch/riscv/arch/object/structures.h
@@ -30,7 +30,7 @@ typedef struct asid_pool asid_pool_t;
 #define ASID_POOL_REF(p)    ((word_t)p)
 #define ASID_BITS           (asidHighBits + asidLowBits)
 #define nASIDPools          BIT(asidHighBits)
-#define ASID_LOW(a)         (a & MASK(asidLowBits))
+#define ASID_LOW(a)         ((a) & MASK(asidLowBits))
 #define ASID_HIGH(a)        ((a) >> asidLowBits)
 
 typedef struct arch_tcb {

--- a/include/arch/x86/arch/32/mode/object/structures.h
+++ b/include/arch/x86/arch/32/mode/object/structures.h
@@ -51,7 +51,6 @@ struct asid_pool {
 
 typedef struct asid_pool asid_pool_t;
 
-#define ASID_POOL_INDEX_BITS    seL4_ASIDPoolIndexBits
 #define ASID_POOL_PTR(r)    ((asid_pool_t*)r)
 #define ASID_POOL_REF(p)    ((word_t)p)
 #define ASID_BITS           (asidHighBits + asidLowBits)
@@ -116,4 +115,3 @@ static inline void *CONST cap_get_modeCapPtr(cap_t cap)
 {
     fail("Invalid mode cap type");
 }
-

--- a/include/arch/x86/arch/32/mode/object/structures.h
+++ b/include/arch/x86/arch/32/mode/object/structures.h
@@ -56,7 +56,7 @@ typedef struct asid_pool asid_pool_t;
 #define ASID_BITS           (asidHighBits + asidLowBits)
 #define nASIDPools          BIT(asidHighBits)
 #define ASID_LOW(a)         (a & MASK(asidLowBits))
-#define ASID_HIGH(a)        ((a >> asidLowBits) & MASK(asidHighBits))
+#define ASID_HIGH(a)        ((a) >> asidLowBits)
 
 static inline asid_t CONST cap_frame_cap_get_capFMappedASID(cap_t cap)
 {
@@ -115,3 +115,4 @@ static inline void *CONST cap_get_modeCapPtr(cap_t cap)
 {
     fail("Invalid mode cap type");
 }
+

--- a/include/arch/x86/arch/32/mode/object/structures.h
+++ b/include/arch/x86/arch/32/mode/object/structures.h
@@ -55,7 +55,7 @@ typedef struct asid_pool asid_pool_t;
 #define ASID_POOL_REF(p)    ((word_t)p)
 #define ASID_BITS           (asidHighBits + asidLowBits)
 #define nASIDPools          BIT(asidHighBits)
-#define ASID_LOW(a)         (a & MASK(asidLowBits))
+#define ASID_LOW(a)         ((a) & MASK(asidLowBits))
 #define ASID_HIGH(a)        ((a) >> asidLowBits)
 
 static inline asid_t CONST cap_frame_cap_get_capFMappedASID(cap_t cap)

--- a/include/arch/x86/arch/64/mode/object/structures.h
+++ b/include/arch/x86/arch/64/mode/object/structures.h
@@ -107,7 +107,7 @@ typedef struct asid_pool asid_pool_t;
 #define ASID_BITS           (asidHighBits + asidLowBits)
 #define nASIDPools          BIT(asidHighBits)
 #define ASID_LOW(a)         (a & MASK(asidLowBits))
-#define ASID_HIGH(a)        ((a >> asidLowBits) & MASK(asidHighBits))
+#define ASID_HIGH(a)        ((a) >> asidLowBits)
 
 static inline asid_t PURE cap_get_capMappedASID(cap_t cap)
 {
@@ -190,3 +190,4 @@ static inline void *CONST cap_get_modeCapPtr(cap_t cap)
         return NULL;
     }
 }
+

--- a/include/arch/x86/arch/64/mode/object/structures.h
+++ b/include/arch/x86/arch/64/mode/object/structures.h
@@ -102,8 +102,6 @@ struct asid_pool {
 
 typedef struct asid_pool asid_pool_t;
 
-#define ASID_POOL_INDEX_BITS  seL4_ASIDPoolIndexBits
-#define ASID_POOL_SIZE_BITS (seL4_ASIDPoolBits + WORD_SIZE_BITS)
 #define ASID_POOL_PTR(r)    ((asid_pool_t*)r)
 #define ASID_POOL_REF(p)    ((word_t)p)
 #define ASID_BITS           (asidHighBits + asidLowBits)
@@ -192,4 +190,3 @@ static inline void *CONST cap_get_modeCapPtr(cap_t cap)
         return NULL;
     }
 }
-

--- a/include/arch/x86/arch/64/mode/object/structures.h
+++ b/include/arch/x86/arch/64/mode/object/structures.h
@@ -106,7 +106,7 @@ typedef struct asid_pool asid_pool_t;
 #define ASID_POOL_REF(p)    ((word_t)p)
 #define ASID_BITS           (asidHighBits + asidLowBits)
 #define nASIDPools          BIT(asidHighBits)
-#define ASID_LOW(a)         (a & MASK(asidLowBits))
+#define ASID_LOW(a)         ((a) & MASK(asidLowBits))
 #define ASID_HIGH(a)        ((a) >> asidLowBits)
 
 static inline asid_t PURE cap_get_capMappedASID(cap_t cap)

--- a/src/arch/arm/32/kernel/vspace.c
+++ b/src/arch/arm/32/kernel/vspace.c
@@ -612,7 +612,7 @@ findPDForASID_ret_t findPDForASID(asid_t asid)
         return ret;
     }
 
-    pd = poolPtr->array[asid & MASK(asidLowBits)];
+    pd = poolPtr->array[ASID_LOW(asid)];
     if (unlikely(!pd)) {
         current_lookup_fault = lookup_fault_invalid_root_new();
 
@@ -1078,7 +1078,7 @@ static void invalidateASID(asid_t asid)
     asidPool = armKSASIDTable[ASID_HIGH(asid)];
     assert(asidPool);
 
-    pd = asidPool->array[asid & MASK(asidLowBits)];
+    pd = asidPool->array[ASID_LOW(asid)];
     assert(pd);
 
     pd[PD_ASID_SLOT] = pde_pde_invalid_new(0, false);
@@ -1092,7 +1092,7 @@ static pde_t PURE loadHWASID(asid_t asid)
     asidPool = armKSASIDTable[ASID_HIGH(asid)];
     assert(asidPool);
 
-    pd = asidPool->array[asid & MASK(asidLowBits)];
+    pd = asidPool->array[ASID_LOW(asid)];
     assert(pd);
 
     return pd[PD_ASID_SLOT];
@@ -1106,7 +1106,7 @@ static void storeHWASID(asid_t asid, hw_asid_t hw_asid)
     asidPool = armKSASIDTable[ASID_HIGH(asid)];
     assert(asidPool);
 
-    pd = asidPool->array[asid & MASK(asidLowBits)];
+    pd = asidPool->array[ASID_LOW(asid)];
     assert(pd);
 
     /* Store HW ASID in the last entry
@@ -1300,10 +1300,10 @@ void deleteASID(asid_t asid, pde_t *pd)
 
     poolPtr = armKSASIDTable[ASID_HIGH(asid)];
 
-    if (poolPtr != NULL && poolPtr->array[asid & MASK(asidLowBits)] == pd) {
+    if (poolPtr != NULL && poolPtr->array[ASID_LOW(asid)] == pd) {
         flushSpace(asid);
         invalidateASIDEntry(asid);
-        poolPtr->array[asid & MASK(asidLowBits)] = NULL;
+        poolPtr->array[ASID_LOW(asid)] = NULL;
         setVMRoot(NODE_STATE(ksCurThread));
     }
 }
@@ -1969,7 +1969,7 @@ static exception_t performASIDPoolInvocation(asid_t asid, asid_pool_t *poolPtr,
 {
     cap_page_directory_cap_ptr_set_capPDMappedASID(&pdCapSlot->cap, asid);
     cap_page_directory_cap_ptr_set_capPDIsMapped(&pdCapSlot->cap, 1);
-    poolPtr->array[asid & MASK(asidLowBits)] =
+    poolPtr->array[ASID_LOW(asid)] =
         PDE_PTR(cap_page_directory_cap_get_capPDBasePtr(pdCapSlot->cap));
 
     return EXCEPTION_NONE;

--- a/src/arch/arm/32/kernel/vspace.c
+++ b/src/arch/arm/32/kernel/vspace.c
@@ -591,7 +591,7 @@ BOOT_CODE void activate_kernel_vspace(void)
 BOOT_CODE void write_it_asid_pool(cap_t it_ap_cap, cap_t it_pd_cap)
 {
     asid_pool_t *ap = ASID_POOL_PTR(pptr_of_cap(it_ap_cap));
-    ap->array[IT_ASID] = PDE_PTR(pptr_of_cap(it_pd_cap));
+    ap->array[ASID_LOW(IT_ASID)] = PDE_PTR(pptr_of_cap(it_pd_cap));
     armKSASIDTable[ASID_HIGH(IT_ASID)] = ap;
 }
 

--- a/src/arch/arm/32/kernel/vspace.c
+++ b/src/arch/arm/32/kernel/vspace.c
@@ -592,7 +592,7 @@ BOOT_CODE void write_it_asid_pool(cap_t it_ap_cap, cap_t it_pd_cap)
 {
     asid_pool_t *ap = ASID_POOL_PTR(pptr_of_cap(it_ap_cap));
     ap->array[IT_ASID] = PDE_PTR(pptr_of_cap(it_pd_cap));
-    armKSASIDTable[IT_ASID >> asidLowBits] = ap;
+    armKSASIDTable[ASID_HIGH(IT_ASID)] = ap;
 }
 
 /* ==================== BOOT CODE FINISHES HERE ==================== */
@@ -603,7 +603,7 @@ findPDForASID_ret_t findPDForASID(asid_t asid)
     asid_pool_t *poolPtr;
     pde_t *pd;
 
-    poolPtr = armKSASIDTable[asid >> asidLowBits];
+    poolPtr = armKSASIDTable[ASID_HIGH(asid)];
     if (unlikely(!poolPtr)) {
         current_lookup_fault = lookup_fault_invalid_root_new();
 
@@ -1075,7 +1075,7 @@ static void invalidateASID(asid_t asid)
     asid_pool_t *asidPool;
     pde_t *pd;
 
-    asidPool = armKSASIDTable[asid >> asidLowBits];
+    asidPool = armKSASIDTable[ASID_HIGH(asid)];
     assert(asidPool);
 
     pd = asidPool->array[asid & MASK(asidLowBits)];
@@ -1089,7 +1089,7 @@ static pde_t PURE loadHWASID(asid_t asid)
     asid_pool_t *asidPool;
     pde_t *pd;
 
-    asidPool = armKSASIDTable[asid >> asidLowBits];
+    asidPool = armKSASIDTable[ASID_HIGH(asid)];
     assert(asidPool);
 
     pd = asidPool->array[asid & MASK(asidLowBits)];
@@ -1103,7 +1103,7 @@ static void storeHWASID(asid_t asid, hw_asid_t hw_asid)
     asid_pool_t *asidPool;
     pde_t *pd;
 
-    asidPool = armKSASIDTable[asid >> asidLowBits];
+    asidPool = armKSASIDTable[ASID_HIGH(asid)];
     assert(asidPool);
 
     pd = asidPool->array[asid & MASK(asidLowBits)];
@@ -1282,14 +1282,14 @@ void deleteASIDPool(asid_t asid_base, asid_pool_t *pool)
     /* Haskell error: "ASID pool's base must be aligned" */
     assert((asid_base & MASK(asidLowBits)) == 0);
 
-    if (armKSASIDTable[asid_base >> asidLowBits] == pool) {
+    if (armKSASIDTable[ASID_HIGH(asid_base)] == pool) {
         for (offset = 0; offset < BIT(asidLowBits); offset++) {
             if (pool->array[offset]) {
                 flushSpace(asid_base + offset);
                 invalidateASIDEntry(asid_base + offset);
             }
         }
-        armKSASIDTable[asid_base >> asidLowBits] = NULL;
+        armKSASIDTable[ASID_HIGH(asid_base)] = NULL;
         setVMRoot(NODE_STATE(ksCurThread));
     }
 }
@@ -1298,7 +1298,7 @@ void deleteASID(asid_t asid, pde_t *pd)
 {
     asid_pool_t *poolPtr;
 
-    poolPtr = armKSASIDTable[asid >> asidLowBits];
+    poolPtr = armKSASIDTable[ASID_HIGH(asid)];
 
     if (poolPtr != NULL && poolPtr->array[asid & MASK(asidLowBits)] == pd) {
         flushSpace(asid);
@@ -1991,7 +1991,7 @@ static exception_t performASIDControlInvocation(void *frame, cte_t *slot,
               parent, slot);;
     /* Haskell error: "ASID pool's base must be aligned" */
     assert((asid_base & MASK(asidLowBits)) == 0);
-    armKSASIDTable[asid_base >> asidLowBits] = (asid_pool_t *)frame;
+    armKSASIDTable[ASID_HIGH(asid_base)] = (asid_pool_t *)frame;
 
     return EXCEPTION_NONE;
 }
@@ -2626,8 +2626,7 @@ exception_t decodeARMMMUInvocation(word_t invLabel, word_t length, cptr_t cptr,
             return EXCEPTION_SYSCALL_ERROR;
         }
 
-        pool = armKSASIDTable[cap_asid_pool_cap_get_capASIDBase(cap) >>
-                                                                     asidLowBits];
+        pool = armKSASIDTable[ASID_HIGH(cap_asid_pool_cap_get_capASIDBase(cap))];
         if (unlikely(!pool)) {
             userError("ASIDPoolAssign: Failed to lookup pool.");
             current_syscall_error.type = seL4_FailedLookup;

--- a/src/arch/arm/32/model/statedata.c
+++ b/src/arch/arm/32/model/statedata.c
@@ -15,7 +15,7 @@
 #include <plat/machine/hardware.h>
 
 /* The top level asid mapping table */
-asid_pool_t *armKSASIDTable[BIT(asidHighBits)];
+asid_pool_t *armKSASIDTable[nASIDPools];
 
 /* The hardware ASID to virtual ASID mapping table */
 asid_t armKSHWASIDTable[BIT(hwASIDBits)];

--- a/src/arch/arm/64/kernel/vspace.c
+++ b/src/arch/arm/64/kernel/vspace.c
@@ -567,7 +567,7 @@ BOOT_CODE void write_it_asid_pool(cap_t it_ap_cap, cap_t it_vspace_cap)
                               , 0, false
 #endif
                           );
-    ap->array[IT_ASID] = asid_map;
+    ap->array[ASID_LOW(IT_ASID)] = asid_map;
     armKSASIDTable[ASID_HIGH(IT_ASID)] = ap;
 }
 

--- a/src/arch/arm/64/kernel/vspace.c
+++ b/src/arch/arm/64/kernel/vspace.c
@@ -582,7 +582,7 @@ asid_map_t findMapForASID(asid_t asid)
         return asid_map_asid_map_none_new();
     }
 
-    return poolPtr->array[asid & MASK(asidLowBits)];
+    return poolPtr->array[ASID_LOW(asid)];
 }
 
 static findVSpaceForASID_ret_t findVSpaceForASID(asid_t asid)
@@ -817,13 +817,13 @@ static inline asid_pool_t *getPoolPtr(asid_t asid)
 static inline asid_map_t getASIDMap(asid_pool_t *poolPtr, asid_t asid)
 {
     assert(poolPtr != NULL);
-    return poolPtr->array[asid & MASK(asidLowBits)];
+    return poolPtr->array[ASID_LOW(asid)];
 }
 
 static inline void setASIDMap(asid_pool_t *poolPtr, asid_t asid, asid_map_t asid_map)
 {
     assert(poolPtr != NULL);
-    poolPtr->array[asid & MASK(asidLowBits)] = asid_map;
+    poolPtr->array[ASID_LOW(asid)] = asid_map;
 }
 
 static void invalidateASID(asid_t asid)
@@ -925,7 +925,7 @@ static word_t getASIDBindCB(asid_t asid)
     asidPool = armKSASIDTable[ASID_HIGH(asid)];
     assert(asidPool);
 
-    asid_map_t asid_map = asidPool->array[asid & MASK(asidLowBits)];
+    asid_map_t asid_map = asidPool->array[ASID_LOW(asid)];
     assert(asid_map_get_type(asid_map) == asid_map_asid_map_vspace);
 
     return asid_map_asid_map_vspace_get_bind_cb(asid_map);
@@ -938,7 +938,7 @@ void increaseASIDBindCB(asid_t asid)
     asidPool = armKSASIDTable[ASID_HIGH(asid)];
     assert(asidPool);
 
-    asid_map_t *asid_map = &asidPool->array[asid & MASK(asidLowBits)];
+    asid_map_t *asid_map = &asidPool->array[ASID_LOW(asid)];
     assert(asid_map_ptr_get_type(asid_map) == asid_map_asid_map_vspace);
 
     asid_map_asid_map_vspace_ptr_set_bind_cb(asid_map, asid_map_asid_map_vspace_ptr_get_bind_cb(asid_map) + 1);
@@ -951,7 +951,7 @@ void decreaseASIDBindCB(asid_t asid)
     asidPool = armKSASIDTable[ASID_HIGH(asid)];
     assert(asidPool);
 
-    asid_map_t *asid_map = &asidPool->array[asid & MASK(asidLowBits)];
+    asid_map_t *asid_map = &asidPool->array[ASID_LOW(asid)];
     assert(asid_map_ptr_get_type(asid_map) == asid_map_asid_map_vspace);
 
     asid_map_asid_map_vspace_ptr_set_bind_cb(asid_map, asid_map_asid_map_vspace_ptr_get_bind_cb(asid_map) - 1);
@@ -1073,14 +1073,14 @@ void deleteASID(asid_t asid, vspace_root_t *vspace)
     poolPtr = armKSASIDTable[ASID_HIGH(asid)];
 
     if (poolPtr != NULL) {
-        asid_map_t asid_map = poolPtr->array[asid & MASK(asidLowBits)];
+        asid_map_t asid_map = poolPtr->array[ASID_LOW(asid)];
         if (asid_map_get_type(asid_map) == asid_map_asid_map_vspace &&
             (vspace_root_t *)asid_map_asid_map_vspace_get_vspace_root(asid_map) == vspace) {
             invalidateTLBByASID(asid);
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
             invalidateASIDEntry(asid);
 #endif
-            poolPtr->array[asid & MASK(asidLowBits)] = asid_map_asid_map_none_new();
+            poolPtr->array[ASID_LOW(asid)] = asid_map_asid_map_none_new();
             setVMRoot(NODE_STATE(ksCurThread));
         }
     }

--- a/src/arch/arm/64/model/statedata.c
+++ b/src/arch/arm/64/model/statedata.c
@@ -18,7 +18,7 @@
 #endif
 
 
-asid_pool_t *armKSASIDTable[BIT(asidHighBits)];
+asid_pool_t *armKSASIDTable[nASIDPools];
 
 /* AArch64 Memory map explanation:
  *

--- a/src/arch/riscv/kernel/vspace.c
+++ b/src/arch/riscv/kernel/vspace.c
@@ -331,7 +331,7 @@ static findVSpaceForASID_ret_t findVSpaceForASID(asid_t asid)
         return ret;
     }
 
-    vspace_root = poolPtr->array[asid & MASK(asidLowBits)];
+    vspace_root = poolPtr->array[ASID_LOW(asid)];
     if (!vspace_root) {
         current_lookup_fault = lookup_fault_invalid_root_new();
 
@@ -486,7 +486,7 @@ static exception_t performASIDPoolInvocation(asid_t asid, asid_pool_t *poolPtr, 
 
     copyGlobalMappings(regionBase);
 
-    poolPtr->array[asid & MASK(asidLowBits)] = regionBase;
+    poolPtr->array[ASID_LOW(asid)] = regionBase;
 
     return EXCEPTION_NONE;
 }
@@ -496,9 +496,9 @@ void deleteASID(asid_t asid, pte_t *vspace)
     asid_pool_t *poolPtr;
 
     poolPtr = riscvKSASIDTable[ASID_HIGH(asid)];
-    if (poolPtr != NULL && poolPtr->array[asid & MASK(asidLowBits)] == vspace) {
+    if (poolPtr != NULL && poolPtr->array[ASID_LOW(asid)] == vspace) {
         hwASIDFlush(asid);
-        poolPtr->array[asid & MASK(asidLowBits)] = NULL;
+        poolPtr->array[ASID_LOW(asid)] = NULL;
         setVMRoot(NODE_STATE(ksCurThread));
     }
 }

--- a/src/arch/riscv/kernel/vspace.c
+++ b/src/arch/riscv/kernel/vspace.c
@@ -310,7 +310,7 @@ BOOT_CODE void activate_kernel_vspace(void)
 BOOT_CODE void write_it_asid_pool(cap_t it_ap_cap, cap_t it_lvl1pt_cap)
 {
     asid_pool_t *ap = ASID_POOL_PTR(pptr_of_cap(it_ap_cap));
-    ap->array[IT_ASID] = PTE_PTR(pptr_of_cap(it_lvl1pt_cap));
+    ap->array[ASID_LOW(IT_ASID)] = PTE_PTR(pptr_of_cap(it_lvl1pt_cap));
     riscvKSASIDTable[ASID_HIGH(IT_ASID)] = ap;
 }
 

--- a/src/arch/riscv/model/statedata.c
+++ b/src/arch/riscv/model/statedata.c
@@ -15,7 +15,7 @@
 #include <plat/machine/hardware.h>
 
 /* The top level asid mapping table */
-asid_pool_t *riscvKSASIDTable[BIT(asidHighBits)];
+asid_pool_t *riscvKSASIDTable[nASIDPools];
 
 /* Kernel Page Tables */
 pte_t kernel_root_pageTable[BIT(PT_INDEX_BITS)] ALIGN_BSS(BIT(seL4_PageTableBits));

--- a/src/arch/x86/32/kernel/vspace_32paging.c
+++ b/src/arch/x86/32/kernel/vspace_32paging.c
@@ -210,7 +210,7 @@ exception_t performASIDPoolInvocation(asid_t asid, asid_pool_t *poolPtr, cte_t *
         cap_page_directory_cap_ptr_set_capPDIsMapped(&vspaceCapSlot->cap, 1);
         asid_map = asid_map_asid_map_vspace_new(cap_page_directory_cap_get_capPDBasePtr(vspaceCapSlot->cap));
     }
-    poolPtr->array[asid & MASK(asidLowBits)] = asid_map;
+    poolPtr->array[ASID_LOW(asid)] = asid_map;
 
     return EXCEPTION_NONE;
 }

--- a/src/arch/x86/64/kernel/vspace.c
+++ b/src/arch/x86/64/kernel/vspace.c
@@ -814,7 +814,7 @@ exception_t performASIDPoolInvocation(asid_t asid, asid_pool_t *poolPtr, cte_t *
         cap_pml4_cap_ptr_set_capPML4IsMapped(&vspaceCapSlot->cap, 1);
         asid_map = asid_map_asid_map_vspace_new(cap_pml4_cap_get_capPML4BasePtr(vspaceCapSlot->cap));
     }
-    poolPtr->array[asid & MASK(asidLowBits)] = asid_map;
+    poolPtr->array[ASID_LOW(asid)] = asid_map;
     return EXCEPTION_NONE;
 }
 

--- a/src/arch/x86/kernel/ept.c
+++ b/src/arch/x86/kernel/ept.c
@@ -43,7 +43,7 @@ void deleteEPTASID(asid_t asid, ept_pml4e_t *ept)
 {
     asid_pool_t *poolPtr;
 
-    poolPtr = x86KSASIDTable[asid >> asidLowBits];
+    poolPtr = x86KSASIDTable[ASID_HIGH(asid)];
     if (poolPtr != NULL) {
         asid_map_t asid_map = poolPtr->array[asid & MASK(asidLowBits)];
         if (asid_map_get_type(asid_map) == asid_map_asid_map_ept &&

--- a/src/arch/x86/kernel/ept.c
+++ b/src/arch/x86/kernel/ept.c
@@ -45,10 +45,10 @@ void deleteEPTASID(asid_t asid, ept_pml4e_t *ept)
 
     poolPtr = x86KSASIDTable[ASID_HIGH(asid)];
     if (poolPtr != NULL) {
-        asid_map_t asid_map = poolPtr->array[asid & MASK(asidLowBits)];
+        asid_map_t asid_map = poolPtr->array[ASID_LOW(asid)];
         if (asid_map_get_type(asid_map) == asid_map_asid_map_ept &&
             (ept_pml4e_t *)asid_map_asid_map_ept_get_ept_root(asid_map) == ept) {
-            poolPtr->array[asid & MASK(asidLowBits)] = asid_map_asid_map_none_new();
+            poolPtr->array[ASID_LOW(asid)] = asid_map_asid_map_none_new();
         }
     }
 }

--- a/src/arch/x86/kernel/vspace.c
+++ b/src/arch/x86/kernel/vspace.c
@@ -529,7 +529,7 @@ BOOT_CODE bool_t init_pat_msr(void)
 BOOT_CODE void write_it_asid_pool(cap_t it_ap_cap, cap_t it_vspace_cap)
 {
     asid_pool_t *ap = ASID_POOL_PTR(pptr_of_cap(it_ap_cap));
-    ap->array[IT_ASID] = asid_map_asid_map_vspace_new(pptr_of_cap(it_vspace_cap));
+    ap->array[ASID_LOW(IT_ASID)] = asid_map_asid_map_vspace_new(pptr_of_cap(it_vspace_cap));
     x86KSASIDTable[ASID_HIGH(IT_ASID)] = ap;
 }
 

--- a/src/arch/x86/kernel/vspace.c
+++ b/src/arch/x86/kernel/vspace.c
@@ -83,11 +83,11 @@ void deleteASID(asid_t asid, vspace_root_t *vspace)
 
     poolPtr = x86KSASIDTable[ASID_HIGH(asid)];
     if (poolPtr != NULL) {
-        asid_map_t asid_map = poolPtr->array[asid & MASK(asidLowBits)];
+        asid_map_t asid_map = poolPtr->array[ASID_LOW(asid)];
         if (asid_map_get_type(asid_map) == asid_map_asid_map_vspace &&
             (vspace_root_t *)asid_map_asid_map_vspace_get_vspace_root(asid_map) == vspace) {
             hwASIDInvalidate(asid, vspace);
-            poolPtr->array[asid & MASK(asidLowBits)] = asid_map_asid_map_none_new();
+            poolPtr->array[ASID_LOW(asid)] = asid_map_asid_map_none_new();
             setVMRoot(NODE_STATE(ksCurThread));
         }
     }
@@ -542,7 +542,7 @@ asid_map_t findMapForASID(asid_t asid)
         return asid_map_asid_map_none_new();
     }
 
-    return poolPtr->array[asid & MASK(asidLowBits)];
+    return poolPtr->array[ASID_LOW(asid)];
 }
 
 findVSpaceForASID_ret_t findVSpaceForASID(asid_t asid)

--- a/src/arch/x86/model/statedata.c
+++ b/src/arch/x86/model/statedata.c
@@ -23,7 +23,7 @@ UP_STATE_DEFINE(interrupt_t, x86KSPendingInterrupt);
 x86_arch_global_state_t x86KSGlobalState[CONFIG_MAX_NUM_NODES] ALIGN(L1_CACHE_LINE_SIZE) SKIM_BSS;
 
 /* The top level ASID table */
-asid_pool_t *x86KSASIDTable[BIT(asidHighBits)];
+asid_pool_t *x86KSASIDTable[nASIDPools];
 
 /* Current user value of the fs/gs base */
 UP_STATE_DEFINE(word_t, x86KSCurrentFSBase);

--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -432,7 +432,7 @@ BOOT_CODE create_frames_of_region_ret_t create_frames_of_region(
 
 BOOT_CODE cap_t create_it_asid_pool(cap_t root_cnode_cap)
 {
-    cap_t ap_cap = cap_asid_pool_cap_new(ASID_HIGH(IT_ASID), rootserver.asid_pool);
+    cap_t ap_cap = cap_asid_pool_cap_new(ASID_HIGH(IT_ASID) << asidLowBits, rootserver.asid_pool);
     write_slot(SLOT_PTR(pptr_of_cap(root_cnode_cap), seL4_CapInitThreadASIDPool), ap_cap);
 
     /* create ASID control cap */

--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -432,7 +432,7 @@ BOOT_CODE create_frames_of_region_ret_t create_frames_of_region(
 
 BOOT_CODE cap_t create_it_asid_pool(cap_t root_cnode_cap)
 {
-    cap_t ap_cap = cap_asid_pool_cap_new(IT_ASID >> asidLowBits, rootserver.asid_pool);
+    cap_t ap_cap = cap_asid_pool_cap_new(ASID_HIGH(IT_ASID), rootserver.asid_pool);
     write_slot(SLOT_PTR(pptr_of_cap(root_cnode_cap), seL4_CapInitThreadASIDPool), ap_cap);
 
     /* create ASID control cap */


### PR DESCRIPTION
In theory, this shouldn't affect any of the proofs, as the preprocessor output should be almost identical to previous (This is part of the motivation for changing the definition of `ASID_HIGH` to be consistent with the users of the macro).

There's also a bug (lying in wait, so not actually a bug) with the initial thread asid pool cap where we weren't actually creating it as an "asid base", but it was fine since it was 0 anyway.
