### PR TITLE
boot: Make init_kernel arguments word sized

### DIFF
--- a/include/arch/arm/arch/kernel/boot.h
+++ b/include/arch/arm/arch/kernel/boot.h
@@ -18,8 +18,8 @@ void init_kernel(
     sword_t pv_offset,
     vptr_t  v_entry,
     paddr_t dtb_addr_p,
-    uint64_t dtb_size,
+    paddr_t dtb_size,
     paddr_t extra_device_addr_p,
-    uint64_t extra_device_size
+    paddr_t extra_device_size
 );
 

--- a/include/arch/riscv/arch/kernel/boot.h
+++ b/include/arch/riscv/arch/kernel/boot.h
@@ -20,9 +20,9 @@ void init_kernel(
     sword_t pv_offset,
     vptr_t  v_entry,
     paddr_t dtb_addr_p,
-    uint64_t dtb_size,
+    paddr_t dtb_size,
     paddr_t extra_device_addr_p,
-    uint64_t extra_device_size
+    paddr_t extra_device_size
 #ifdef ENABLE_SMP_SUPPORT
     ,
     word_t hart_id,

--- a/src/arch/arm/kernel/boot.c
+++ b/src/arch/arm/kernel/boot.c
@@ -656,9 +656,9 @@ BOOT_CODE VISIBLE void init_kernel(
     sword_t pv_offset,
     vptr_t  v_entry,
     paddr_t dtb_addr_p,
-    uint64_t dtb_size,
+    paddr_t dtb_size,
     paddr_t extra_device_addr_p,
-    uint64_t extra_device_size
+    paddr_t extra_device_size
 )
 {
     bool_t result;

--- a/src/arch/riscv/kernel/boot.c
+++ b/src/arch/riscv/kernel/boot.c
@@ -478,9 +478,9 @@ BOOT_CODE VISIBLE void init_kernel(
     sword_t pv_offset,
     vptr_t  v_entry,
     paddr_t dtb_addr_p,
-    uint64_t dtb_size,
+    paddr_t dtb_size,
     paddr_t extra_device_addr_p,
-    uint64_t extra_device_size
+    paddr_t extra_device_size
 #ifdef ENABLE_SMP_SUPPORT
     ,
     word_t hart_id,


### PR DESCRIPTION
The kernel head.S files for RISCV and Arm assume all arguments are word sized. Previously, the patch to boot with an additional device reserved region (c8ef493d038b81cc43f82c0190788e4b3bdb4d9d) only supported aarch64 booting.

Make the 64-bit size arguments word_t width so that they continue to be 64-bit on 64bit architectures, but only 32-bit on 32-bit architectures to stay within the word-sized argument calling convention.

None of the 32-bit platforms support memory sizes larger than 32-bit so these dtb and reserved device regions cannot be larger than 32-bit sized.