### PR TITLE
arm64: replace set/way cache ops with VA-based ops

### DIFF
--- a/src/arch/arm/armv/armv8-a/64/cache.c
+++ b/src/arch/arm/armv/armv8-a/64/cache.c
@@ -4,105 +4,41 @@
  * SPDX-License-Identifier: GPL-2.0-only
  */
 
+#include <config.h>
+#include <arch/machine.h>
 #include <arch/machine/hardware.h>
+#include <kernel/boot.h>
 
-static inline void cleanByWSL(word_t wsl)
+static void get_boot_flush_region(word_t *start, word_t *end)
 {
-    asm volatile("dc csw, %0" : : "r"(wsl));
+    *start = (word_t)ptrFromPAddr(physBase());
+
+    if (rootserver.paging.end != 0) {
+        /* After init_freemem: flush up to rootserver allocations + margin */
+        *end = rootserver.paging.end + (2 * 1024 * 1024);
+    } else {
+        /* Early boot: rootserver not yet initialized, flush kernel image */
+        *end = (word_t)ki_end + (2 * 1024 * 1024);
+    }
 }
-
-static inline void cleanInvalidateByWSL(word_t wsl)
-{
-    asm volatile("dc cisw, %0" : : "r"(wsl));
-}
-
-static inline word_t readCLID(void)
-{
-    word_t CLID;
-    MRS("clidr_el1", CLID);
-    return CLID;
-}
-
-#define LOUU(x)    (((x) >> 27)        & MASK(3))
-#define LOC(x)     (((x) >> 24)        & MASK(3))
-#define LOUIS(x)   (((x) >> 21)        & MASK(3))
-#define CTYPE(x,n) (((x) >> (n*3))     & MASK(3))
-
-enum arm_cache_type {
-    ARMCacheI =    1,
-    ARMCacheD =    2,
-    ARMCacheID =   3,
-};
-
-static inline word_t readCacheSize(int level, bool_t instruction)
-{
-    word_t size, csselr_old;
-    /* Save CSSELR */
-    MRS("csselr_el1", csselr_old);
-    /* Select cache level */
-    MSR("csselr_el1", ((level << 1) | instruction));
-    /* Read 'size' */
-    MRS("ccsidr_el1", size);
-    /* Restore CSSELR */
-    MSR("csselr_el1", csselr_old);
-    return size;
-}
-
-#define LINEBITS(s)     (((s) & MASK(3)) + 4)
-#define ASSOC(s)        ((((s) >> 3) & MASK(10)) + 1)
-#define NSETS(s)        ((((s) >> 13) & MASK(15)) + 1)
 
 void clean_D_PoU(void)
 {
-    int clid = readCLID();
-    int lou = LOUU(clid);
-
-    for (int l = 0; l < lou; l++) {
-        if (CTYPE(clid, l) > ARMCacheI) {
-            word_t lsize = readCacheSize(l, 0);
-            int lbits = LINEBITS(lsize);
-            int assoc = ASSOC(lsize);
-            int assoc_bits = wordBits - clzl(assoc - 1);
-            int nsets = NSETS(lsize);
-            for (int w = 0; w < assoc; w++) {
-                for (int s = 0; s < nsets; s++) {
-                    cleanByWSL((w << (32 - assoc_bits)) |
-                               (s << lbits) | (l << 1));
-                }
-            }
-        }
-    }
-}
-
-static inline void cleanInvalidate_D_by_level(int l)
-{
-    word_t lsize = readCacheSize(l, 0);
-    int lbits = LINEBITS(lsize);
-    int assoc = ASSOC(lsize);
-    int assoc_bits = wordBits - clzl(assoc - 1);
-    int nsets = NSETS(lsize);
-
-    for (int w = 0; w < assoc; w++) {
-        for (int s = 0; s < nsets; s++) {
-            cleanInvalidateByWSL((w << (32 - assoc_bits)) |
-                                 (s << lbits) | (l << 1));
-        }
-    }
+    word_t start, end;
+    get_boot_flush_region(&start, &end);
+    cleanInvalidateCacheRange_RAM(start, end - 1, addrFromKPPtr((void *)start));
 }
 
 void cleanInvalidate_D_PoC(void)
 {
-    int clid = readCLID();
-    int loc = LOC(clid);
-
-    for (int l = 0; l < loc; l++) {
-        if (CTYPE(clid, l) > ARMCacheI) {
-            cleanInvalidate_D_by_level(l);
-        }
-    }
+    word_t start, end;
+    get_boot_flush_region(&start, &end);
+    cleanInvalidateCacheRange_RAM(start, end - 1, addrFromKPPtr((void *)start));
 }
 
 void cleanInvalidate_L1D(void)
 {
-    cleanInvalidate_D_by_level(0);
+    word_t start, end;
+    get_boot_flush_region(&start, &end);
+    cleanInvalidateCacheRange_RAM(start, end - 1, addrFromKPPtr((void *)start));
 }


### PR DESCRIPTION
I bumped this while porting seL4 to NVIDIA tegra234. 

On modern aarch64, cache ops by set/way are flaky at best. Since we know the VA range during boot, we can use VA-based cache clean/invalidate.