### PR TITLE
x86: pass the EFI system table pointer to root task

### DIFF
--- a/include/arch/x86/arch/kernel/boot.h
+++ b/include/arch/x86/arch/kernel/boot.h
@@ -38,7 +38,9 @@ bool_t init_sys_state(
     acpi_rsdp_t      *acpi_rsdp,
     seL4_X86_BootInfo_VBE *vbe,
     seL4_X86_BootInfo_mmap_t *mb_mmap,
-    seL4_X86_BootInfo_fb_t *fb_info
+    seL4_X86_BootInfo_fb_t *fb_info,
+    uint32_t      efi_systbl_ptr32,
+    uint64_t      efi_systbl_ptr64
 );
 
 bool_t init_cpu(

--- a/include/arch/x86/arch/kernel/boot_sys.h
+++ b/include/arch/x86/arch/kernel/boot_sys.h
@@ -30,6 +30,8 @@ typedef struct boot_state {
     seL4_X86_BootInfo_VBE vbe_info; /* Potential VBE information from multiboot */
     seL4_X86_BootInfo_mmap_t mb_mmap_info; /* memory map information from multiboot */
     seL4_X86_BootInfo_fb_t fb_info; /* framebuffer information as set by bootloader */
+    uint32_t     efi_ptr32;   /* 32-bit EFI system table pointer */
+    uint64_t     efi_ptr64;   /* 64-bit EFI system table pointer */
 } boot_state_t;
 
 extern boot_state_t boot_state;

--- a/include/arch/x86/arch/kernel/multiboot2.h
+++ b/include/arch/x86/arch/kernel/multiboot2.h
@@ -48,6 +48,8 @@ enum multiboot2_tags {
     MULTIBOOT2_TAG_MODULE  = 3,
     MULTIBOOT2_TAG_MEMORY  = 6,
     MULTIBOOT2_TAG_FB      = 8,
+    MULTIBOOT2_TAG_EFI32   = 11, /* 32-bit EFI system table pointer */
+    MULTIBOOT2_TAG_EFI64   = 12, /* 64-bit EFI system table pointer */
     MULTIBOOT2_TAG_ACPI_1  = 14,
     MULTIBOOT2_TAG_ACPI_2  = 15,
 };

--- a/libsel4/include/sel4/bootinfo_types.h
+++ b/libsel4/include/sel4/bootinfo_types.h
@@ -106,6 +106,7 @@ typedef enum {
     SEL4_BOOTINFO_HEADER_X86_FRAMEBUFFER    = 4,
     SEL4_BOOTINFO_HEADER_X86_TSC_FREQ       = 5, /* frequency is in MHz */
     SEL4_BOOTINFO_HEADER_FDT                = 6, /* device tree */
+    SEL4_BOOTINFO_HEADER_X86_EFI_SYSTBL_PTR = 7, /* EFI system table pointer on x86 */
     /* Add more IDs here, the two elements below must always be at the end. */
     SEL4_BOOTINFO_HEADER_NUM,
     SEL4_FORCE_LONG_ENUM(seL4_BootInfoID)

--- a/src/arch/x86/kernel/boot.c
+++ b/src/arch/x86/kernel/boot.c
@@ -94,7 +94,9 @@ BOOT_CODE bool_t init_sys_state(
     acpi_rsdp_t      *acpi_rsdp,
     seL4_X86_BootInfo_VBE *vbe,
     seL4_X86_BootInfo_mmap_t *mb_mmap,
-    seL4_X86_BootInfo_fb_t *fb_info
+    seL4_X86_BootInfo_fb_t *fb_info,
+    uint32_t      efi_systbl_ptr32,
+    uint64_t      efi_systbl_ptr64
 )
 {
     cap_t         root_cnode_cap;
@@ -131,6 +133,12 @@ BOOT_CODE bool_t init_sys_state(
     }
     if (fb_info && fb_info->addr) {
         extra_bi_size += sizeof(seL4_BootInfoHeader) + sizeof(*fb_info);
+    }
+    if (efi_systbl_ptr64) {
+        extra_bi_size += sizeof(seL4_BootInfoHeader) + sizeof(uint64_t);
+    }
+    if (efi_systbl_ptr32) {
+        extra_bi_size += sizeof(seL4_BootInfoHeader) + sizeof(uint32_t);
     }
 
     word_t mb_mmap_size = sizeof(seL4_X86_BootInfo_mmap_t);
@@ -224,6 +232,26 @@ BOOT_CODE bool_t init_sys_state(
         extra_bi_offset += sizeof(header);
         *(uint32_t *)(extra_bi_region.start + extra_bi_offset) = tsc_freq;
         extra_bi_offset += 4;
+    }
+
+    /* populate EFI system table pointer block */
+    if (efi_systbl_ptr64) {
+        seL4_BootInfoHeader header;
+        header.id = SEL4_BOOTINFO_HEADER_X86_EFI_SYSTBL_PTR;
+        header.len = sizeof(header) + sizeof(uint64_t);
+        *(seL4_BootInfoHeader *)(extra_bi_region.start + extra_bi_offset) = header;
+        extra_bi_offset += sizeof(header);
+        *(uint64_t *)(extra_bi_region.start + extra_bi_offset) = efi_systbl_ptr64;
+        extra_bi_offset += sizeof(uint64_t);
+    }
+    if (efi_systbl_ptr32) {
+        seL4_BootInfoHeader header;
+        header.id = SEL4_BOOTINFO_HEADER_X86_EFI_SYSTBL_PTR;
+        header.len = sizeof(header) + sizeof(uint32_t);
+        *(seL4_BootInfoHeader *)(extra_bi_region.start + extra_bi_offset) = header;
+        extra_bi_offset += sizeof(header);
+        *(uint32_t *)(extra_bi_region.start + extra_bi_offset) = efi_systbl_ptr32;
+        extra_bi_offset += sizeof(uint32_t);
     }
 
 #ifdef CONFIG_KERNEL_MCS

--- a/src/arch/x86/kernel/boot_sys.c
+++ b/src/arch/x86/kernel/boot_sys.c
@@ -179,7 +179,9 @@ static BOOT_CODE bool_t try_boot_sys_node(cpu_id_t cpu_id)
             &boot_state.acpi_rsdp,
             &boot_state.vbe_info,
             &boot_state.mb_mmap_info,
-            &boot_state.fb_info
+            &boot_state.fb_info,
+            boot_state.efi_ptr32,
+            boot_state.efi_ptr64
         )) {
         return false;
     }
@@ -629,6 +631,18 @@ static BOOT_CODE bool_t try_boot_sys_mbi2(
         if (tag->type == MULTIBOOT2_TAG_CMDLINE) {
             char const *const cmdline = (char const * const)(behind_tag);
             cmdline_parse(cmdline, &cmdline_opt);
+        } else if (tag->type == MULTIBOOT2_TAG_EFI32) {
+            if (tag->size - sizeof(*tag) == sizeof(uint32_t)) {
+                boot_state.efi_ptr32 = *(uint32_t *)behind_tag;
+                printf("32-bit EFI system table at physical address=0x%x\n",
+                       boot_state.efi_ptr32);
+            }
+        } else if (tag->type == MULTIBOOT2_TAG_EFI64) {
+            if (tag->size - sizeof(*tag) == sizeof(uint64_t)) {
+                boot_state.efi_ptr64 = *(uint64_t *)behind_tag;
+                printf("64-bit EFI system table at physical address=0x%llx\n",
+                       boot_state.efi_ptr64);
+            }
         } else if (tag->type == MULTIBOOT2_TAG_ACPI_1) {
             if (ACPI_V1_SIZE == tag->size - sizeof(*tag)) {
                 memcpy(&boot_state.acpi_rsdp, (void *)behind_tag, tag->size - sizeof(*tag));


### PR DESCRIPTION
Pass the EFI system table pointer supplied by the bootloader in the multiboot2 information structure to the root task, in the form of an extra bootinfo structure. The EFI system table remains (partially) valid after the boot loader has exited the EFI services, and contains pointers to firmware tables such as SMBIOS tables, which userspace tasks can then map using standard seL4 APIs.