### PR TITLE
aarch64: use fixed virtual address for kernel address space

### DIFF
--- a/include/arch/arm/arch/kernel/vspace.h
+++ b/include/arch/arm/arch/kernel/vspace.h
@@ -20,6 +20,7 @@ cap_t create_mapped_it_frame_cap(cap_t pd_cap, pptr_t pptr, vptr_t vptr, asid_t 
                                  bool_t executable);
 
 void map_kernel_window(void);
+void map_kernel_elf_image(pte_t kernel_mapping_pds[]);
 void map_kernel_frame(paddr_t paddr, pptr_t vaddr, vm_rights_t vm_rights, vm_attributes_t vm_attributes);
 void activate_kernel_vspace(void);
 void write_it_asid_pool(cap_t it_ap_cap, cap_t it_pd_cap);

--- a/include/arch/arm/arch/kernel/vspace.h
+++ b/include/arch/arm/arch/kernel/vspace.h
@@ -21,6 +21,7 @@ cap_t create_mapped_it_frame_cap(cap_t pd_cap, pptr_t pptr, vptr_t vptr, asid_t 
 
 void map_kernel_window(void);
 void map_kernel_elf_image(pte_t kernel_mapping_pds[]);
+void map_kernel_physical_window(void);
 void map_kernel_frame(paddr_t paddr, pptr_t vaddr, vm_rights_t vm_rights, vm_attributes_t vm_attributes);
 void activate_kernel_vspace(void);
 void write_it_asid_pool(cap_t it_ap_cap, cap_t it_pd_cap);

--- a/include/machine.h
+++ b/include/machine.h
@@ -13,7 +13,11 @@
 /* When translating a physical address into an address accessible to the
  * kernel via virtual addressing we always use the mapping of the memory
  * into the physical memory window, even if the mapping originally
- * referred to a kernel virtual address. */
+ * referred to a kernel virtual address.
+ * As a result, this function should _not_ be used to modify memory if the
+ * addresses might lie within the kernel ELF mapping. See the comments attached
+ * to `map_kernel_elf_image()` on the AArch64 vspace code.
+ */
 static inline void *CONST ptrFromPAddr(paddr_t paddr)
 {
     return (void *)(paddr + PPTR_BASE_OFFSET);

--- a/src/arch/arm/64/kernel/vspace.c
+++ b/src/arch/arm/64/kernel/vspace.c
@@ -233,6 +233,87 @@ BOOT_CODE void map_kernel_frame(paddr_t paddr, pptr_t vaddr, vm_rights_t vm_righ
                                                                                             attr_index);
 }
 
+/* Essentially, assert that the ELF, kernel devices, and log buffer are all in the same PUD.
+   In the current code this is the top index. This is arbitrary, the important part
+   is that they are all the same.
+ */
+compile_assert(elf_in_kernel_mappings, GET_KPT_INDEX(KERNEL_ELF_BASE,
+                                                     KLVL_FRM_ARM_PT_LVL(1)) == BIT(PT_INDEX_BITS) - 1);
+compile_assert(kdev_in_kernel_mappings, GET_KPT_INDEX(KDEV_BASE,
+                                                      KLVL_FRM_ARM_PT_LVL(1)) == BIT(PT_INDEX_BITS) - 1);
+compile_assert(log_buf_in_kernel_mappings, GET_KPT_INDEX(KS_LOG_BASE,
+                                                         KLVL_FRM_ARM_PT_LVL(1)) == BIT(PT_INDEX_BITS) - 1);
+
+/**
+ *  Per ARM ARM DDI 0487 (version L.b), in B2.11 "Mismatched memory attributes",
+ *  when physical memory locations are accessed with mismatched attributes
+ *  (caching, memory type (device/normal), shareability), the coherency of these
+ *  memory locations may be lost, as well as various violations of read and
+ *  write orderings or atomic operations. Other ARM documents refer to the
+ *  situation in which two virtual addresses map to the same physical address as
+ *  "Memory aliasing" (e.g. Document ID 102376 0200_01_en).
+ *
+ *  Currently, the memory attributes used in the physical memory window does
+ *  match that of the kernel ELF mapping, so this is OK. At the same time,
+ *  the current physical window mapping does use NORMAL memory covering memory
+ *  that is not DRAM, which is questionable for newer processors with more
+ *  speculative execution. (FIXME)
+ *
+ *  Hence, the kernel should never access kernel ELF memory through the physical
+ *  memory window, i.e., never modify the result of `ptrFromPAddr()` when the
+ *  physical address lies within the kernel ELF. (Reads are fine if they
+ *  have been flushed appropriately per B2.11; this should be the case for
+ *  any paging structures).
+ *
+ *  As an addendum, LWN Article "ARM's multiply-mapped memory mess" specifies
+ *  that in ARMv6 specifications this kind of aliasing would be UNPREDICTABLE;
+ *  the current ARMv8 A-Profile specifications no longer contain this wording,
+ *  and instead specify the loss of coherency and other behaviours in B2.11.
+ */
+BOOT_CODE void map_kernel_elf_image(pte_t kernel_mapping_pds[])
+{
+    /** This is not strictly necessary, but to handle a non-aligned KERNEL_ELF_PADDR_BASE
+     *  we'd need to do a bit more logic and probably do what riscv64 does
+     *  where the *actual* KERNEL_ELF_BASE is rounded up to the alignment.
+     *  This is simpler and memory is cheap.
+     **/
+    compile_assert(elf_paddr_aligned, IS_ALIGNED(KERNEL_ELF_PADDR_BASE_RAW, seL4_LargePageBits));
+    compile_assert(elf_base_aligned, IS_ALIGNED(KERNEL_ELF_BASE, seL4_LargePageBits));
+
+    /* Please don't overlap with KDEV_BASE */
+    assert(KERNEL_ELF_TOP <= KDEV_BASE);
+    /* Please don't overlap with KS_LOG_PPTR */
+    assert(KERNEL_ELF_TOP <= KS_LOG_PPTR);
+
+    const word_t pd_start = GET_KPT_INDEX(KERNEL_ELF_BASE, KLVL_FRM_ARM_PT_LVL(2));
+    /* pd_end and ELF_TOP are both exclusive, so handle that correctly */
+    const word_t pd_end   = GET_KPT_INDEX(KERNEL_ELF_TOP - 1, KLVL_FRM_ARM_PT_LVL(2)) + 1;
+
+    paddr_t paddr = KERNEL_ELF_PADDR_BASE;
+    UNUSED pptr_t vaddr = KERNEL_ELF_BASE;
+
+    for (word_t pd = pd_start; pd < pd_end; pd++) {
+        assert(pd == GET_KPT_INDEX(vaddr, KLVL_FRM_ARM_PT_LVL(2)));
+
+        kernel_mapping_pds[pd] = pte_pte_page_new(
+#ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
+                                     /* XN */ 0,
+#else
+                                     /* UXN */ 1,
+#endif
+                                     /* page_base_address */ paddr,
+                                     /* global (nG) */ 0,
+                                     /* access flag (AF) */ 1,
+                                     /* shareability (SH) */ SMP_TERNARY(SMP_SHARE, 0),
+                                     /* AP */ APFromVMRights(VMKernelOnly),
+                                     /* AttrIndx */ NORMAL
+                                 );
+
+        paddr += BIT(seL4_LargePageBits);
+        vaddr += BIT(seL4_LargePageBits);
+    }
+}
+
 BOOT_CODE void map_kernel_window(void)
 {
 
@@ -253,8 +334,8 @@ BOOT_CODE void map_kernel_window(void)
     assert(IS_ALIGNED(PPTR_TOP, seL4_HugePageBits));
 
     /* place the PUD into the PGD */
-    armKSGlobalKernelPGD[GET_KPT_INDEX(PPTR_BASE, KLVL_FRM_ARM_PT_LVL(0))] = pte_pte_table_new(
-                                                                                 addrFromKPPtr(armKSGlobalKernelPUD));
+    armKSGlobalKernelPGD[GET_KPT_INDEX(PPTR_BASE, KLVL_FRM_ARM_PT_LVL(0))]
+        = pte_pte_table_new(addrFromKPPtr(armKSGlobalKernelPUD));
 
     /* place all PDs except the last one in PUD */
     for (idx = GET_KPT_INDEX(PPTR_BASE, KLVL_FRM_ARM_PT_LVL(1)); idx < GET_KPT_INDEX(PPTR_TOP, KLVL_FRM_ARM_PT_LVL(1));
@@ -283,6 +364,13 @@ BOOT_CODE void map_kernel_window(void)
                                                                                                                     );
         vaddr += BIT(seL4_LargePageBits);
     }
+
+
+    const word_t elf_pud_idx = GET_KPT_INDEX(KERNEL_ELF_BASE, KLVL_FRM_ARM_PT_LVL(1));
+    pte_t *kernel_mapping_pds = armKSGlobalKernelPDs[elf_pud_idx];
+
+    /* map the kernel ELF */
+    map_kernel_elf_image(kernel_mapping_pds);
 
     /* put the PD into the PUD for device window */
     armKSGlobalKernelPUD[GET_KPT_INDEX(PPTR_TOP, KLVL_FRM_ARM_PT_LVL(1))] = pte_pte_table_new(

--- a/src/arch/arm/64/kernel/vspace.c
+++ b/src/arch/arm/64/kernel/vspace.c
@@ -369,18 +369,17 @@ BOOT_CODE void map_kernel_window(void)
     const word_t elf_pud_idx = GET_KPT_INDEX(KERNEL_ELF_BASE, KLVL_FRM_ARM_PT_LVL(1));
     pte_t *kernel_mapping_pds = armKSGlobalKernelPDs[elf_pud_idx];
 
+    /* place the kernel mapping PDs in the kernel mapping PUD */
+    armKSGlobalKernelPUD[elf_pud_idx] = pte_pte_table_new(addrFromKPPtr(kernel_mapping_pds));
+
     /* map the kernel ELF */
     map_kernel_elf_image(kernel_mapping_pds);
 
-    /* put the PD into the PUD for device window */
-    armKSGlobalKernelPUD[GET_KPT_INDEX(PPTR_TOP, KLVL_FRM_ARM_PT_LVL(1))] = pte_pte_table_new(
-                                                                                addrFromKPPtr(&armKSGlobalKernelPDs[BIT(PT_INDEX_BITS) - 1][0])
-                                                                            );
-
-    /* put the PT into the PD for device window */
-    armKSGlobalKernelPDs[BIT(PT_INDEX_BITS) - 1][BIT(PT_INDEX_BITS) - 1] = pte_pte_table_new(
-                                                                               addrFromKPPtr(armKSGlobalKernelPT)
-                                                                           );
+    /* put the PT into the PD for device window. It would be nice if
+       we could pass kernel_mapping_pds[511] to map_kernel_devices(), but it is
+       shared between AArch64 and AArch32, so... */
+    kernel_mapping_pds[BIT(PT_INDEX_BITS) - 1]
+        = pte_pte_table_new(addrFromKPPtr(armKSGlobalKernelPT));
 
     map_kernel_devices();
 }

--- a/src/arch/arm/64/kernel/vspace.c
+++ b/src/arch/arm/64/kernel/vspace.c
@@ -337,16 +337,11 @@ compile_assert(physical_window_bottom_kernel_region,
 compile_assert(physical_window_top_kernel_region,
                GET_KPT_INDEX(PPTR_TOP, KLVL_FRM_ARM_PT_LVL(1)) == BIT(PT_INDEX_BITS) - 1);
 
-BOOT_CODE void map_kernel_window(void)
+BOOT_CODE void map_kernel_physical_window(void)
 {
-
     paddr_t paddr;
     pptr_t vaddr;
     word_t idx;
-
-    /* place the PUD into the PGD */
-    armKSGlobalKernelPGD[GET_KPT_INDEX(PPTR_BASE, KLVL_FRM_ARM_PT_LVL(0))]
-        = pte_pte_table_new(addrFromKPPtr(armKSGlobalKernelPUD));
 
     /* place all PDs except the last one in PUD */
     for (idx = GET_KPT_INDEX(PPTR_BASE, KLVL_FRM_ARM_PT_LVL(1)); idx < GET_KPT_INDEX(PPTR_TOP, KLVL_FRM_ARM_PT_LVL(1));
@@ -375,7 +370,15 @@ BOOT_CODE void map_kernel_window(void)
                                                                                                                     );
         vaddr += BIT(seL4_LargePageBits);
     }
+}
 
+BOOT_CODE void map_kernel_window(void)
+{
+    /* place the PUD into the PGD */
+    armKSGlobalKernelPGD[GET_KPT_INDEX(PPTR_BASE, KLVL_FRM_ARM_PT_LVL(0))] =
+        pte_pte_table_new(addrFromKPPtr(armKSGlobalKernelPUD));
+
+    map_kernel_physical_window();
 
     const word_t elf_pud_idx = GET_KPT_INDEX(KERNEL_ELF_BASE, KLVL_FRM_ARM_PT_LVL(1));
     pte_t *kernel_mapping_pds = armKSGlobalKernelPDs[elf_pud_idx];

--- a/src/arch/arm/64/kernel/vspace.c
+++ b/src/arch/arm/64/kernel/vspace.c
@@ -314,24 +314,35 @@ BOOT_CODE void map_kernel_elf_image(pte_t kernel_mapping_pds[])
     }
 }
 
