### PR TITLE
benchmark: account for thread utilisations on riscv's fastpath

### DIFF
--- a/include/arch/riscv/arch/fastpath/fastpath.h
+++ b/include/arch/riscv/arch/fastpath/fastpath.h
@@ -42,6 +42,10 @@ static inline void FORCE_INLINE switchToThread_fp(tcb_t *thread, pte_t *vroot, p
 
     setVSpaceRoot(addrFromPPtr(vroot), asid);
 
+#ifdef CONFIG_BENCHMARK_TRACK_UTILISATION
+    benchmark_utilisation_switch(NODE_STATE(ksCurThread), thread);
+#endif
+
 #ifdef CONFIG_HAVE_FPU
     lazyFPURestore(thread);
 #endif


### PR DESCRIPTION
On risc-v, the benchmark config using `CONFIG_BENCHMARK_TRACK_UTILISATION` currently returns incorrect data (e.g. user utilisation for a protection domain is > 1000% in some networking benchmarks). This is caused by missing a `benchmark_utilisation_switch` call inside the fast path.

I have confirmed that with the proposed fix, the resulting data on risc-v does not suffer from the issue.

This switch exists in current implementation for all other architectures. Commit https://github.com/seL4/seL4/commit/00a05777905d31036881b2e9e117c0a8ecc8c16d added the switch to both 64-bit x86 and arm, but it was before any risc-v commits.