### PR TITLE
Add SBI cap

### DIFF
--- a/include/arch/riscv/arch/32/mode/object/structures.bf
+++ b/include/arch/riscv/arch/32/mode/object/structures.bf
@@ -58,6 +58,16 @@ block asid_pool_cap {
     field       capType         4
 }
 
+#ifdef CONFIG_ALLOW_SBI_CALLS
+block sbi_cap {
+    field capSBIFIDBadge 30
+    field capSBIEIDBadged 1
+    field capSBIFIDBadged 1
+    field capSBIEIDBadge 28
+    field capType 4
+}
+#endif
+
 -- NB: odd numbers are arch caps (see isArchCap())
 tagged_union cap capType {
     mask 4 0xe
@@ -75,6 +85,9 @@ tagged_union cap capType {
     -- 4-bit tag arch caps
     tag frame_cap           1
     tag page_table_cap      3
+#ifdef CONFIG_ALLOW_SBI_CALLS
+    tag sbi_cap             5
+#endif
     tag asid_control_cap    11
     tag asid_pool_cap       13
 

--- a/include/arch/riscv/arch/64/mode/object/structures.bf
+++ b/include/arch/riscv/arch/64/mode/object/structures.bf
@@ -64,6 +64,17 @@ block asid_pool_cap {
     field_high  capASIDPool     37
 }
 
+#ifdef CONFIG_ALLOW_SBI_CALLS
+block sbi_cap {
+    field capSBIFIDBadge 64
+    field capType 5
+    field capSBIEIDBadge 28
+    field capSBIEIDBadged 1
+    field capSBIFIDBadged 1
+    padding 29
+}
+#endif
+
 -- NB: odd numbers are arch caps (see isArchCap())
 tagged_union cap capType {
     -- 5-bit tag caps
@@ -88,6 +99,9 @@ tagged_union cap capType {
     tag page_table_cap      3
     tag asid_control_cap    11
     tag asid_pool_cap       13
+#ifdef CONFIG_ALLOW_SBI_CALLS
+    tag sbi_cap             15
+#endif
 }
 
 ---- Arch-independent object types

--- a/include/arch/riscv/arch/object/sbi.h
+++ b/include/arch/riscv/arch/object/sbi.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#define NUM_SBI_REGS 8
+
+exception_t decodeRISCVSBIInvocation(word_t label, unsigned int length, cptr_t cptr,
+                                    cte_t *srcSlot, cap_t cap, bool_t call, word_t *buffer);
+

--- a/include/arch/riscv/arch/object/structures.h
+++ b/include/arch/riscv/arch/object/structures.h
@@ -145,6 +145,23 @@ static inline void *CONST cap_get_archCapPtr(cap_t cap)
 
 static inline bool_t CONST Arch_isCapRevocable(cap_t derivedCap, cap_t srcCap)
 {
+#ifdef CONFIG_ALLOW_SBI_CALLS
+    switch (cap_get_capType(derivedCap)) {
+    case cap_sbi_cap:
+        if (!cap_sbi_cap_get_capSBIEIDBadged(derivedCap) || !cap_sbi_cap_get_capSBIFIDBadged(derivedCap)) {
+            return true;
+        }
+
+        return (cap_sbi_cap_get_capSBIFIDBadge(derivedCap) !=
+            cap_sbi_cap_get_capSBIFIDBadge(srcCap) ||
+            cap_sbi_cap_get_capSBIEIDBadge(derivedCap) !=
+            cap_sbi_cap_get_capSBIEIDBadge(srcCap)
+            );
+
+    default:
+        return false;
+    }
+#endif
     return false;
 }
 

--- a/libsel4/arch_include/riscv/interfaces/object-api-arch.xml
+++ b/libsel4/arch_include/riscv/interfaces/object-api-arch.xml
@@ -42,6 +42,23 @@
             <member name="t6"/>
             <member name="tp"/>
     </struct>
+
+    <struct name="seL4_RISCV_SBIContext">
+        <member name="a0"/>
+        <member name="a1"/>
+        <member name="a2"/>
+        <member name="a3"/>
+        <member name="a4"/>
+        <member name="a5"/>
+        <member name="a6"/>
+        <member name="a7"/>
+    </struct>
+
+    <struct name="seL4_RISCV_SBIRet">
+        <member name="error"/>
+        <member name="value"/>
+    </struct>
+
     <interface name="seL4_RISCV_PageTable" manual_name="Page Table" cap_description="Capability to the page table to invoke.">
         <method id="RISCVPageTableMap" name="Map" manual_label="pagetable_map">
             <brief>
@@ -366,6 +383,25 @@
             </error>
         </method>
 
+    </interface>
+        <interface name="seL4_RISCV_SBI" manual_name="SBI" cap_description="Capability to allow threads to make SBI (Supervisor Binary Interface) calls.">
+        <method id="RISCVSBICall" name="Call" manual_name="SBI Call" manual_label="sbi_call">
+            <brief>
+                Specify SBI call
+            </brief>
+            <description>
+                Register a6 is for the SBI function ID (FID).
+                Register a7 is for the SBI extension ID (EID).
+                Registers a0-a5 are for the SBI call's arguments.
+                Takes a0-a7 as arguments to an SBI call which are defined as a seL4_RISCV_SBIContext
+                struct. The kernel makes the SBI call and then returns the registers a0 and a1
+                in a new seL4_RISCV_SBIRet as the result.
+            </description>
+            <param dir="in" name="sbi_args" type="seL4_RISCV_SBIContext"
+                description="The structure that has the provided arguments."/>
+            <param dir="out" name="sbi_ret" type="seL4_RISCV_SBIRet"
+                description="The structure to capture the responses."/>
+        </method>
     </interface>
 
 </api>

--- a/libsel4/arch_include/riscv/sel4/arch/types.h
+++ b/libsel4/arch_include/riscv/sel4/arch/types.h
@@ -16,6 +16,7 @@ typedef seL4_CPtr seL4_RISCV_Page;
 typedef seL4_CPtr seL4_RISCV_PageTable;
 typedef seL4_CPtr seL4_RISCV_ASIDControl;
 typedef seL4_CPtr seL4_RISCV_ASIDPool;
+typedef seL4_CPtr seL4_RISCV_SBI;
 
 
 #define seL4_EndpointBits     4
@@ -59,6 +60,22 @@ typedef struct seL4_UserContext_ {
 
     seL4_Word tp;
 } seL4_UserContext;
+
+typedef struct seL4_RISCV_SBIContext_ {
+    seL4_Word a0;
+    seL4_Word a1;
+    seL4_Word a2;
+    seL4_Word a3;
+    seL4_Word a4;
+    seL4_Word a5;
+    seL4_Word a6;
+    seL4_Word a7;
+} seL4_RISCV_SBIContext;
+
+typedef struct seL4_RISCV_SBIRet_ {
+    seL4_Word error;
+    seL4_Word value;
+} seL4_RISCV_SBIRet;
 
 typedef enum {
     seL4_RISCV_ExecuteNever = 0x1,

--- a/libsel4/include/sel4/bootinfo_types.h
+++ b/libsel4/include/sel4/bootinfo_types.h
@@ -28,7 +28,8 @@ enum seL4_RootCNodeCapSlots {
     seL4_CapSMMUCBControl       = 13, /* global SMMU CB controller cap, null cap if not supported */
     seL4_CapInitThreadSC        = 14, /* initial thread's scheduling context cap, null cap if not supported */
     seL4_CapSMC                 = 15, /* global SMC cap, null cap if not supported */
-    seL4_NumInitialCaps         = 16
+    seL4_CapSBI                 = 16, /* global SBI cap, null cap if not supported */
+    seL4_NumInitialCaps         = 17
 };
 
 /* Legacy code will have assumptions on the vspace root being a Page Directory

--- a/libsel4/tools/syscall_stub_gen.py
+++ b/libsel4/tools/syscall_stub_gen.py
@@ -361,7 +361,10 @@ def init_arch_types(wordsize, args):
             CapType("seL4_RISCV_PageTable", wordsize),
             CapType("seL4_RISCV_ASIDControl", wordsize),
             CapType("seL4_RISCV_ASIDPool", wordsize),
+            CapType("seL4_RISCV_SBI", wordsize),
             StructType("seL4_UserContext", wordsize * 32, wordsize),
+            StructType("seL4_RISCV_SBIContext", wordsize * 8, wordsize),
+            StructType("seL4_RISCV_SBIRet", wordsize * 2, wordsize),
         ],
         "riscv64": [
             Type("seL4_RISCV_VMAttributes", wordsize, wordsize),
@@ -369,7 +372,10 @@ def init_arch_types(wordsize, args):
             CapType("seL4_RISCV_PageTable", wordsize),
             CapType("seL4_RISCV_ASIDControl", wordsize),
             CapType("seL4_RISCV_ASIDPool", wordsize),
+            CapType("seL4_RISCV_SBI", wordsize),
             StructType("seL4_UserContext", wordsize * 32, wordsize),
+            StructType("seL4_RISCV_SBIContext", wordsize * 8, wordsize),
+            StructType("seL4_RISCV_SBIRet", wordsize * 2, wordsize),
         ]
     }
 

--- a/src/arch/riscv/config.cmake
+++ b/src/arch/riscv/config.cmake
@@ -50,6 +50,12 @@ config_option(
     DEPENDS "KernelArchRiscV"
 )
 
+config_option(
+    KernelAllowSBICalls ALLOW_SBI_CALLS "Allow user-space to make SBI calls. TODO"
+    DEFAULT OFF
+    DEPENDS "NOT KernelVerificationBuild; KernelArchRiscV"
+)
+
 # Until RISC-V has instructions to count leading/trailing zeros, we provide
 # library implementations. Platforms that implement the bit manipulation
 # extension can override these settings to remove the library functions from
@@ -143,6 +149,7 @@ add_sources(
            object/interrupt.c
            object/objecttype.c
            object/tcb.c
+           object/sbi.c
            smp/ipi.c
     ASMFILES head.S traps.S idle.S
 )

--- a/src/arch/riscv/kernel/boot.c
+++ b/src/arch/riscv/kernel/boot.c
@@ -112,6 +112,12 @@ BOOT_CODE static void init_irqs(cap_t root_cnode_cap)
     write_slot(SLOT_PTR(pptr_of_cap(root_cnode_cap), seL4_CapIRQControl), cap_irq_control_cap_new());
 }
 
+#ifdef CONFIG_ALLOW_SBI_CALLS
+BOOT_CODE static void init_sbi(cap_t root_cnode_cap) {
+    write_slot(SLOT_PTR(pptr_of_cap(root_cnode_cap), seL4_CapSBI), cap_sbi_cap_new(0, 0, 0, 0));
+}
+#endif
+
 /* This and only this function initialises the CPU. It does NOT initialise any kernel state. */
 
 #ifdef CONFIG_HAVE_FPU
@@ -369,6 +375,10 @@ static BOOT_CODE bool_t try_init_kernel(
 
 #ifdef CONFIG_KERNEL_MCS
     init_sched_control(root_cnode_cap, CONFIG_MAX_NUM_NODES);
+#endif
+
+#ifdef CONFIG_ALLOW_SBI_CALLS
+    init_sbi(root_cnode_cap);
 #endif
 
     /* create the initial thread's IPC buffer */

--- a/src/arch/riscv/object/objecttype.c
+++ b/src/arch/riscv/object/objecttype.c
@@ -13,6 +13,10 @@
 #include <arch/model/statedata.h>
 #include <arch/object/objecttype.h>
 
+#ifdef CONFIG_ALLOW_SBI_CALLS
+#include <arch/object/sbi.h>
+#endif
+
 deriveCap_ret_t Arch_deriveCap(cte_t *slot, cap_t cap)
 {
     deriveCap_ret_t ret;
@@ -39,6 +43,9 @@ deriveCap_ret_t Arch_deriveCap(cte_t *slot, cap_t cap)
 
     case cap_asid_control_cap:
     case cap_asid_pool_cap:
+#ifdef CONFIG_ALLOW_SBI_CALLS
+    case cap_sbi_cap:
+#endif
         ret.cap = cap;
         ret.status = EXCEPTION_NONE;
         return ret;
@@ -52,6 +59,25 @@ deriveCap_ret_t Arch_deriveCap(cte_t *slot, cap_t cap)
 
 cap_t CONST Arch_updateCapData(bool_t preserve, word_t data, cap_t cap)
 {
+#ifdef CONFIG_ALLOW_SBI_CALLS
+    if (cap_get_capType(cap) == cap_sbi_cap) {
+        if (preserve) {
+            return cap_null_cap_new();
+        } else {
+            if (cap_sbi_cap_get_capSBIEIDBadge(cap)) {
+                if (cap_sbi_cap_get_capSBIFIDBadge(cap)) {
+                    return cap_null_cap_new();
+                } else {
+                    cap_t badged_cap = cap_sbi_cap_set_capSBIFIDBadge(cap, data);
+                    return cap_sbi_cap_set_capSBIFIDBadged(badged_cap, 1);
+                }
+            } else {
+                cap_t badged_cap = cap_sbi_cap_set_capSBIEIDBadge(cap, data);
+                return cap_sbi_cap_set_capSBIEIDBadged(badged_cap, 1);
+            }
+        }
+    }
+#endif
     return cap;
 }
 
@@ -149,6 +175,13 @@ bool_t CONST Arch_sameRegionAs(cap_t cap_a, cap_t cap_b)
                    cap_asid_pool_cap_get_capASIDPool(cap_b);
         }
         break;
+#ifdef CONFIG_ALLOW_SBI_CALLS
+    case cap_sbi_cap:
+        if (cap_get_capType(cap_b) == cap_sbi_cap) {
+            return true;
+        }
+        break;
+#endif
     }
 
     return false;
@@ -298,6 +331,11 @@ exception_t Arch_decodeInvocation(
     word_t *buffer
 )
 {
+#ifdef CONFIG_ALLOW_SBI_CALLS
+    if (cap_get_capType(cap) == cap_sbi_cap) {
+        return decodeRISCVSBIInvocation(label, length, cptr, slot, cap, call, buffer);
+    }
+#endif
     return decodeRISCVMMUInvocation(label, length, cptr, slot, cap, call, buffer);
 }
 

--- a/src/arch/riscv/object/sbi.c
+++ b/src/arch/riscv/object/sbi.c
@@ -1,0 +1,107 @@
+#include <config.h>
+
+#ifdef CONFIG_ALLOW_SBI_CALLS
+
+#include <arch/object/sbi.h>
+
+// TODO: duplicated because I don't know the right inlcude for libsel4 types
+// TODO: maybe just make this an internal type
+typedef struct seL4_RISCV_SBIRet_ {
+    seL4_Word error;
+    seL4_Word value;
+} seL4_RISCV_SBIRet;
+
+compile_assert(n_msgRegisters_less_than_sbi_regs, n_msgRegisters <= NUM_SBI_REGS);
+
+static inline seL4_RISCV_SBIRet doSBICall(word_t args[NUM_SBI_REGS])
+{
+    register seL4_Word a0 asm("a0") = args[0];
+    register seL4_Word a1 asm("a1") = args[1];
+    register seL4_Word a2 asm("a2") = args[2];
+    register seL4_Word a3 asm("a3") = args[3];
+    register seL4_Word a4 asm("a4") = args[4];
+    register seL4_Word a5 asm("a5") = args[5];
+    register seL4_Word a6 asm("a6") = args[6];
+    register seL4_Word a7 asm("a7") = args[7];
+
+    asm volatile("ecall"
+                 : "+r"(a0), "+r"(a1)
+                 : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(a4), "r"(a5), "r"(a6), "r"(a7)
+                 : "memory");
+
+    seL4_RISCV_SBIRet ret;
+    ret.error = a0;
+    ret.value = a1;
+
+    return ret;
+}
+
+static inline exception_t invokeSBICall(word_t *buffer, bool_t call)
+{
+    word_t i;
+    seL4_Word args[NUM_SBI_REGS];
+    word_t *ipcBuffer;
+    for (i = 0; i < NUM_SBI_REGS; i++) {
+        args[i] = getSyscallArg(i, buffer);
+    }
+
+    ipcBuffer = lookupIPCBuffer(true, NODE_STATE(ksCurThread));
+
+    seL4_RISCV_SBIRet ret = doSBICall(args);
+
+    if (call) {
+        setMR(NODE_STATE(ksCurThread), ipcBuffer, 0, ret.error);
+        setMR(NODE_STATE(ksCurThread), ipcBuffer, 1, ret.value);
+
+        setRegister(NODE_STATE(ksCurThread), badgeRegister, 0);
+        setRegister(NODE_STATE(ksCurThread), msgInfoRegister, wordFromMessageInfo(
+                        seL4_MessageInfo_new(0, 0, 0, 2)));
+    }
+
+    setThreadState(NODE_STATE(ksCurThread), ThreadState_Running);
+    return EXCEPTION_NONE;
+}
+
+
+exception_t decodeRISCVSBIInvocation(word_t label, unsigned int length, cptr_t cptr,
+                                   cte_t *srcSlot, cap_t cap, bool_t call, word_t *buffer)
+{
+    if (label != RISCVSBICall) {
+        userError("RISCVSBIInvocation: Illegal operation.");
+        current_syscall_error.type = seL4_IllegalOperation;
+        return EXCEPTION_SYSCALL_ERROR;
+    }
+
+    if (length < NUM_SBI_REGS) {
+        userError("RISCVSBICall: Truncated message.");
+        current_syscall_error.type = seL4_TruncatedMessage;
+        return EXCEPTION_SYSCALL_ERROR;
+    }
+
+    if (cap_sbi_cap_get_capSBIEIDBadged(cap)) {
+        word_t eid_badge = cap_sbi_cap_get_capSBIEIDBadge(cap);
+        word_t eid = getSyscallArg(7, buffer);
+
+        if (eid != eid_badge) {
+            userError("RISCVSBICall: Illegal operation, invalid EID given (0x%lx), only EID 0x%lx is allowed.", eid, eid_badge);
+            current_syscall_error.type = seL4_IllegalOperation;
+            return EXCEPTION_SYSCALL_ERROR;
+        }
+
+        if (cap_sbi_cap_get_capSBIFIDBadged(cap)) {
+            word_t fid_badge = cap_sbi_cap_get_capSBIFIDBadge(cap);
+            word_t fid = getSyscallArg(6, buffer);
+
+            if (fid != fid_badge) {
+                userError("RISCVSBICall: Illegal operation, invalid FID given (0x%lx), only FID 0x%lx is allowed.", fid, fid_badge);
+                current_syscall_error.type = seL4_IllegalOperation;
+                return EXCEPTION_SYSCALL_ERROR;
+            }
+        }
+    }
+
+    setThreadState(NODE_STATE(ksCurThread), ThreadState_Restart);
+    return invokeSBICall(buffer, call);
+}
+
+#endif /* CONFIG_ALLOW_SBI_CALLS */


### PR DESCRIPTION
Implements RFC-22 [1].

This implementation was done with Gerwin Klein.

This has been tested 32-bit and 64-bit RISC-V platforms.

For 64-bit, the HiFive P550 and QEMU virt were tested.
For 32-bit, the only supported platform is QEMU virt so I have
not been able to test this implementation on 32-bit hardware.

[1]: https://github.com/seL4/rfcs/pull/35