### PR TITLE
x86: Added missing BOOT_CODE annotation on x86_cpuid_initialize

### DIFF
--- a/src/arch/x86/machine/cpu_identification.c
+++ b/src/arch/x86/machine/cpu_identification.c
@@ -113,7 +113,7 @@ BOOT_CODE static void x86_cpuid_amd_identity_initialize(cpu_identity_t *ci,
     }
 }
 
-bool_t x86_cpuid_initialize(void)
+BOOT_CODE bool_t x86_cpuid_initialize(void)
 {
     cpu_identity_t *ci = x86_cpuid_get_identity();
     struct family_model original;


### PR DESCRIPTION
Every function called in the early boot process is marked with BOOT_CODE to indicate to the linker it should be placed within the boot section of the kernel. x86_cpuid_initialize was - seemingly accidentally - missing this annotation. This PR fixes this oversight.

Fixes #1575