### PR TITLE
arm64: Use Point of Coherence page table cache maintenance ops

### DIFF
--- a/include/arch/arm/arch/machine.h
+++ b/include/arch/arm/arch/machine.h
@@ -53,8 +53,8 @@ static inline void clearMemory(word_t *ptr, word_t bits)
 static inline void clearMemory_PT(word_t *ptr, word_t bits)
 {
     memzero(ptr, BIT(bits));
-    cleanCacheRange_PoU((word_t)ptr, (word_t)ptr + BIT(bits) - 1,
-                        addrFromPPtr(ptr));
+    cleanInvalidateCacheRange_RAM((word_t)ptr, (word_t)ptr + BIT(bits) - 1,
+                                  addrFromPPtr(ptr));
 }
 
 #ifdef ENABLE_SMP_SUPPORT

--- a/src/arch/arm/64/kernel/vspace.c
+++ b/src/arch/arm/64/kernel/vspace.c
@@ -1028,7 +1028,7 @@ void unmapPageTable(asid_t asid, vptr_t vptr, pte_t *target_pt)
     /* If we found a pt then ptSlot won't be null */
     assert(ptSlot != NULL);
     *ptSlot = pte_pte_invalid_new();
-    cleanByVA_PoU((vptr_t)ptSlot, pptr_to_paddr(ptSlot));
+    cleanInvalByVA((vptr_t)ptSlot, pptr_to_paddr(ptSlot));
     invalidateTLBByASID(asid);
 }
 
@@ -1061,7 +1061,7 @@ void unmapPage(vm_page_size_t page_size, asid_t asid, vptr_t vptr, pptr_t pptr)
     }
 
     *(lu_ret.ptSlot) = pte_pte_invalid_new();
-    cleanByVA_PoU((vptr_t)lu_ret.ptSlot, pptr_to_paddr(lu_ret.ptSlot));
+    cleanInvalByVA((vptr_t)lu_ret.ptSlot, pptr_to_paddr(lu_ret.ptSlot));
     assert(asid < BIT(16));
     invalidateTLBByASIDVA(asid, vptr);
 }
@@ -1175,7 +1175,7 @@ static exception_t performPageTableInvocationMap(cap_t cap, cte_t *ctSlot, pte_t
 {
     ctSlot->cap = cap;
     *ptSlot = pte;
-    cleanByVA_PoU((vptr_t)ptSlot, pptr_to_paddr(ptSlot));
+    cleanInvalByVA((vptr_t)ptSlot, pptr_to_paddr(ptSlot));
 
     return EXCEPTION_NONE;
 }
@@ -1201,7 +1201,7 @@ static exception_t performPageInvocationMap(asid_t asid, cap_t cap, cte_t *ctSlo
     ctSlot->cap = cap;
     *ptSlot = pte;
 
-    cleanByVA_PoU((vptr_t)ptSlot, pptr_to_paddr(ptSlot));
+    cleanInvalByVA((vptr_t)ptSlot, pptr_to_paddr(ptSlot));
     if (unlikely(tlbflush_required)) {
         assert(asid < BIT(16));
         invalidateTLBByASIDVA(asid, cap_frame_cap_get_capFMappedAddress(cap));
@@ -1996,7 +1996,7 @@ exception_t benchmark_arch_map_logBuffer(word_t frame_cptr)
                              0,                         /* VMKernelOnly */
                              NORMAL_WT);
 
-    cleanByVA_PoU((vptr_t)armKSGlobalLogPTE, addrFromKPPtr(armKSGlobalLogPTE));
+    cleanInvalByVA((vptr_t)armKSGlobalLogPTE, addrFromKPPtr(armKSGlobalLogPTE));
     invalidateTranslationSingle(KS_LOG_PPTR);
     return EXCEPTION_NONE;
 }

--- a/src/arch/arm/64/object/objecttype.c
+++ b/src/arch/arm/64/object/objecttype.c
@@ -161,9 +161,9 @@ finaliseCap_ret_t Arch_finaliseCap(cap_t cap, bool_t final)
         }
         if (final) {
             pte_t *base = VSPACE_PTR(cap_vspace_cap_get_capVSBasePtr(cap));
-            cleanCacheRange_PoU((word_t)base,
-                                (word_t)base + MASK(seL4_VSpaceBits),
-                                addrFromPPtr(base));
+            cleanInvalidateCacheRange_RAM((word_t)base,
+                                              (word_t)base + MASK(seL4_VSpaceBits),
+                                              addrFromPPtr(base));
         }
         break;
 
