### PR TITLE
libsel4: include vmenter.h if VTX is enabled

### DIFF
--- a/libsel4/include/sel4/syscalls.h
+++ b/libsel4/include/sel4/syscalls.h
@@ -21,6 +21,10 @@
 #include "syscalls_master.h"
 #endif
 
+#ifdef CONFIG_VTX
+#include <sel4/arch/vmenter.h>
+#endif
+
 /**
  * @defgroup DebuggingSystemCalls
  * This section documents debugging system calls available when the kernel is


### PR DESCRIPTION
`seL4_VMEnter()`, declared in `<sel4/syscalls.h>`, takes three arguments in message registers. The indices for those arguments are defined in `<sel4/arch/vmenter.h>`, but that header is not included transitively.

Include `<sel4/arch/vmenter.h>` from `<sel4/syscalls.h>` when `CONFIG_VTX` is enabled so userspace code including `<sel4/sel4.h>` does not need an extra include.