### PR TITLE
Aarch64: Drop ISBs in enableFpu/disableFpu

### DIFF
--- a/include/arch/arm/arch/64/mode/machine/fpu.h
+++ b/include/arch/arm/arch/64/mode/machine/fpu.h
@@ -102,7 +102,11 @@ static inline void enableFpuEL01(void)
     MRS("cpacr_el1", cpacr);
     cpacr |= (3 << CPACR_EL1_FPEN);
     MSR("cpacr_el1", cpacr);
-    isb();
+    /*
+     * No ISB because we rely on context switch for synchronisation
+     * of the FPU enable for EL0 and disableFpuEL0() keeps the FPU
+     * enabled for the kernel itself, which runs in EL1.
+     */
 }
 
 /* Enable the FPU to be used without faulting.
@@ -126,7 +130,7 @@ static inline void enableTrapFpu(void)
     MRS("cptr_el2", cptr);
     cptr |= (BIT(10) | BIT(31));
     MSR("cptr_el2", cptr);
-    isb();
+    /* No ISB because we rely on context switch for synchronisation */
 }
 
 /* Disable FPU access in EL0 */
@@ -135,9 +139,10 @@ static inline void disableFpuEL0(void)
     word_t cpacr;
     MRS("cpacr_el1", cpacr);
     cpacr &= ~(3 << CPACR_EL1_FPEN);
+    /* Keep FPU enabled for the kernel */
     cpacr |= (1 << CPACR_EL1_FPEN);
     MSR("cpacr_el1", cpacr);
-    isb();
+    /* No ISB because we rely on context switch for synchronisation */
 }
 
 /* Disable the FPU so that usage of it causes a fault */

--- a/src/arch/arm/64/machine/fpu.c
+++ b/src/arch/arm/64/machine/fpu.c
@@ -17,7 +17,8 @@ BOOT_CODE bool_t fpsimd_init(void)
     if (config_set(CONFIG_ARM_HYPERVISOR_SUPPORT)) {
         enableFpuEL01();
     }
-
+    /* Non-HYP Kernel assumes FPU is always enabled for EL1: Make sure it is */
+    isb();
     return true;
 }
 #endif /* CONFIG_HAVE_FPU */


### PR DESCRIPTION
The kernel is not doing any FPU operations after disabling the FPU, so there is never a need for an ISB there. Returning to user space counts as a synchronising context switch and ensures the FPU enable or disable has completed when user space starts executing.

An ISB after enabling the FPU is only needed in case the FPU was disabled for the kernel and the kernel wants to do FPU operations like saving or restoring the FPU state. The ISB ensures that the FPU enable system register write is finished before FPU using instructions are executed.

For Aarch64 non-HYP it is possible to disable the FPU for user space (EL0), but keep it enabled for the kernel (EL1). This is done by setting CPACR_EL1.FPEN to 1, which the code actually already did.

Aarch64 with virtualisation enabled is more complicated and needs higher level changes to achieve the same, which aren't done here, the change is limited to removing the ISB in disableFpu().

This partially fixes issue #1569.