### PR TITLE
libsel4: make thread-local ipc buffer optional

### DIFF
--- a/libsel4/CMakeLists.txt
+++ b/libsel4/CMakeLists.txt
@@ -28,7 +28,8 @@ config_choice(
 )
 
 config_option(
-    LibSel4StubsUseIPCBufferOnly LIB_SEL4_STUBS_USE_IPC_BUFFER_ONLY
+    LibSel4StubsUseIPCBufferOnly
+    LIB_SEL4_STUBS_USE_IPC_BUFFER_ONLY
     "use only IPC buffer for syscalls. When generating syscall wrappers, only use the \
     IPC buffer for marshalling and unmarshalling arguments. Without this option set, \
     arguments will be passed in registers where possible for better performance."
@@ -62,8 +63,7 @@ gen_invocation_header(
 
 gen_invocation_header(
     OUTPUT sel4_arch_include/${KernelSel4Arch}/sel4/sel4_arch/invocation.h
-    XML
-        "${CMAKE_CURRENT_SOURCE_DIR}/sel4_arch_include/${KernelSel4Arch}/interfaces/object-api-sel4-arch.xml"
+    XML "${CMAKE_CURRENT_SOURCE_DIR}/sel4_arch_include/${KernelSel4Arch}/interfaces/object-api-sel4-arch.xml"
     LIBSEL4 SEL4ARCH
 )
 
@@ -73,8 +73,7 @@ gen_invocation_header(
     LIBSEL4 ARCH
 )
 
-set(
-    source_header_dirs
+set(source_header_dirs
     "${CMAKE_CURRENT_SOURCE_DIR}/include"
     "${CMAKE_CURRENT_SOURCE_DIR}/arch_include/${KernelArch}"
     "${CMAKE_CURRENT_SOURCE_DIR}/sel4_arch_include/${KernelSel4Arch}"
@@ -105,11 +104,9 @@ function(genbf target_prefix pbf_location bf_location header_output)
     )
 endfunction(genbf)
 
-genbf(
-    "libsel4_shared_types_gen"
-    "${CMAKE_CURRENT_BINARY_DIR}/include/sel4/shared_types.pbf"
-    "${CMAKE_CURRENT_SOURCE_DIR}/mode_include/${KernelWordSize}/sel4/shared_types.bf"
-    "${CMAKE_CURRENT_BINARY_DIR}/include/sel4/shared_types_gen.h"
+genbf("libsel4_shared_types_gen" "${CMAKE_CURRENT_BINARY_DIR}/include/sel4/shared_types.pbf"
+      "${CMAKE_CURRENT_SOURCE_DIR}/mode_include/${KernelWordSize}/sel4/shared_types.bf"
+      "${CMAKE_CURRENT_BINARY_DIR}/include/sel4/shared_types_gen.h"
 )
 
 genbf(
@@ -128,25 +125,19 @@ endif()
 add_custom_command(
     OUTPUT include/sel4/syscall.h
     COMMAND rm -f include/sel4/syscall.h
-    COMMAND
-        "${XMLLINT_PATH}"
-        --noout
-        --schema
-            "${CMAKE_CURRENT_SOURCE_DIR}/include/api/syscall.xsd"
+    COMMAND "${XMLLINT_PATH}" --noout --schema "${CMAKE_CURRENT_SOURCE_DIR}/include/api/syscall.xsd"
             "${CMAKE_CURRENT_SOURCE_DIR}/include/api/syscall.xml"
     COMMAND
-        ${PYTHON3} "${SYSCALL_ID_GEN_PATH}"
-        --xml "${CMAKE_CURRENT_SOURCE_DIR}/include/api/syscall.xml"
-        --libsel4_header include/sel4/syscall.h ${mcs}
-    DEPENDS
-        "${SYSCALL_ID_GEN_PATH}" "${CMAKE_CURRENT_SOURCE_DIR}/include/api/syscall.xsd"
-        "${CMAKE_CURRENT_SOURCE_DIR}/include/api/syscall.xml"
+        ${PYTHON3} "${SYSCALL_ID_GEN_PATH}" --xml
+        "${CMAKE_CURRENT_SOURCE_DIR}/include/api/syscall.xml" --libsel4_header
+        include/sel4/syscall.h ${mcs}
+    DEPENDS "${SYSCALL_ID_GEN_PATH}" "${CMAKE_CURRENT_SOURCE_DIR}/include/api/syscall.xsd"
+            "${CMAKE_CURRENT_SOURCE_DIR}/include/api/syscall.xml"
     COMMENT "Generate syscall.h"
     VERBATIM
 )
 
-set(
-    interface_xmls
+set(interface_xmls
     "${CMAKE_CURRENT_SOURCE_DIR}/sel4_arch_include/${KernelSel4Arch}/interfaces/object-api-sel4-arch.xml"
     "${CMAKE_CURRENT_SOURCE_DIR}/arch_include/${KernelArch}/interfaces/object-api-arch.xml"
     "${CMAKE_CURRENT_SOURCE_DIR}/include/interfaces/object-api.xml"
@@ -155,9 +146,8 @@ set(
 add_custom_command(
     OUTPUT include/interfaces/sel4_client.h
     COMMAND rm -f include/interfaces/sel4_client.h
-    COMMAND
-        "${PYTHON3}" "${SYSCALL_STUB_GEN_PATH}" ${buffer} ${64bitguests} ${mcs} -a
-        "${KernelSel4Arch}" -o include/interfaces/sel4_client.h ${interface_xmls}
+    COMMAND "${PYTHON3}" "${SYSCALL_STUB_GEN_PATH}" ${buffer} ${64bitguests} ${mcs} -a
+            "${KernelSel4Arch}" -o include/interfaces/sel4_client.h ${interface_xmls}
     DEPENDS "${SYSCALL_STUB_GEN_PATH}" ${interface_xmls}
     COMMENT "Generate sel4_client.h"
     VERBATIM
@@ -165,24 +155,21 @@ add_custom_command(
 
 add_custom_target(
     sel4_generated
-    DEPENDS
-        include/interfaces/sel4_client.h
-        include/sel4/syscall.h
-        include/sel4/invocation.h
-        arch_include/${KernelArch}/sel4/arch/invocation.h
-        include/sel4/shared_types_gen.h
-        sel4_arch_include/${KernelSel4Arch}/sel4/sel4_arch/invocation.h
-        sel4_arch_include/${KernelSel4Arch}/sel4/sel4_arch/types_gen.h
+    DEPENDS include/interfaces/sel4_client.h
+            include/sel4/syscall.h
+            include/sel4/invocation.h
+            arch_include/${KernelArch}/sel4/arch/invocation.h
+            include/sel4/shared_types_gen.h
+            sel4_arch_include/${KernelSel4Arch}/sel4/sel4_arch/invocation.h
+            sel4_arch_include/${KernelSel4Arch}/sel4/sel4_arch/types_gen.h
 )
 
 add_library(sel4 src/sel4_bootinfo.c)
 target_link_libraries(sel4 PRIVATE kernel_Config sel4_Config sel4_autoconf)
 target_include_directories(
     sel4
-    PUBLIC
-        ${source_header_dirs}
-        "${CMAKE_CURRENT_BINARY_DIR}/include"
-        "${CMAKE_CURRENT_BINARY_DIR}/arch_include/${KernelArch}"
-        "${CMAKE_CURRENT_BINARY_DIR}/sel4_arch_include/${KernelSel4Arch}"
+    PUBLIC ${source_header_dirs} "${CMAKE_CURRENT_BINARY_DIR}/include"
+           "${CMAKE_CURRENT_BINARY_DIR}/arch_include/${KernelArch}"
+           "${CMAKE_CURRENT_BINARY_DIR}/sel4_arch_include/${KernelSel4Arch}"
 )
 add_dependencies(sel4 sel4_generated)

--- a/libsel4/CMakeLists.txt
+++ b/libsel4/CMakeLists.txt
@@ -44,6 +44,15 @@ config_string(
     UNQUOTE
 )
 
+config_option(
+    LibSel4UseThreadLocals
+    LIB_SEL4_USE_THREAD_LOCALS
+    "mark the __sel4_ipc_buffer variable as thread local using '__thread'. \
+     This requires thread local storage support and is useful if multiple \
+     threads share the same virtual address space."
+    DEFAULT ON
+)
+
 if(LibSel4StubsUseIPCBufferOnly)
     set(buffer "--buffer")
 endif()

--- a/libsel4/include/sel4/functions.h
+++ b/libsel4/include/sel4/functions.h
@@ -10,10 +10,10 @@
 #include <sel4/types.h>
 #include <sel4/syscalls.h>
 
-extern __thread seL4_IPCBuffer *__sel4_ipc_buffer;
+extern LIBSEL4_THREAD_LOCAL seL4_IPCBuffer *__sel4_ipc_buffer;
 
 #ifdef CONFIG_KERNEL_INVOCATION_REPORT_ERROR_IPC
-extern __thread char __sel4_print_error;
+extern LIBSEL4_THREAD_LOCAL char __sel4_print_error;
 
 LIBSEL4_INLINE_FUNC char *seL4_GetDebugError(void)
 {

--- a/libsel4/include/sel4/macros.h
+++ b/libsel4/include/sel4/macros.h
@@ -42,6 +42,12 @@
 
 #endif
 
+#if defined(CONFIG_LIB_SEL4_USE_THREAD_LOCALS)
+#define LIBSEL4_THREAD_LOCAL    __thread
+#else
+#define LIBSEL4_THREAD_LOCAL
+#endif
+
 /* _Static_assert() is a c11 feature. Since the kernel is currently compiled
  * with c99, we have to emulate it. */
 #if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)

--- a/libsel4/src/sel4_bootinfo.c
+++ b/libsel4/src/sel4_bootinfo.c
@@ -7,11 +7,11 @@
 #include <sel4/sel4.h>
 
 #ifdef CONFIG_KERNEL_INVOCATION_REPORT_ERROR_IPC
-__thread char __sel4_print_error = CONFIG_LIB_SEL4_PRINT_INVOCATION_ERRORS;
+LIBSEL4_THREAD_LOCAL char __sel4_print_error = CONFIG_LIB_SEL4_PRINT_INVOCATION_ERRORS;
 #endif
 
 /** Userland per-thread IPC buffer address **/
-__thread seL4_IPCBuffer *__sel4_ipc_buffer;
+LIBSEL4_THREAD_LOCAL seL4_IPCBuffer *__sel4_ipc_buffer;
 
 /** Consider moving bootinfo into libsel4_startup */
 seL4_BootInfo *bootinfo;


### PR DESCRIPTION
At the moment, the seL4 microkit does not setup TLS variable support (nor does it intend to). The workaround has been to `#define __thread` (blank) before including `<sel4/sel4.h>` in `<microkit.h>`, which causes issues if `<microkit.h>` is included *after* `<sel4/sel4.h>`, often with obscure linker errors to `__emutls_**` symbols.

Instead we add a libsel4 config option that allows us to build it with __thread copied out. We introduce an LIBSEL4_THREAD_LOCAL macro in a similar way to the existing LIBSEL4_INLINE macro.