### PR TITLE
trivial: use KERNEL_ELF_TOP over ki_end

### DIFF
--- a/src/arch/riscv/kernel/vspace.c
+++ b/src/arch/riscv/kernel/vspace.c
@@ -109,7 +109,7 @@ BOOT_CODE VISIBLE void map_kernel_window(void)
      * KERNEL_ELF_PHYS_BASE  */
     assert(CONFIG_PT_LEVELS > 1 && CONFIG_PT_LEVELS <= 4);
     /* Kernel image finishes before KDEV_BASE */
-    assert(KDEV_BASE >= (word_t)ki_end);
+    assert(KERNEL_ELF_TOP <= KDEV_BASE);
 
     /* kernel window starts at PPTR_BASE */
     word_t pptr = PPTR_BASE;

--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -39,7 +39,7 @@ BOOT_CODE p_region_t get_p_reg_kernel_img(void)
 {
     return (p_region_t) {
         .start = kpptr_to_paddr((const void *)KERNEL_ELF_BASE),
-        .end   = kpptr_to_paddr(ki_end)
+        .end   = kpptr_to_paddr((const void *)KERNEL_ELF_TOP)
     };
 }
 


### PR DESCRIPTION
Split out from PR 1516.

This is just being consistent.