### PR TITLE
Disable clock sync test on QEMU RISC-V

### DIFF
--- a/include/kernel/boot.h
+++ b/include/kernel/boot.h
@@ -138,7 +138,7 @@ static inline BOOT_CODE pptr_t it_alloc_paging(void)
 /* return the amount of paging structures required to cover v_reg */
 word_t arch_get_n_paging(v_region_t it_veg);
 
-#if defined(CONFIG_DEBUG_BUILD) && defined(ENABLE_SMP_SUPPORT) && defined(CONFIG_KERNEL_MCS) && !defined(CONFIG_PLAT_QEMU_ARM_VIRT)
+#if defined(CONFIG_DEBUG_BUILD) && defined(ENABLE_SMP_SUPPORT) && defined(CONFIG_KERNEL_MCS) && !defined(CONFIG_PLAT_QEMU_ARM_VIRT) && !defined(CONFIG_PLAT_QEMU_RISCV_VIRT)
 /* Test whether clocks are synchronised across nodes */
 #define ENABLE_SMP_CLOCK_SYNC_TEST_ON_BOOT
 #endif


### PR DESCRIPTION
This will sometimes fail when using QEMU RISC-V virt with multiple cores, make the behaviour consistent as QEMU ARM virt.

Given that QEMU is not intended to be a cycle accurate simulator, I imagine that is why this does not reliably succeed.