### PR TITLE
sel4.h: add missing vmenter.h include

### DIFF
--- a/libsel4/include/sel4/sel4.h
+++ b/libsel4/include/sel4/sel4.h
@@ -27,4 +27,7 @@
 #include <sel4/arch/constants.h>
 #include <sel4/plat/api/constants.h>
 
+#ifdef CONFIG_VTX
+#include <sel4/arch/vmenter.h>
+#endif
 


### PR DESCRIPTION
I may be missing something but my understanding is that sel4.h should include everything from libsel4 so that users only have to include sel4.h.

When I was working on an x86-64 VMM I ran into this header missing.