@@ -175,9 +175,9 @@ finaliseCap_ret_t Arch_finaliseCap(cap_t cap, bool_t final)
         }
         if (final) {
             pte_t *base = PTE_PTR(cap_page_table_cap_get_capPTBasePtr(cap));
-            cleanCacheRange_PoU((word_t)base,
-                                (word_t)base + MASK(seL4_PageTableBits),
-                                addrFromPPtr(base));
+            cleanInvalidateCacheRange_RAM((word_t)base,
+                                              (word_t)base + MASK(seL4_PageTableBits),
+                                              addrFromPPtr(base));
         }
         break;
 
@@ -461,9 +461,9 @@ cap_t Arch_createObject(object_t t, void *regionBase, word_t userSize, bool_t de
         /** AUXUPD: "(True, ptr_retyps 1
               (Ptr (ptr_val \<acute>regionBase) :: (pte_C[vs_array_len]) ptr))" */
         /** GHOSTUPD: "(True, gs_new_pt_t VSRootPT_T (ptr_val \<acute>regionBase))" */
-        cleanCacheRange_PoU((word_t)regionBase,
-                            (word_t)regionBase + MASK(seL4_VSpaceBits),
-                            addrFromPPtr(regionBase));
+        cleanInvalidateCacheRange_RAM((word_t)regionBase,
+                                      (word_t)regionBase + MASK(seL4_VSpaceBits),
+                                      addrFromPPtr(regionBase));
 #ifdef CONFIG_ARM_SMMU
         return cap_vspace_cap_new(
                    asidInvalid,           /* capVSMappedASID */
@@ -482,9 +482,9 @@ cap_t Arch_createObject(object_t t, void *regionBase, word_t userSize, bool_t de
         /** AUXUPD: "(True, ptr_retyps 1
               (Ptr (ptr_val \<acute>regionBase) :: (pte_C[pt_array_len]) ptr))" */
         /** GHOSTUPD: "(True, gs_new_pt_t NormalPT_T (ptr_val \<acute>regionBase))" */
-        cleanCacheRange_PoU((word_t)regionBase,
-                            (word_t)regionBase + MASK(seL4_PageTableBits),
-                            addrFromPPtr(regionBase));
+        cleanInvalidateCacheRange_RAM((word_t)regionBase,
+                                      (word_t)regionBase + MASK(seL4_PageTableBits),
+                                      addrFromPPtr(regionBase));
         return cap_page_table_cap_new(
                    asidInvalid,           /* capPTMappedASID    */
                    (word_t)regionBase,    /* capPTBasePtr       */


### PR DESCRIPTION
I bumped into this while porting seL4 to NVIDIA tegra234 with `ARM_HYPERVISOR_SUPPORT` (seL4 running at EL2).

ARM reference manual says that data cache coherency is guaranteed by HW, but when walking the page tables, it's a different matter: stage-1 page tables are walked from PoU, while stage-2 page tables are walked from PoC. Since modifying page tables is not that hot path, let us do cache clean/invalidate to PoC even if we are running at EL1, much cleaner code.

When I changed code to use PoC, sel4test caught a new corner case, the commit message on flushing cache on final cap delete explains it all.

With this and sel4#1621, sel4#1620 and sel4#1619 I finally managed to run sel4test on tegra234 without any errors.