### PR TITLE
tools: support multiple methods with the same id

### DIFF
--- a/libsel4/tools/sel4_idl.xsd
+++ b/libsel4/tools/sel4_idl.xsd
@@ -40,6 +40,7 @@
         <xsd:attribute name="name" type="xsd:string" use="required" />
         <xsd:attribute name="manual_name" type="xsd:string" use="optional" />
         <xsd:attribute name="cap_description" type="xsd:string" use="optional" />
+        <xsd:attribute name="duplicate" type="xsd:boolean" use="optional" />
     </xsd:complexType>
 
 

--- a/tools/invocation_header_gen.py
+++ b/tools/invocation_header_gen.py
@@ -147,10 +147,18 @@ def parse_xml(xml_file):
         sys.exit(-1)
 
     invocation_labels = []
+    invocation_ids = set()
     for method in doc.getElementsByTagName("method"):
-        invocation_labels.append((str(method.getAttribute("id")),
-                                  str(condition_to_cpp(method.getElementsByTagName("condition")))))
-
+        label = str(method.getAttribute("id"))
+        condition = str(condition_to_cpp(method.getElementsByTagName("condition")))
+        uid = label + condition
+        dup = method.getAttribute("duplicate")
+        if uid not in invocation_ids:
+            invocation_ids.add(uid)
+            invocation_labels.append((label, condition))
+        elif dup not in ("true", "1"):
+            print("Error: Implicit duplicate id '%s' in xml file" % label, file=sys.stderr)
+            sys.exit(-1)
     return invocation_labels
 
 

--- a/tools/invocation_json_gen.py
+++ b/tools/invocation_json_gen.py
@@ -32,7 +32,7 @@ def xml_to_json_invocations(xml, gen_config, counter, invocations_dict, ):
     for method in xml.getElementsByTagName("method"):
         label = str(method.getAttribute("id"))
         exists = condition_to_bool(method.getElementsByTagName("condition"), gen_config)
-        if exists:
+        if exists and label not in invocations_dict:
             invocations_dict[label] = counter
             counter += 1
 


### PR DESCRIPTION
Useful to implement multiple API definitions for syscalls with optional arguments.

Useful for e.g. PR #1547 and PR #889 or any future API expansion with optional arguments added to existing syscalls.