### PR TITLE
boot: allow early printf() - before kernel vspace

### DIFF
--- a/include/machine/io.h
+++ b/include/machine/io.h
@@ -19,6 +19,11 @@ unsigned char kernel_getDebugChar(void);
 #include <arch/types.h>
 #include <stdarg.h>
 
+#ifdef CONFIG_ARCH_ARM
+/* See arm/machine/io.c for definition */
+extern pptr_t uart_pptr;
+#endif
+
 /* the actual output function */
 void kernel_putDebugChar(unsigned char c);
 

--- a/src/arch/arm/kernel/boot.c
+++ b/src/arch/arm/kernel/boot.c
@@ -340,6 +340,8 @@ static BOOT_CODE bool_t try_init_kernel(
     word_t  dtb_size
 )
 {
+    printf("Bootstrapping kernel\n");
+
     cap_t root_cnode_cap;
     cap_t it_ap_cap;
     cap_t it_pd_cap;
@@ -369,14 +371,19 @@ static BOOT_CODE bool_t try_init_kernel(
     /* setup virtual memory for the kernel */
     map_kernel_window();
 
+#ifdef CONFIG_PRINTING
+    /* Switch printf() from using the physical UART address to the virtual
+     * UART address (in the kernel device region). printf() can no longer be
+     * called until activate_kernel_vspace() at the start of init_cpu() has
+     * finished. */
+    uart_pptr = UART_PPTR;
+#endif
+
     /* initialise the CPU */
     if (!init_cpu()) {
         printf("ERROR: CPU init failed\n");
         return false;
     }
-
-    /* debug output via serial port is only available from here */
-    printf("Bootstrapping kernel\n");
 
     /* initialise the platform */
     init_plat();

--- a/src/arch/arm/machine/io.c
+++ b/src/arch/arm/machine/io.c
@@ -9,6 +9,13 @@
 #include <drivers/uart.h>
 
 #ifdef CONFIG_PRINTING
+
+/**
+ * This is initially the PADDR for the early kernel boots, and we switch it
+ * out to use the PPTR once the kernel has mapped memory in.
+ */
+pptr_t uart_pptr = UART_PADDR;
+
 void kernel_putDebugChar(unsigned char c)
 {
     uart_console_putchar(c);

--- a/src/arch/riscv/kernel/boot.c
+++ b/src/arch/riscv/kernel/boot.c
@@ -199,6 +199,8 @@ static BOOT_CODE bool_t try_init_kernel(
     word_t  dtb_size
 )
 {
+    printf("Bootstrapping kernel\n");
+
     cap_t root_cnode_cap;
     cap_t it_pd_cap;
     cap_t it_ap_cap;
@@ -228,8 +230,6 @@ static BOOT_CODE bool_t try_init_kernel(
 
     /* initialise the CPU */
     init_cpu();
-
-    printf("Bootstrapping kernel\n");
 
     /* initialize the platform */
     init_plat();

--- a/src/drivers/serial/bcm2835-aux-uart.c
+++ b/src/drivers/serial/bcm2835-aux-uart.c
@@ -34,7 +34,7 @@
 #define MU_LCR_BREAK     BIT(6)
 #define MU_LCR_DATASIZE  BIT(0)
 
-#define UART_REG(x) ((volatile uint32_t *)(UART_PPTR + (x)))
+#define UART_REG(x) ((volatile uint32_t *)(uart_pptr + (x)))
 
 #ifdef CONFIG_PRINTING
 void uart_drv_putchar(unsigned char c)

--- a/src/drivers/serial/exynos4210-uart.c
+++ b/src/drivers/serial/exynos4210-uart.c
@@ -30,7 +30,7 @@
 #define TXBUF_EMPTY     BIT(1)
 #define RXBUF_READY     BIT(0)
 
-#define UART_REG(X) ((volatile uint32_t *)(UART_PPTR + (X)))
+#define UART_REG(X) ((volatile uint32_t *)(uart_pptr + (X)))
 
 #ifdef CONFIG_PRINTING
 void uart_drv_putchar(unsigned char c)

--- a/src/drivers/serial/imx-lpuart.c
+++ b/src/drivers/serial/imx-lpuart.c
@@ -22,7 +22,7 @@
 
 #define STAT_TDRE (1 << 23)
 
-#define UART_REG(x) ((volatile uint32_t *)(UART_PPTR + (x)))
+#define UART_REG(x) ((volatile uint32_t *)(uart_pptr + (x)))
 
 #if defined(CONFIG_DEBUG_BUILD) || defined(CONFIG_PRINTING)
 void uart_drv_putchar(unsigned char c)

--- a/src/drivers/serial/imx.c
+++ b/src/drivers/serial/imx.c
@@ -32,7 +32,7 @@
 #define UART_SR2_TXFIFO_EMPTY BIT(14)
 #define UART_SR2_RXFIFO_RDR   BIT(0)
 
-#define UART_REG(x) ((volatile uint32_t *)(UART_PPTR + (x)))
+#define UART_REG(x) ((volatile uint32_t *)(uart_pptr + (x)))
 
 #ifdef CONFIG_PRINTING
 void uart_drv_putchar(unsigned char c)

--- a/src/drivers/serial/meson-gx-uart.c
+++ b/src/drivers/serial/meson-gx-uart.c
@@ -17,7 +17,7 @@
 #define UART_TX_FULL        BIT(21)
 #define UART_RX_EMPTY       BIT(20)
 
-#define UART_REG(x) ((volatile uint32_t *)(UART_PPTR + (x)))
+#define UART_REG(x) ((volatile uint32_t *)(uart_pptr + (x)))
 
 #ifdef CONFIG_PRINTING
 void uart_drv_putchar(unsigned char c)

--- a/src/drivers/serial/msm-uartdm.c
+++ b/src/drivers/serial/msm-uartdm.c
@@ -18,7 +18,7 @@
 #define USR_TXRDY             BIT(2)
 #define USR_TXEMP             BIT(3)
 
-#define UART_REG(X) ((volatile uint32_t *)(UART_PPTR + (X)))
+#define UART_REG(X) ((volatile uint32_t *)(uart_pptr + (X)))
 
 #ifdef CONFIG_PRINTING
 void uart_drv_putchar(unsigned char c)

--- a/src/drivers/serial/pl011.c
+++ b/src/drivers/serial/pl011.c
@@ -16,7 +16,7 @@
 #define PL011_UARTFR_TXFF         BIT(5)
 #define PL011_UARTFR_RXFE         BIT(4)
 
-#define UART_REG(x) ((volatile uint32_t *)(UART_PPTR + (x)))
+#define UART_REG(x) ((volatile uint32_t *)(uart_pptr + (x)))
 
 #ifdef CONFIG_PRINTING
 void uart_drv_putchar(unsigned char c)

--- a/src/drivers/serial/tegra_omap3_dwapb.c
+++ b/src/drivers/serial/tegra_omap3_dwapb.c
@@ -16,7 +16,7 @@
 #define ULSR_THRE   BIT(5)
 #define ULSR_RDR    BIT(0)
 
-#define UART_REG(x) ((volatile uint32_t *)(UART_PPTR + (x)))
+#define UART_REG(x) ((volatile uint32_t *)(uart_pptr + (x)))
 
 #ifdef CONFIG_PRINTING
 void uart_drv_putchar(unsigned char c)

--- a/src/drivers/serial/xuartps.c
+++ b/src/drivers/serial/xuartps.c
@@ -30,7 +30,7 @@
 #define UART_INTRPT_MASK_TXEMPTY     BIT(3)
 #define UART_CHANNEL_STS_TXEMPTY     BIT(3)
 
-#define UART_REG(x) ((volatile uint32_t *)(UART_PPTR + (x)))
+#define UART_REG(x) ((volatile uint32_t *)(uart_pptr + (x)))
 
 #ifdef CONFIG_PRINTING
 void uart_drv_putchar(unsigned char c)

--- a/tools/hardware/outputs/c_header.py
+++ b/tools/hardware/outputs/c_header.py
@@ -12,7 +12,7 @@ from typing import Dict, List
 import hardware
 from hardware.config import Config
 from hardware.fdt import FdtParser
-from hardware.utils.rule import HardwareYaml
+from hardware.utils.rule import HardwareYaml, KernelRegionGroup
 
 
 HEADER_TEMPLATE = '''/*
@@ -69,6 +69,13 @@ static inline CONST word_t physBase(void)
 {% for (addr, macro) in sorted(kernel_macros.items()) %}
 #define {{ macro }} (KDEV_BASE + {{ "0x{:x}".format(addr) }})
 {% endfor %}
+
+{% if uart_region is not none %}
+/* UART DEVICE (early-printf) */
+{{ uart_region.get_macro() }}
+#define UART_PADDR ({{ "0x{:x}".format(uart_region.regions[0].base) }})
+{{ uart_region.get_endif() }}
+{% endif %}
 
 {% if len(kernel_regions) > 0 %}
 static const kernel_frame_t BOOT_RODATA kernel_device_frames[] = {
@@ -186,8 +193,8 @@ def get_interrupts(tree: FdtParser, hw_yaml: HardwareYaml) -> List:
 
 
 def create_c_header_file(config, kernel_irqs: List, kernel_macros: Dict,
-                         kernel_regions: List, physBase: int, physical_memory,
-                         outputStream):
+                         kernel_regions: List, physBase: int, uart_region: KernelRegionGroup,
+                         physical_memory, outputStream):
 
     jinja_env = jinja2.Environment(loader=jinja2.BaseLoader, trim_blocks=True,
                                    lstrip_blocks=True)
@@ -201,6 +208,7 @@ def create_c_header_file(config, kernel_irqs: List, kernel_macros: Dict,
             'kernel_macros': kernel_macros,
             'kernel_regions': kernel_regions,
             'physBase': physBase,
+            'uart_region': uart_region,
             'physical_memory': physical_memory})
     data = template.render(template_args)
 
@@ -215,12 +223,17 @@ def run(tree: FdtParser, hw_yaml: HardwareYaml, config: Config, kernel_config_di
     physical_memory, reserved, physBase = hardware.utils.memory.get_physical_memory(tree, config)
     kernel_regions, kernel_macros = get_kernel_devices(tree, hw_yaml, kernel_config_dict)
 
+    # FIXME: There is probably a better way to do this....
+    uart_region = next((r for r in kernel_regions if 'UART_PPTR' in r.labels), None)
+    assert uart_region is None or len(uart_region.regions) == 1
+
     create_c_header_file(
         config,
         get_interrupts(tree, hw_yaml),
         kernel_macros,
         kernel_regions,
         physBase,
+        uart_region,
         physical_memory,
         args.header_out)
 


### PR DESCRIPTION
On ARM and RISC-V (not x86, which uses IO ports), the kernel's printf() call goes via the virtual address, which means that early prints before we setup virtual memory cause faults. Any issues at early stages will silently fail, e.g. various assert() that may go off.

We add a global variable that gets adjusted once the vspace exists so that the UART drivers can go through the physical memory address (since the kernel expects to be mapped 1:1 at boot time) early-on and then migrate to virtual address later. This makes debugging early-boot issues significantly easier on bare metal (without gdb).

Fixes: #540
Fixes: #1191