### PR TITLE
mcs: hotfix for spurious IRQs due to time preempt

### DIFF
--- a/include/api/failures.h
+++ b/include/api/failures.h
@@ -19,6 +19,9 @@ enum exception {
     EXCEPTION_LOOKUP_FAULT,
     EXCEPTION_SYSCALL_ERROR,
     EXCEPTION_PREEMPTED
+#ifdef CONFIG_KERNEL_MCS
+    , EXCEPTION_TIME
+#endif
 };
 typedef word_t exception_t;
 

--- a/src/api/syscall.c
+++ b/src/api/syscall.c
@@ -327,9 +327,16 @@ static exception_t handleInvocation(bool_t isCall, bool_t isBlocking)
                               isBlocking, isCall, buffer);
 #endif
 
+#ifdef CONFIG_KERNEL_MCS
+    if (unlikely(status == EXCEPTION_PREEMPTED || status == EXCEPTION_TIME)) {
+        return status;
+    }
+#else
     if (unlikely(status == EXCEPTION_PREEMPTED)) {
         return status;
     }
+#endif
+
 
     if (unlikely(status == EXCEPTION_SYSCALL_ERROR)) {
         if (isCall) {
@@ -531,7 +538,13 @@ exception_t handleSyscall(syscall_t syscall)
             ret = handleInvocation(false, true, false, false, getRegister(NODE_STATE(ksCurThread), capRegister));
             if (unlikely(ret != EXCEPTION_NONE)) {
                 mcsPreemptionPoint();
+#ifdef CONFIG_KERNEL_MCS
+                if (ret == EXCEPTION_PREEMPTED) {
+                    checkInterrupt();
+                }
+#else
                 checkInterrupt();
+#endif
             }
 
             break;
@@ -540,7 +553,13 @@ exception_t handleSyscall(syscall_t syscall)
             ret = handleInvocation(false, false, false, false, getRegister(NODE_STATE(ksCurThread), capRegister));
             if (unlikely(ret != EXCEPTION_NONE)) {
                 mcsPreemptionPoint();
+#ifdef CONFIG_KERNEL_MCS
+                if (ret == EXCEPTION_PREEMPTED) {
+                    checkInterrupt();
+                }
+#else
                 checkInterrupt();
+#endif
             }
             break;
 
@@ -548,7 +567,13 @@ exception_t handleSyscall(syscall_t syscall)
             ret = handleInvocation(true, true, true, false, getRegister(NODE_STATE(ksCurThread), capRegister));
             if (unlikely(ret != EXCEPTION_NONE)) {
                 mcsPreemptionPoint();
+#ifdef CONFIG_KERNEL_MCS
+                if (ret == EXCEPTION_PREEMPTED) {
+                    checkInterrupt();
+                }
+#else
                 checkInterrupt();
+#endif
             }
             break;
 
@@ -587,7 +612,13 @@ exception_t handleSyscall(syscall_t syscall)
             ret = handleInvocation(false, false, true, true, dest);
             if (unlikely(ret != EXCEPTION_NONE)) {
                 mcsPreemptionPoint();
+#ifdef CONFIG_KERNEL_MCS
+                if (ret == EXCEPTION_PREEMPTED) {
+                    checkInterrupt();
+                }
+#else
                 checkInterrupt();
+#endif
                 break;
             }
             handleRecv(true, true);
@@ -598,7 +629,13 @@ exception_t handleSyscall(syscall_t syscall)
             ret = handleInvocation(false, false, true, true, getRegister(NODE_STATE(ksCurThread), replyRegister));
             if (unlikely(ret != EXCEPTION_NONE)) {
                 mcsPreemptionPoint();
+#ifdef CONFIG_KERNEL_MCS
+                if (ret == EXCEPTION_PREEMPTED) {
+                    checkInterrupt();
+                }
+#else
                 checkInterrupt();
+#endif
                 break;
             }
             handleRecv(true, false);

--- a/src/model/preemption.c
+++ b/src/model/preemption.c
@@ -30,11 +30,12 @@ exception_t preemptionPoint(void)
         ksWorkUnitsCompleted = 0;
 #ifdef CONFIG_KERNEL_MCS
         updateTimestamp();
-        if (isIRQPending() || isCurDomainExpired()
+        if (isCurDomainExpired()
             || !(sc_active(NODE_STATE(ksCurSC)) && refill_sufficient(NODE_STATE(ksCurSC), NODE_STATE(ksConsumed)))) {
-#else
-        if (isIRQPending()) {
+            return EXCEPTION_TIME;
+        }
 #endif
+        if (isIRQPending()) {
             return EXCEPTION_PREEMPTED;
         }
     }


### PR DESCRIPTION
This is a hotfix for #1540.

I'm not going to say this is a *fix* for that issue since it feels like a bit of a hack, but at the moment #1510 is causing a large amount of (clearly incorrect) spurious IRQ warnings on MCS, that's also breaking the CI.