### PR TITLE
x86: Fix AMD CPU model assignment typo

### DIFF
--- a/src/arch/x86/machine/cpu_identification.c
+++ b/src/arch/x86/machine/cpu_identification.c
@@ -109,7 +109,7 @@ BOOT_CODE static void x86_cpuid_amd_identity_initialize(cpu_identity_t *ci,
         ci->display.model = original.model;
     } else {
         ci->display.family = original.family + ci->display.extended_family;
-        ci->display.family = (ci->display.extended_model << 4u) + original.model;
+        ci->display.model = (ci->display.extended_model << 4u) + original.model;
     }
 }
 


### PR DESCRIPTION
When original.family >= 0xF, the extended model was incorrectly assigned to ci->display.family instead of ci->display.model. This matches the Intel implementation and AMD CPUID specification.