### PR TITLE
github: update Isabelle branch for MCS proofs

### DIFF
--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -45,7 +45,7 @@ jobs:
         L4V_FEATURES: ${{ matrix.features }}
         session: ${{ matrix.session }}
         manifest: ${{ matrix.features == 'MCS' && 'mcs.xml' || 'default.xml' }}
-        isa_branch: ${{ matrix.features == 'MCS' && 'ts-2024' || 'ts-2025' }}
+        isa_branch: 'ts-2025'
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
MCS proofs are now also running on Isabelle2025.