### PR TITLE
Make fastpath_restore match restore_user_context

### DIFF
--- a/include/arch/arm/arch/32/mode/fastpath/fastpath.h
+++ b/include/arch/arm/arch/32/mode/fastpath/fastpath.h
@@ -118,13 +118,13 @@ static inline int fastpath_reply_cap_check(cap_t cap)
 /** DONT_TRANSLATE */
 static inline void NORETURN FORCE_INLINE fastpath_restore(word_t badge, word_t msgInfo, tcb_t *cur_thread)
 {
-    NODE_UNLOCK;
-
     c_exit_hook();
 
 #ifdef ARM_CP14_SAVE_AND_RESTORE_NATIVE_THREADS
     restore_user_debug_context(cur_thread);
 #endif
+
+    NODE_UNLOCK;
 
     register word_t badge_reg asm("r0") = badge;
     register word_t msgInfo_reg asm("r1") = msgInfo;

--- a/include/arch/arm/arch/64/mode/fastpath/fastpath.h
+++ b/include/arch/arm/arch/64/mode/fastpath/fastpath.h
@@ -139,13 +139,13 @@ static inline int fastpath_reply_cap_check(cap_t cap)
 /** DONT_TRANSLATE */
 static inline void NORETURN FORCE_INLINE fastpath_restore(word_t badge, word_t msgInfo, tcb_t *cur_thread)
 {
-    NODE_UNLOCK;
-
     c_exit_hook();
 
 #ifdef ARM_CP14_SAVE_AND_RESTORE_NATIVE_THREADS
     restore_user_debug_context(cur_thread);
 #endif
+
+    NODE_UNLOCK;
 
     register word_t badge_reg asm("x0") = badge;
     register word_t msgInfo_reg asm("x1") = msgInfo;

--- a/include/arch/riscv/arch/fastpath/fastpath.h
+++ b/include/arch/riscv/arch/fastpath/fastpath.h
@@ -100,7 +100,7 @@ static inline int fastpath_reply_cap_check(cap_t cap)
 /** DONT_TRANSLATE */
 static inline void NORETURN FORCE_INLINE fastpath_restore(word_t badge, word_t msgInfo, tcb_t *cur_thread)
 {
-    NODE_UNLOCK_IF_HELD;
+    c_exit_hook();
 
     word_t cur_thread_regs = (word_t)cur_thread->tcbArch.tcbContext.registers;
 
@@ -110,11 +110,11 @@ static inline void NORETURN FORCE_INLINE fastpath_restore(word_t badge, word_t m
     *((word_t *)sp) = cur_thread_regs;
 #endif
 
-    c_exit_hook();
-
 #ifdef CONFIG_HAVE_FPU
     set_tcb_fs_state(cur_thread, isFpuEnable());
 #endif
+
+    NODE_UNLOCK_IF_HELD;
 
     register word_t badge_reg asm("a0") = badge;
     register word_t msgInfo_reg asm("a1") = msgInfo;

--- a/include/arch/x86/arch/32/mode/fastpath/fastpath.h
+++ b/include/arch/x86/arch/32/mode/fastpath/fastpath.h
@@ -99,12 +99,12 @@ static inline void NORETURN FORCE_INLINE fastpath_restore(word_t badge, word_t m
 
     NODE_UNLOCK;
 
+    setKernelEntryStackPointer(cur_thread);
+
 #ifdef CONFIG_HARDWARE_DEBUG_API
     restore_user_debug_context(cur_thread);
     assert(!cur_thread->tcbArch.tcbContext.breakpointState.single_step_enabled);
 #endif
-
-    setKernelEntryStackPointer(cur_thread);
 
     if (config_set(CONFIG_KERNEL_X86_IBRS_BASIC)) {
         x86_disable_ibrs();

--- a/include/arch/x86/arch/64/mode/fastpath/fastpath.h
+++ b/include/arch/x86/arch/64/mode/fastpath/fastpath.h
@@ -131,8 +131,9 @@ static inline void NORETURN FORCE_INLINE fastpath_restore(word_t badge, word_t m
          */
         restore_user_context();
     }
-    NODE_UNLOCK;
     c_exit_hook();
+
+    NODE_UNLOCK;
 
     if (config_set(CONFIG_KERNEL_SKIM_WINDOW)) {
         /* see restore_user_context for a full explanation of why we do this */


### PR DESCRIPTION
Mostly call c_exit_hook() with global lock held.

It got more out of sync since the SMP fixes got merged, those missed the fastpath code.