### PR TITLE
scheduleTCB: simplify scheduler action logic

### DIFF
--- a/src/kernel/thread.c
+++ b/src/kernel/thread.c
@@ -586,7 +586,8 @@ void scheduleTCB(tcb_t *tptr)
     if (tptr == NODE_STATE(ksCurThread) &&
         NODE_STATE(ksSchedulerAction) == SchedulerAction_ResumeCurrentThread &&
         !isSchedulable(tptr)) {
-        rescheduleRequired();
+        /* short-cut rescheduleRequired(), because we know what the scheduler action is. */
+        NODE_STATE(ksSchedulerAction) = SchedulerAction_ChooseNewThread;
     }
 }
 


### PR DESCRIPTION
The call to rescheduleRequired within scheduleTCB
is performed only when the scheduler action is
ResumeCurrentThread, and therefore will only set
the scheduler action to ChooseNewThread. This
removes the call to rescheduleRequired and
replaces it with the direct update to the
scheduler action.