### PR TITLE
x86: skip unaddressable memory for multiboot2 booting as well

### DIFF
--- a/src/arch/x86/kernel/boot_sys.c
+++ b/src/arch/x86/kernel/boot_sys.c
@@ -671,6 +671,7 @@ static BOOT_CODE bool_t try_boot_sys_mbi2(
                 printf("\tPhysical Memory Region from %llx size %llx type %u\n", m->addr, m->size, m->type);
                 if (m->addr != (uint64_t)(word_t)m->addr) {
                     printf("\t\tPhysical memory region not addressable\n");
+                    continue;
                 }
 
                 if (m->type == MULTIBOOT_MMAP_USEABLE_TYPE && m->addr >= HIGHMEM_PADDR) {


### PR DESCRIPTION
On 32-bit x86, when booting under multiboot1 the physical memories above 4GB are skipped and not included as usable memory regions. Make sure we also do this when booting under multiboot2.

If we don't do this, 32-bit machines with more than 4GB of RAM would not boot under multiboot2. For instance, on a test platform (GPD Micropc) the seL4 kernel gets the following memory regions from the bootloader
```
        Physical Memory Region from 0 size 3f000 type 1
        ...
        Physical Memory Region from 100000 size ff00000 type 1
Adding physical memory region 0x100000-0x10000000
        Physical Memory Region from 100000 size ff00000 type 1
        ...
        Physical Memory Region from 100000000 size 180000000 type 1
                Physical memory region not addressable
Adding physical memory region 0x0-0x1f400000
```
Despite the last region not being addressible, it still gets added, which leads to corruption later:
```
available phys memory regions: 3
  [100000..10000000)
  [12151000..1f400000)
  [0..1f400000)
ERROR: memory region 2 in wrong order
ERROR: free memory management initialization failed
```