### PR TITLE
arm64: fix cache maintenance completion barriers

### DIFF
--- a/include/arch/arm/arch/64/mode/machine.h
+++ b/include/arch/arm/arch/64/mode/machine.h
@@ -280,19 +280,19 @@ void lockTLBEntry(vptr_t vaddr);
 static inline void cleanByVA(vptr_t vaddr, paddr_t paddr)
 {
     asm volatile("dc cvac, %0" : : "r"(vaddr));
-    dmb();
+    dsb();
 }
 
 static inline void cleanByVA_PoU(vptr_t vaddr, paddr_t paddr)
 {
     asm volatile("dc cvau, %0" : : "r"(vaddr));
-    dmb();
+    dsb();
 }
 
 static inline void invalidateByVA(vptr_t vaddr, paddr_t paddr)
 {
     asm volatile("dc ivac, %0" : : "r"(vaddr));
-    dmb();
+    dsb();
 }
 
 static inline void invalidateByVA_I(vptr_t vaddr, paddr_t paddr)


### PR DESCRIPTION
ARM reference manual says `DSB` must be used after these cache ops, not `DMB`. Actually `DSB ISH` would be enough but since `dsb()` (which expands to `DSB SY`) is used everywhere else, let us use it as well.