### PR TITLE
asid_map_t,aarch32 feature (DRAFT)

### DIFF
--- a/include/arch/arm/arch/32/mode/fastpath/fastpath.h
+++ b/include/arch/arm/arch/32/mode/fastpath/fastpath.h
@@ -47,7 +47,7 @@ static inline void FORCE_INLINE switchToThread_fp(tcb_t *thread, pde_t *cap_pd, 
     if (config_set(CONFIG_ARM_HYPERVISOR_SUPPORT)) {
         vcpu_switch(thread->tcbArch.tcbVCPU);
     }
-    hw_asid = pde_pde_invalid_get_stored_hw_asid(stored_hw_asid);
+    hw_asid = (hw_asid_t)(stored_hw_asid.words[0] & 0xffff);
     armv_contextSwitch_HWASID(cap_pd, hw_asid);
 
 #ifdef CONFIG_BENCHMARK_TRACK_UTILISATION

--- a/include/arch/arm/arch/32/mode/kernel/vspace.h
+++ b/include/arch/arm/arch/32/mode/kernel/vspace.h
@@ -41,6 +41,7 @@ struct lookupPTSlot_ret {
 };
 typedef struct lookupPTSlot_ret lookupPTSlot_ret_t;
 
+
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
 hw_asid_t getHWASID(asid_t asid);
 #endif
@@ -59,6 +60,7 @@ void flushPage(vm_page_size_t page_size, pde_t *pd, asid_t asid, word_t vptr);
 void flushTable(pde_t *pd, asid_t asid, word_t vptr, pte_t *pt);
 void flushSpace(asid_t asid);
 void invalidateTLBByASID(asid_t asid);
+asid_map_t findMapForASID(asid_t asid);
 
 bool_t CONST isIOSpaceFrameCap(cap_t cap);
 

--- a/include/arch/arm/arch/32/mode/kernel/vspace.h
+++ b/include/arch/arm/arch/32/mode/kernel/vspace.h
@@ -11,9 +11,6 @@
 #include <api/failures.h>
 #include <object/structures.h>
 
-/* PD slot reserved for storing the PD's allocated hardware ASID */
-#define PD_ASID_SLOT (0xff000000 >> (PT_INDEX_BITS + PAGE_BITS))
-
 enum pde_pte_tag {
     ME_PDE,
     ME_PTE
@@ -63,13 +60,4 @@ void invalidateTLBByASID(asid_t asid);
 asid_map_t findMapForASID(asid_t asid);
 
 bool_t CONST isIOSpaceFrameCap(cap_t cap);
-
-/* Reserved memory ranges */
-static const region_t BOOT_RODATA mode_reserved_region[] = {
-    {
-        (PD_ASID_SLOT + 0) << ARMSectionBits,
-                           (PD_ASID_SLOT + 1) << ARMSectionBits
-    }
-};
-#define MODE_RESERVED ARRAY_SIZE(mode_reserved_region)
 

--- a/include/arch/arm/arch/32/mode/object/structures.bf
+++ b/include/arch/arm/arch/32/mode/object/structures.bf
@@ -261,9 +261,7 @@ block stored_hw_asid {
 
 -- Page directory entries
 block pde_invalid {
-    field stored_hw_asid 8
-    field stored_asid_valid 1
-    padding 21
+    padding 30
     field pdeType 2
 }
 
@@ -359,9 +357,7 @@ tagged_union pte pteSize {
 
 block pdeS2_invalid {
     padding 32
-    field stored_hw_asid 8
-    field stored_asid_valid 1
-    padding 21
+    padding 30
     field pdeS2Type 2
 }
 
@@ -613,7 +609,9 @@ block asid_map_none {
 block asid_map_vspace {
     field_high vspace_root          32
 
-    padding                         30
+    padding                         21
+    field hw_asid                   8
+    field hw_asid_valid             1
     field type                      2
 }
 

--- a/include/arch/arm/arch/32/mode/object/structures.bf
+++ b/include/arch/arm/arch/32/mode/object/structures.bf
@@ -17,17 +17,28 @@ base 32
 
 -- 4k frame (these have a separate cap type as there is no room to
 -- store their size)
-block small_frame_cap {
-    field capFMappedASIDLow  10
+block small_frame_cap (
+    capFMappedASIDLow,
+    capFVMRights,
+    capFMappedAddress,
+    capFIsDevice,
+#ifdef CONFIG_ARM_SMMU
+    capFIsIOSpace,
+#endif
+    capFMappedASIDHigh,
+    capFBasePtr,
+    capType
+) {
+    field capFMappedASIDLow  9
     field capFVMRights       2
+    field capFIsDevice       1
     field_high capFMappedAddress 20
 
-    field capFIsDevice       1
 #ifdef CONFIG_TK1_SMMU
     field capFIsIOSpace      1
-    field capFMappedASIDHigh 6
-#else
     field capFMappedASIDHigh 7
+#else
+    field capFMappedASIDHigh 8
 #endif
     field_high capFBasePtr  20
     field capType            4
@@ -36,13 +47,14 @@ block small_frame_cap {
 -- 64k, 1M, 16M frames
 block frame_cap {
     field capFSize           2
-    field capFMappedASIDLow  10
+    field capFMappedASIDLow  9
     field capFVMRights       2
+    padding                  1
     field_high capFMappedAddress 18
 
-    padding                  2
+    padding                  1
     field capFIsDevice       1
-    field capFMappedASIDHigh 7
+    field capFMappedASIDHigh 8
     field_high capFBasePtr  18
     field capType            4
 }
@@ -590,5 +602,24 @@ block dbg_wcr {
     field enabled 1
 }
 #endif /* CONFIG_HARDWARE_DEBUG_API */
+
+block asid_map_none {
+    padding                         32
+
+    padding                         30
+    field type                      2
+}
+
+block asid_map_vspace {
+    field_high vspace_root          32
+
+    padding                         30
+    field type                      2
+}
+
+tagged_union asid_map type {
+    tag asid_map_none 0
+    tag asid_map_vspace 1
+}
 
 #include <sel4/arch/shared_types.bf>

--- a/include/arch/arm/arch/32/mode/object/structures.h
+++ b/include/arch/arm/arch/32/mode/object/structures.h
@@ -89,7 +89,7 @@ typedef word_t pde_type_t;
 #define LPAE_PT_REF(p) ((unsigned int)p)
 
 struct asid_pool {
-    pde_t *array[BIT(asidLowBits)];
+    asid_map_t array[BIT(asidLowBits)];
 };
 
 typedef struct asid_pool asid_pool_t;

--- a/include/arch/arm/arch/64/mode/kernel/vspace.h
+++ b/include/arch/arm/arch/64/mode/kernel/vspace.h
@@ -29,12 +29,6 @@ hw_asid_t getHWASID(asid_t asid);
 
 asid_map_t findMapForASID(asid_t asid);
 
-#ifdef __clang__
-static const region_t BOOT_RODATA mode_reserved_region[] = {};
-#else
-static const region_t BOOT_RODATA *mode_reserved_region = NULL;
-#endif
-
 #define PAR_EL1_MASK 0x0000fffffffff000ul
 #define GET_PAR_ADDR(x) ((x) & PAR_EL1_MASK)
 

--- a/include/arch/arm/arch/bootinfo.h
+++ b/include/arch/arm/arch/bootinfo.h
@@ -12,19 +12,17 @@
 
 /* The max number of free memory regions is:
  * +1 for each available physical memory region (elements in avail_p_regs)
- * +1 for each MODE_RESERVED region, there might be none
  * +1 to allow the kernel to release its own boot data region
  * +1 for a possible gap between ELF images and rootserver objects
  */
-#define MAX_NUM_FREEMEM_REG (ARRAY_SIZE(avail_p_regs) + MODE_RESERVED + 1 + 1)
+#define MAX_NUM_FREEMEM_REG (ARRAY_SIZE(avail_p_regs) + 1 + 1)
 
 /* The regions reserved by the boot code are:
  * +1 for kernel
  * +1 for device tree binary
  * +1 for user image.
- * +1 for each the MODE_RESERVED region, there might be none
  */
-#define NUM_RESERVED_REGIONS (3 + MODE_RESERVED)
+#define NUM_RESERVED_REGIONS (3)
 
 
 /* The maximum number of reserved regions is:

--- a/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/constants.h
@@ -211,14 +211,15 @@ typedef enum {
 #define seL4_VSpaceBits seL4_PageDirBits
 
 #ifdef CONFIG_TK1_SMMU
-#define seL4_NumASIDPoolsBits 6
-#else
 #define seL4_NumASIDPoolsBits 7
+#else
+#define seL4_NumASIDPoolsBits 8
 #endif
 #define seL4_ASIDPoolBits 12
-#define seL4_ASIDPoolIndexBits 10
+#define seL4_ASIDPoolIndexBits 9
 #define seL4_ARM_VCPUBits       12
 #define seL4_IOPageTableBits    12
+#define seL4_ASIDMapSizeBits 3
 
 /* bits in a word */
 #define seL4_WordBits (sizeof(seL4_Word) * 8)
@@ -228,7 +229,7 @@ typedef enum {
 #ifndef __ASSEMBLER__
 SEL4_SIZE_SANITY(seL4_PageTableEntryBits, seL4_PageTableIndexBits, seL4_PageTableBits);
 SEL4_SIZE_SANITY(seL4_PageDirEntryBits,   seL4_PageDirIndexBits,   seL4_PageDirBits);
-SEL4_SIZE_SANITY(seL4_WordSizeBits, seL4_ASIDPoolIndexBits, seL4_ASIDPoolBits);
+SEL4_SIZE_SANITY(seL4_ASIDMapSizeBits, seL4_ASIDPoolIndexBits, seL4_ASIDPoolBits);
 #ifdef seL4_PGDBits
 SEL4_SIZE_SANITY(seL4_PGDEntryBits, seL4_PGDIndexBits, seL4_PGDBits);
 #endif

--- a/src/arch/arm/32/kernel/vspace.c
+++ b/src/arch/arm/32/kernel/vspace.c
@@ -591,7 +591,7 @@ BOOT_CODE void activate_kernel_vspace(void)
 BOOT_CODE void write_it_asid_pool(cap_t it_ap_cap, cap_t it_pd_cap)
 {
     asid_pool_t *ap = ASID_POOL_PTR(pptr_of_cap(it_ap_cap));
-    asid_map_t asid_map = asid_map_asid_map_vspace_new(pptr_of_cap(it_pd_cap));
+    asid_map_t asid_map = asid_map_asid_map_vspace_new(pptr_of_cap(it_pd_cap), 0, false);
     ap->array[ASID_LOW(IT_ASID)] = asid_map;
     armKSASIDTable[ASID_HIGH(IT_ASID)] = ap;
 }
@@ -608,6 +608,16 @@ asid_map_t findMapForASID(asid_t asid)
     }
 
     return poolPtr->array[ASID_LOW(asid)];
+}
+
+static asid_map_t *findMapRefForASID(asid_t asid)
+{
+    asid_pool_t        *poolPtr;
+
+    poolPtr = armKSASIDTable[ASID_HIGH(asid)];
+    assert(poolPtr != NULL);
+
+    return &poolPtr->array[ASID_LOW(asid)];
 }
 
 findPDForASID_ret_t findPDForASID(asid_t asid)
@@ -1075,52 +1085,24 @@ pde_t *pageTableMapped(asid_t asid, vptr_t vaddr, pte_t *pt)
 
 static void invalidateASID(asid_t asid)
 {
-    asid_pool_t *asidPool;
-    pde_t *pd;
+    asid_map_t *asid_map;
 
-    asidPool = armKSASIDTable[ASID_HIGH(asid)];
-    assert(asidPool);
+    asid_map = findMapRefForASID(asid);
+    assert(asid_map_get_type(*asid_map) == asid_map_asid_map_vspace);
 
-    asid_map_t asid_map = asidPool->array[ASID_LOW(asid)];
-    assert(asid_map_get_type(asid_map) == asid_map_asid_map_vspace);
-
-    pd = (pde_t *)asid_map_asid_map_vspace_get_vspace_root(asid_map);
-
-    pd[PD_ASID_SLOT] = pde_pde_invalid_new(0, false);
-}
-
-static pde_t PURE loadHWASID(asid_t asid)
-{
-    asid_pool_t *asidPool;
-    pde_t *pd;
-
-    asidPool = armKSASIDTable[ASID_HIGH(asid)];
-    assert(asidPool);
-
-    asid_map_t asid_map = asidPool->array[ASID_LOW(asid)];
-    assert(asid_map_get_type(asid_map) == asid_map_asid_map_vspace);
-
-    pd = (pde_t *)asid_map_asid_map_vspace_get_vspace_root(asid_map);
-
-    return pd[PD_ASID_SLOT];
+    asid_map_asid_map_vspace_ptr_set_hw_asid(asid_map, 0);
+    asid_map_asid_map_vspace_ptr_set_hw_asid_valid(asid_map, false);
 }
 
 static void storeHWASID(asid_t asid, hw_asid_t hw_asid)
 {
-    asid_pool_t *asidPool;
-    pde_t *pd;
+    asid_map_t *asid_map;
 
-    asidPool = armKSASIDTable[ASID_HIGH(asid)];
-    assert(asidPool);
+    asid_map = findMapRefForASID(asid);
+    assert(asid_map_get_type(*asid_map) == asid_map_asid_map_vspace);
 
-    asid_map_t asid_map = asidPool->array[ASID_LOW(asid)];
-    assert(asid_map_get_type(asid_map) == asid_map_asid_map_vspace);
-
-    pd = (pde_t *)asid_map_asid_map_vspace_get_vspace_root(asid_map);
-
-    /* Store HW ASID in the last entry
-       Masquerade as an invalid PDE */
-    pd[PD_ASID_SLOT] = pde_pde_invalid_new(hw_asid, true);
+    asid_map_asid_map_vspace_ptr_set_hw_asid(asid_map, hw_asid);
+    asid_map_asid_map_vspace_ptr_set_hw_asid_valid(asid_map, true);
 
     armKSHWASIDTable[hw_asid] = asid;
 }
@@ -1157,11 +1139,11 @@ hw_asid_t findFreeHWASID(void)
 
 hw_asid_t getHWASID(asid_t asid)
 {
-    pde_t stored_hw_asid;
+    asid_map_t asid_map;
 
-    stored_hw_asid = loadHWASID(asid);
-    if (pde_pde_invalid_get_stored_asid_valid(stored_hw_asid)) {
-        return pde_pde_invalid_get_stored_hw_asid(stored_hw_asid);
+    asid_map = findMapForASID(asid);
+    if (asid_map_asid_map_vspace_get_hw_asid_valid(asid_map)) {
+        return asid_map_asid_map_vspace_get_hw_asid(asid_map);
     } else {
         hw_asid_t new_hw_asid;
 
@@ -1173,11 +1155,11 @@ hw_asid_t getHWASID(asid_t asid)
 
 static void invalidateASIDEntry(asid_t asid)
 {
-    pde_t stored_hw_asid;
+    asid_map_t asid_map;
 
-    stored_hw_asid = loadHWASID(asid);
-    if (pde_pde_invalid_get_stored_asid_valid(stored_hw_asid)) {
-        armKSHWASIDTable[pde_pde_invalid_get_stored_hw_asid(stored_hw_asid)] =
+    asid_map = findMapForASID(asid);
+    if (asid_map_asid_map_vspace_get_hw_asid_valid(asid_map)) {
+        armKSHWASIDTable[asid_map_asid_map_vspace_get_hw_asid(asid_map)] =
             asidInvalid;
     }
     invalidateASID(asid);
@@ -1194,7 +1176,7 @@ void unmapPageTable(asid_t asid, vptr_t vaddr, pte_t *pt)
         pdIndex = vaddr >> (PT_INDEX_BITS + PAGE_BITS);
         pdSlot = pd + pdIndex;
 
-        *pdSlot = pde_pde_invalid_new(0, 0);
+        *pdSlot = pde_pde_invalid_new();
         cleanByVA_PoU((word_t)pdSlot, addrFromPPtr(pdSlot));
         flushTable(pd, asid, vaddr, pt);
     }
@@ -1429,7 +1411,7 @@ void unmapPage(vm_page_size_t page_size, asid_t asid, vptr_t vptr, void *pptr)
             return;
         }
 
-        *pd = pde_pde_invalid_new(0, 0);
+        *pd = pde_pde_invalid_new();
         cleanByVA_PoU((word_t)pd, addrFromPPtr(pd));
 
         break;
@@ -1456,7 +1438,7 @@ void unmapPage(vm_page_size_t page_size, asid_t asid, vptr_t vptr, void *pptr)
         }
 
         for (i = 0; i < SECTIONS_PER_SUPER_SECTION; i++) {
-            pd[i] = pde_pde_invalid_new(0, 0);
+            pd[i] = pde_pde_invalid_new();
         }
         cleanCacheRange_PoU((word_t)&pd[0], LAST_BYTE_PDE(pd, SECTIONS_PER_SUPER_SECTION),
                             addrFromPPtr(&pd[0]));
@@ -1475,7 +1457,7 @@ void unmapPage(vm_page_size_t page_size, asid_t asid, vptr_t vptr, void *pptr)
 
 void flushPage(vm_page_size_t page_size, pde_t *pd, asid_t asid, word_t vptr)
 {
-    pde_t stored_hw_asid;
+    asid_map_t asid_map;
     word_t base_addr;
     bool_t root_switched;
 
@@ -1483,13 +1465,13 @@ void flushPage(vm_page_size_t page_size, pde_t *pd, asid_t asid, word_t vptr)
 
     /* Switch to the address space to allow a cache clean by VA */
     root_switched = setVMRootForFlush(pd, asid);
-    stored_hw_asid = loadHWASID(asid);
+    asid_map = findMapForASID(asid);
 
-    if (pde_pde_invalid_get_stored_asid_valid(stored_hw_asid)) {
+    if (asid_map_asid_map_vspace_get_hw_asid_valid(asid_map)) {
         base_addr = vptr & ~MASK(12);
 
         /* Do the TLB flush */
-        invalidateTranslationSingle(base_addr | pde_pde_invalid_get_stored_hw_asid(stored_hw_asid));
+        invalidateTranslationSingle(base_addr | asid_map_asid_map_vspace_get_hw_asid(asid_map));
 
         if (root_switched) {
             setVMRoot(NODE_STATE(ksCurThread));
@@ -1499,17 +1481,17 @@ void flushPage(vm_page_size_t page_size, pde_t *pd, asid_t asid, word_t vptr)
 
 void flushTable(pde_t *pd, asid_t asid, word_t vptr, pte_t *pt)
 {
-    pde_t stored_hw_asid;
+    asid_map_t asid_map;
     bool_t root_switched;
 
     assert((vptr & MASK(PT_INDEX_BITS + ARMSmallPageBits)) == 0);
 
     /* Switch to the address space to allow a cache clean by VA */
     root_switched = setVMRootForFlush(pd, asid);
-    stored_hw_asid = loadHWASID(asid);
+    asid_map = findMapForASID(asid);
 
-    if (pde_pde_invalid_get_stored_asid_valid(stored_hw_asid)) {
-        invalidateTranslationASID(pde_pde_invalid_get_stored_hw_asid(stored_hw_asid));
+    if (asid_map_asid_map_vspace_get_hw_asid_valid(asid_map)) {
+        invalidateTranslationASID(asid_map_asid_map_vspace_get_hw_asid(asid_map));
         if (root_switched) {
             setVMRoot(NODE_STATE(ksCurThread));
         }
@@ -1518,9 +1500,9 @@ void flushTable(pde_t *pd, asid_t asid, word_t vptr, pte_t *pt)
 
 void flushSpace(asid_t asid)
 {
-    pde_t stored_hw_asid;
+    asid_map_t asid_map;
 
-    stored_hw_asid = loadHWASID(asid);
+    asid_map = findMapForASID(asid);
 
     /* Clean the entire data cache, to guarantee that any VAs mapped
      * in the deleted space are clean (because we can't clean by VA after
@@ -1529,28 +1511,28 @@ void flushSpace(asid_t asid)
 
     /* If the given ASID doesn't have a hardware ASID
      * assigned, then it can't have any mappings in the TLB */
-    if (!pde_pde_invalid_get_stored_asid_valid(stored_hw_asid)) {
+    if (!asid_map_asid_map_vspace_get_hw_asid_valid(asid_map)) {
         return;
     }
 
     /* Do the TLB flush */
-    invalidateTranslationASID(pde_pde_invalid_get_stored_hw_asid(stored_hw_asid));
+    invalidateTranslationASID(asid_map_asid_map_vspace_get_hw_asid(asid_map));
 }
 
 void invalidateTLBByASID(asid_t asid)
 {
-    pde_t stored_hw_asid;
+    asid_map_t asid_map;
 
-    stored_hw_asid = loadHWASID(asid);
+    asid_map = findMapForASID(asid);
 
     /* If the given ASID doesn't have a hardware ASID
      * assigned, then it can't have any mappings in the TLB */
-    if (!pde_pde_invalid_get_stored_asid_valid(stored_hw_asid)) {
+    if (!asid_map_asid_map_vspace_get_hw_asid_valid(asid_map)) {
         return;
     }
 
     /* Do the TLB flush */
-    invalidateTranslationASID(pde_pde_invalid_get_stored_hw_asid(stored_hw_asid));
+    invalidateTranslationASID(asid_map_asid_map_vspace_get_hw_asid(asid_map));
 }
 
 static inline bool_t CONST checkVPAlignment(vm_page_size_t sz, word_t w)
@@ -1984,7 +1966,7 @@ static exception_t performASIDPoolInvocation(asid_t asid, asid_pool_t *poolPtr,
     asid_map_t asid_map;
     cap_page_directory_cap_ptr_set_capPDMappedASID(&pdCapSlot->cap, asid);
     cap_page_directory_cap_ptr_set_capPDIsMapped(&pdCapSlot->cap, 1);
-    asid_map = asid_map_asid_map_vspace_new(cap_page_directory_cap_get_capPDBasePtr(pdCapSlot->cap));
+    asid_map = asid_map_asid_map_vspace_new(cap_page_directory_cap_get_capPDBasePtr(pdCapSlot->cap), 0, false);
     poolPtr->array[ASID_LOW(asid)] = asid_map;
 
     return EXCEPTION_NONE;

--- a/src/arch/arm/32/kernel/vspace.c
+++ b/src/arch/arm/32/kernel/vspace.c
@@ -1189,9 +1189,7 @@ void copyGlobalMappings(pde_t *newPD)
     pde_t *global_pd = armKSGlobalPD;
 
     for (i = PPTR_BASE >> ARMSectionBits; i < BIT(PD_INDEX_BITS); i++) {
-        if (i != PD_ASID_SLOT) {
-            newPD[i] = global_pd[i];
-        }
+        newPD[i] = global_pd[i];
     }
 #endif
 }

--- a/src/arch/arm/kernel/boot.c
+++ b/src/arch/arm/kernel/boot.c
@@ -60,51 +60,17 @@ BOOT_CODE static bool_t arch_init_freemem(p_region_t ui_p_reg,
         index++;
     }
 
-    /* Reserve the user image region and the mode-reserved regions. For now,
-     * only one mode-reserved region is supported, because this is all that is
-     * needed.
-     */
-    if (MODE_RESERVED > 1) {
-        printf("ERROR: MODE_RESERVED > 1 unsupported!\n");
-        return false;
-    }
+    /* Reserve the user image region. */
     if (ui_p_reg.start < PADDR_TOP) {
         region_t ui_reg = paddr_to_pptr_reg(ui_p_reg);
-        if (MODE_RESERVED == 1) {
-            if (index + 1 >= ARRAY_SIZE(reserved)) {
-                printf("ERROR: no slot to add the user image and the "
-                       "mode-reserved region to the reserved regions\n");
-                return false;
-            }
-            if (ui_reg.end > mode_reserved_region[0].start) {
-                reserved[index] = mode_reserved_region[0];
-                index++;
-                reserved[index] = ui_reg;
-            } else {
-                reserved[index] = ui_reg;
-                index++;
-                reserved[index] = mode_reserved_region[0];
-            }
-            index++;
-        } else {
-            if (index >= ARRAY_SIZE(reserved)) {
-                printf("ERROR: no slot to add the user image to the reserved"
-                       "regions\n");
-                return false;
-            }
-            reserved[index] = ui_reg;
-            index++;
+        if (index >= ARRAY_SIZE(reserved)) {
+            printf("ERROR: no slot to add the user image to the reserved"
+                   "regions\n");
+            return false;
         }
+        reserved[index] = ui_reg;
+        index++;
     } else {
-        if (MODE_RESERVED == 1) {
-            if (index >= ARRAY_SIZE(reserved)) {
-                printf("ERROR: no slot to add the mode-reserved region\n");
-                return false;
-            }
-            reserved[index] = mode_reserved_region[0];
-            index++;
-        }
-
         /* Reserve the ui_p_reg region still so it doesn't get turned into device UT. */
         reserve_region(ui_p_reg);
     }


### PR DESCRIPTION
This is an updated patch set for aarch32 asid_map_t feature.

The asid_map_t feature associates additional metadata for a vspace root page table object by adding a larger entry in the seL4 asid pool for each asid ID. On aarch32 platforms there are less TLB hardware ASIDs than kernel vspace asids.
On aarch32 the kernel reserved a slot in the virtual address space root page table for holding the currently associated hw asid for the address space. 
With asid_map_t storing the hw_asid, this slot can be made available again. It returns up to 1MiB of memory back to user level that the kernel was reserving because the reserved slot at the end of the kernel mapping window.