### PR TITLE
tools: keep align-reserved memory in 'devices'

### DIFF
--- a/tools/hardware/outputs/c_header.py
+++ b/tools/hardware/outputs/c_header.py
@@ -212,7 +212,7 @@ def run(tree: FdtParser, hw_yaml: HardwareYaml, config: Config, kernel_config_di
     if not args.header_out:
         raise ValueError('You need to specify a header-out to use c header output')
 
-    physical_memory, reserved, physBase = hardware.utils.memory.get_physical_memory(tree, config)
+    physical_memory, physBase = hardware.utils.memory.get_physical_memory(tree, config)
     kernel_regions, kernel_macros = get_kernel_devices(tree, hw_yaml, kernel_config_dict)
 
     create_c_header_file(

--- a/tools/hardware/outputs/json.py
+++ b/tools/hardware/outputs/json.py
@@ -56,10 +56,9 @@ def run(tree: FdtParser, hw_yaml: HardwareYaml, config: Config,
     if not args.json_out:
         raise ValueError('you need to provide a json-out to use the JSON output method')
 
-    phys_mem, reserved, _ = hardware.utils.memory.get_physical_memory(tree, config)
+    phys_mem, _ = hardware.utils.memory.get_physical_memory(tree, config)
     kernel_devs = get_kernel_devices(tree, hw_yaml, kernel_config_dict)
-    dev_mem = hardware.utils.memory.get_addrspace_exclude(
-        list(reserved) + phys_mem + kernel_devs, config)
+    dev_mem = hardware.utils.memory.get_addrspace_exclude(phys_mem + kernel_devs, config)
 
     create_json_file(dev_mem, phys_mem, args.json_out)
 

--- a/tools/hardware/outputs/yaml.py
+++ b/tools/hardware/outputs/yaml.py
@@ -61,10 +61,9 @@ def run(tree: FdtParser, hw_yaml: HardwareYaml, config: Config,
     if not args.yaml_out:
         raise ValueError('you need to provide a yaml-out to use the yaml output method')
 
-    phys_mem, reserved, _ = hardware.utils.memory.get_physical_memory(tree, config)
+    phys_mem, _ = hardware.utils.memory.get_physical_memory(tree, config)
     kernel_devs = get_kernel_devices(tree, hw_yaml, kernel_config_dict)
-    dev_mem = hardware.utils.memory.get_addrspace_exclude(
-        list(reserved) + phys_mem + kernel_devs, config)
+    dev_mem = hardware.utils.memory.get_addrspace_exclude(phys_mem + kernel_devs, config)
 
     create_yaml_file(dev_mem, phys_mem, args.yaml_out)
 

--- a/tools/hardware/utils/memory.py
+++ b/tools/hardware/utils/memory.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-from typing import List, Set
+from typing import List, Set, Tuple
 
 import hardware
 from hardware.config import Config
@@ -83,7 +83,7 @@ def reserve_regions(regions: Set[Region], reserved: Set[Region]) -> Set[Region]:
     return ret
 
 
-def align_memory(regions: Set[Region], config: Config) -> List[Region]:
+def align_memory(regions: Set[Region], config: Config) -> Tuple[List[Region], int]:
     ''' Given a set of regions, sort them and align the first so that the
     ELF loader will be able to load the kernel into it. Will return the
     aligned memory region list, a set of any regions of memory that were
@@ -99,14 +99,14 @@ def align_memory(regions: Set[Region], config: Config) -> List[Region]:
     return ret, physBase
 
 
-def get_physical_memory(tree: FdtParser, config: Config) -> List[Region]:
+def get_physical_memory(tree: FdtParser, config: Config) -> Tuple[List[Region], int]:
     ''' returns a list of regions representing physical memory as used by the kernel '''
     regions = merge_memory_regions(get_memory_regions(tree))
     reserved = parse_reserved_regions(tree.get_path('/reserved-memory'))
     regions = reserve_regions(regions, reserved)
     regions, physBase = align_memory(regions, config)
 
-    return regions, reserved, physBase
+    return regions, physBase
 
 
 def get_addrspace_exclude(regions: List[Region], config: Config):


### PR DESCRIPTION
This is purely a bugfix, the kernel behaves exactly the same either way. This is only a difference in the generated `platform_gen` files to respect reality.

---

`align_memory()` in hardware.py both modifies the first normal memory region to adjust the base of it for alignment, and adds an extra reserved region to our list of reserved regions. This then feeds through `get_addrspace_exclude` which inverts the regions given and turns it into the available "device memory" at user-level.

    dev_mem = hardware.utils.memory.get_addrspace_exclude(
        list(reserved) + phys_mem + kernel_devs, config)

Anything as an argument to this is not given as "device memory" by the kernel. (It does not precisely match how the kernel works).

However, since `align_memory()` has adjusted both the phys_mem up (which *would* have added this region as "device" memory) but also added it to "reserved" region, which then made it disappear entirely, as "reserved" regions are not exposed to userspace.

However, this **does not** match the behaviour of the kernel, as it was not reserved, so this behaviour did not match the untypeds given to userspace. This commit solves this by removing the extra reserved region being added for that memory.

PR #1426 worked around this issue by removing the alignment on AArch64. Whilst this fixed the issue that microkit was seeing, it just masked the underlying issue. Reverting that PR, then applying this fix, results in the following platform_gen.yaml:

    devices:
    - end: 0x1000000 start: 0x0
    - end: 0xff800000 start: 0x3b400000
    - end: 0xff841000 start: 0xff801000
    - end: 0x100000000000 start: 0xff843000
    memory:
    - end: 0x3b400000 start: 0x1000000

Note especially the device region from 0x0 to 0x1000000; which is the combination of the 0x0 to 0x1000 reserved region, and the 0x1000 to 0x1000000 reserved by the kernel's alignment requirement. Previously, the platform_gen.yaml reported only the 0x0 to 0x1000 region,

    devices:
    - end: 0x1000 start: 0x0
    - end: 0xff800000 start: 0x3b400000
    - end: 0xff841000 start: 0xff801000
    - end: 0x100000000000 start: 0xff843000
    memory:
    - end: 0x3b400000 start: 0x1000000

I will be following this commit up with a PR to instead make the alignment-reserved region into a new memory region, since there's not any reason why userspace can't use this memory.

This has been tested on a few platforms with sel4test and with microkit on the pi4B.

