### PR TITLE
cmake: Error message warning fix

### DIFF
--- a/configs/seL4Config.cmake
+++ b/configs/seL4Config.cmake
@@ -199,6 +199,7 @@ foreach(file ${result})
     include("${file}")
 endforeach()
 
+set(kernel_platform_origin "${KernelPlatform}")
 config_choice(KernelPlatform PLAT "Select the platform" ${kernel_platforms})
 
 # Verify that, as a minimum any variables that are used
@@ -206,7 +207,7 @@ config_choice(KernelPlatform PLAT "Select the platform" ${kernel_platforms})
 # point. This means at least: KernelPlatform KernelArch KernelWordSize
 
 if("${KernelPlatform}" STREQUAL "")
-    message(FATAL_ERROR "Variable 'KernelPlatform' is not set - is PLATFORM '${PLATFORM}' correct? \
+    message(FATAL_ERROR "Variable 'KernelPlatform' is not set - Was tested value:'${kernel_platform_origin}' correct? \
 Valid platforms are '${KernelPlatform_all_strings}'"
     )
 endif()


### PR DESCRIPTION
PLATFORM is not a variable defined by the Kernel CMake build and isn't always how the kernel platform is configured. For example the verified configs in configs/ just set KernelPlatform directly.

I was reviewing https://github.com/seL4/seL4/pull/1467 and noticed the PLATFORM may not always be the way that the user tried to configure the platform.

Try changing the platform name in `configs/AARCH64_verified.cmake` to an invalid name and build the config it would not print the right value out.

Because KernelPlatform is cleared by the config_choice on line 203 if it is invalid, we can save the old value and then use it to print out in the error string if the platform name was invalid. 
