### PR TITLE
FPU: Fix task enabling FPU for itself

### DIFF
--- a/src/object/tcb.c
+++ b/src/object/tcb.c
@@ -802,9 +802,12 @@ static void invokeSetFlags(tcb_t *thread, word_t clear, word_t set, bool_t call)
     thread->tcbFlags = flags;
 
 #ifdef CONFIG_HAVE_FPU
-    /* Save current FPU state before disabling FPU: */
     if (flags & seL4_TCBFlag_fpuDisabled) {
+        /* Save current FPU state before disabling FPU: */
         fpuRelease(thread);
+    } else if (thread == cur_thread) {
+        /* Restore FPU here as switchToThread() won't be called: */
+        lazyFPURestore(thread);
     }
 #endif
     if (call) {


### PR DESCRIPTION
There is no switchToThread() call when a task toggles seL4_TCBFlag_fpuDisabled for itself, so the FPU stays disabled even when it was just enabled.

The disable case was handled properly as fpuRelease() does the right thing already.