### PR TITLE
Proposal: Can we make invocation numbers flat?

### DIFF
--- a/libsel4/include/interfaces/object-api.xml
+++ b/libsel4/include/interfaces/object-api.xml
@@ -221,7 +221,7 @@
                 </description>
             </error>
         </method>
-        <method id="TCBConfigure" name="Configure" manual_name="Configure (MCS)" manual_label="tcb_configure_mcs">
+        <method id="TCBConfigureMCS" name="Configure" manual_name="Configure (MCS)" manual_label="tcb_configure_mcs">
             <condition><config var="CONFIG_KERNEL_MCS"/></condition>
             <brief>
                 Set the parameters of a TCB
@@ -353,7 +353,7 @@
                 </description>
             </error>
         </method>
-        <method id="TCBSetSchedParams" name="SetSchedParams" manual_name="Set Sched Params (MCS)" manual_label="tcb_setschedparams_mcs">
+        <method id="TCBSetSchedParamsMCS" name="SetSchedParams" manual_name="Set Sched Params (MCS)" manual_label="tcb_setschedparams_mcs">
             <condition><config var="CONFIG_KERNEL_MCS"/></condition>
             <brief>
                 Change a thread's priority, maximum controlled priority, scheduling context
@@ -487,7 +487,7 @@
             </error>
         </method>
 
-        <method id="TCBSetSpace" name="SetSpace" manual_name="Set Space (MCS)" manual_label="tcb_setspace_mcs">
+        <method id="TCBSetSpaceMCS" name="SetSpace" manual_name="Set Space (MCS)" manual_label="tcb_setspace_mcs">
             <condition><config var="CONFIG_KERNEL_MCS"/></condition>
             <brief>
                 Set the fault endpoint, CSpace and VSpace of a thread

--- a/src/object/tcb.c
+++ b/src/object/tcb.c
@@ -835,6 +835,11 @@ static exception_t decodeSetFlags(cap_t cap, word_t length, bool_t call, word_t 
     return EXCEPTION_NONE;
 }
 
+#ifdef CONFIG_KERNEL_MCS
+#define TCBConfigure TCBConfigureMCS
+#define TCBSetSchedParams TCBSetSchedParamsMCS
+#define TCBSetSpace TCBSetSpaceMCS
+#endif
 /* The following functions sit in the syscall error monad, but include the
  * exception cases for the preemptible bottom end, as they call the invoke
  * functions directly.  This is a significant deviation from the Haskell

--- a/tools/invocation_header_gen.py
+++ b/tools/invocation_header_gen.py
@@ -40,11 +40,11 @@ enum invocation_label {
     InvalidInvocation,
     {%- for label, condition in invocations %}
     {%- if condition %}
-#if {{condition}}
+// if {{condition}}
     {%- endif %}
     {{label}},
     {%- if condition %}
-#endif
+// endif
     {%- endif %}
     {%- endfor %}
     nInvocationLabels
@@ -69,7 +69,7 @@ enum sel4_arch_invocation_label {
             {%- if loop.first %}
 #error "First sel4_arch invocation label cannot be conditional"
             {%- endif %}
-#if {{condition}}
+// if {{condition}}
         {%- endif %}
         {%- if loop.first %}
     {{label}} = nInvocationLabels,
@@ -77,7 +77,7 @@ enum sel4_arch_invocation_label {
     {{label}},
         {%- endif %}
         {%- if condition %}
-#endif
+// endif
         {%- endif %}
     {%- endfor %}
     {%- if invocations|length == 0 %}
@@ -101,7 +101,7 @@ enum arch_invocation_label {
     {%- if loop.first  %}
 #error "First arch invocation label cannot be conditional"
     {%- endif %}
-#if {{condition}}
+// if {{condition}}
     {%- endif %}
     {%- if loop.first %}
     {{label}} = nSeL4ArchInvocationLabels,
@@ -109,7 +109,7 @@ enum arch_invocation_label {
     {{label}},
     {%- endif %}
     {%- if condition %}
-#endif
+// endif
     {%- endif %}
     {%- endfor %}
     {%- if invocations|length == 0 %}


### PR DESCRIPTION
Configuration dependent invocations cause invocation numbers to be unstable across kernel configurations within the same kernel release. This means libsel4.h clients need to be recompiled for different kernel configurations such as hyp vs non-hyp.

By adjusting the tooling to not #ifdef the invocation labels from the enum definitions, the numbers assigned for each label are consistent across kernel configurations.

MCS changes the parameters of the invocations from non-mcs and so we try assign different invocation labels for this. This still prevents using the same libsel4 for both MCS and non-MCS kernels...

When decoding CNode invocations, the kernel assumes all CNode operations within the starting label and ending label are consecutive. This isn't possible if invocation IDs become sparse. This consecutive assumption should be easy to resolve though.

Eg: 
```
enum invocation_label {
    InvalidInvocation,
    UntypedRetype,
    TCBReadRegisters,
    TCBWriteRegisters,
    TCBCopyRegisters,
// if !defined(CONFIG_KERNEL_MCS)
    TCBConfigure,
// endif
// if defined(CONFIG_KERNEL_MCS)
    TCBConfigureMCS,
// endif
    TCBSetPriority,
    TCBSetMCPriority,
// if !defined(CONFIG_KERNEL_MCS)
    TCBSetSchedParams,
// endif
// if defined(CONFIG_KERNEL_MCS)
    TCBSetSchedParamsMCS,
// endif
// if defined(CONFIG_KERNEL_MCS)
    TCBSetTimeoutEndpoint,
// endif
    TCBSetIPCBuffer,
// if !defined(CONFIG_KERNEL_MCS)
    TCBSetSpace,
// endif
// if defined(CONFIG_KERNEL_MCS)
    TCBSetSpaceMCS,
// endif
    TCBSuspend,
    TCBResume,
    TCBBindNotification,
    TCBUnbindNotification,
// if (!defined(CONFIG_KERNEL_MCS) && defined(CONFIG_ENABLE_SMP_SUPPORT))
    TCBSetAffinity,
// endif
// if defined(CONFIG_HARDWARE_DEBUG_API)
    TCBSetBreakpoint,
// endif
// if defined(CONFIG_HARDWARE_DEBUG_API)
    TCBGetBreakpoint,
// endif
// if defined(CONFIG_HARDWARE_DEBUG_API)
    TCBUnsetBreakpoint,
// endif
// if defined(CONFIG_HARDWARE_DEBUG_API)
    TCBConfigureSingleStepping,
// endif
    TCBSetTLSBase,
    TCBSetFlags,
    CNodeRevoke,
    CNodeDelete,
    CNodeCancelBadgedSends,
    CNodeCopy,
    CNodeMint,
    CNodeMove,
    CNodeMutate,
    CNodeRotate,
// if !defined(CONFIG_KERNEL_MCS)
    CNodeSaveCaller,
// endif
    IRQIssueIRQHandler,
    IRQAckIRQ,
    IRQSetIRQHandler,
    IRQClearIRQHandler,
    DomainSetSet,
// if defined(CONFIG_KERNEL_MCS)
    SchedControlConfigureFlags,
// endif
// if defined(CONFIG_KERNEL_MCS)
    SchedContextBind,
// endif
// if defined(CONFIG_KERNEL_MCS)
    SchedContextUnbind,
// endif
// if defined(CONFIG_KERNEL_MCS)
    SchedContextUnbindObject,
// endif
// if defined(CONFIG_KERNEL_MCS)
    SchedContextConsumed,
// endif
// if defined(CONFIG_KERNEL_MCS)
    SchedContextYieldTo,
// endif
    nInvocationLabels
};
```