+#ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
+/* verify that the physical memory window as at the second entry of the PGD */
+compile_assert(physical_window_pgd_location,
+               GET_KPT_INDEX(PPTR_BASE, KLVL_FRM_ARM_PT_LVL(0)) == 1);
+#else
+/* verify that the physical memory window as at the last entry of the PGD */
+compile_assert(physical_window_pgd_location,
+               GET_KPT_INDEX(PPTR_BASE, KLVL_FRM_ARM_PT_LVL(0)) == BIT(PT_INDEX_BITS) - 1);
+#endif
+/* make sure that the PPTR_BASE and PPTR_TOP are huge paged aligned */
+compile_assert(physical_window_base_aligned, IS_ALIGNED(PPTR_BASE, seL4_HugePageBits));
+compile_assert(physical_window_top_aligned, IS_ALIGNED(PPTR_TOP, seL4_HugePageBits));
+
+/* the PPTR_BASE starts from the bottom of the kernel PUD */
+compile_assert(physical_window_bottom_kernel_region,
+               GET_KPT_INDEX(PPTR_BASE, KLVL_FRM_ARM_PT_LVL(1)) == 0);
+/* the PPTR_TOP then ends at the second-to-last entry of the PUD
+    note: because this is the exclusive value the assert is one higher than
+          you would expect.
+*/
+compile_assert(physical_window_top_kernel_region,
+               GET_KPT_INDEX(PPTR_TOP, KLVL_FRM_ARM_PT_LVL(1)) == BIT(PT_INDEX_BITS) - 1);
+
 BOOT_CODE void map_kernel_window(void)
 {
 
     paddr_t paddr;
     pptr_t vaddr;
     word_t idx;
-
-#ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
-    /* verify that the kernel window as at the second entry of the PGD */
-    assert(GET_KPT_INDEX(PPTR_BASE, KLVL_FRM_ARM_PT_LVL(0)) == 1);
-#else
-    /* verify that the kernel window as at the last entry of the PGD */
-    assert(GET_KPT_INDEX(PPTR_BASE, KLVL_FRM_ARM_PT_LVL(0)) == BIT(PT_INDEX_BITS) - 1);
-#endif
-    assert(IS_ALIGNED(PPTR_BASE, seL4_LargePageBits));
-    /* verify that the kernel device window is 1gb aligned and 1gb in size */
-    assert(GET_KPT_INDEX(PPTR_TOP, KLVL_FRM_ARM_PT_LVL(1)) == BIT(PT_INDEX_BITS) - 1);
-    assert(IS_ALIGNED(PPTR_TOP, seL4_HugePageBits));
 
     /* place the PUD into the PGD */
     armKSGlobalKernelPGD[GET_KPT_INDEX(PPTR_BASE, KLVL_FRM_ARM_PT_LVL(0))]

--- a/src/arch/arm/64/kernel/vspace.c
+++ b/src/arch/arm/64/kernel/vspace.c
@@ -357,7 +357,7 @@ BOOT_CODE void map_kernel_physical_window(void)
         armKSGlobalKernelPDs[GET_KPT_INDEX(vaddr, KLVL_FRM_ARM_PT_LVL(1))][GET_KPT_INDEX(vaddr,
                                                                                          KLVL_FRM_ARM_PT_LVL(2))] = pte_pte_page_new(
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
-                                                                                                                        0, // XN
+                                                                                                                        1, // XN
 #else
                                                                                                                         1, // UXN
 #endif

--- a/tools/hardware/config.py
+++ b/tools/hardware/config.py
@@ -42,7 +42,15 @@ class ARMConfig(Config):
         elif sel4arch == 'aarch32':
             self.KERNEL_PHYS_ALIGN = 24
         else:
-            self.KERNEL_PHYS_ALIGN = 0
+            # On AArch64, `PADDR_BASE` is always zero, and only `KERNEL_ELF_PADDR_BASE`
+            # uses `PHYS_BASE`, which is influenced by this alignment.
+            # For simplicity, we require that `KERNEL_ELF_PADDR_BASE` is aligned
+            # to seL4_LargePageBits so that we can map it directly using 2MiB
+            # pages. This does however reserve memory from the true bottom of
+            # RAM up to this alignment (exposed as device UT), but this is no
+            # more than part of a single 2MiB page, which should be acceptable
+            # on AArch64.
+            self.KERNEL_PHYS_ALIGN = 21
 
     def get_kernel_phys_align(self) -> int:
         return self.KERNEL_PHYS_ALIGN


### PR DESCRIPTION
This matches RISC-V which also does this (edit: actually, it doesn't, even though it maps the kernel ELF twice)

This is a precursor to some other boot protocol changes as a part of
the multikernel work where it is useful to be able to load the kernel
at different physical addresses using the same kernel image.

Previously, the kernel would run in the kernel physical memory window
at a platform-specific virtual address.
