### PR TITLE
Add explicit type conversions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,7 @@ add_compile_options(
   #-----------------------------------
   -Wall
   -Werror
+  -Wconversion
   -Wstrict-prototypes
   -Wmissing-prototypes
   -Wnested-externs

--- a/include/arch/arm/arch/32/mode/fastpath/fastpath.h
+++ b/include/arch/arm/arch/32/mode/fastpath/fastpath.h
@@ -47,7 +47,7 @@ static inline void FORCE_INLINE switchToThread_fp(tcb_t *thread, pde_t *cap_pd, 
     if (config_set(CONFIG_ARM_HYPERVISOR_SUPPORT)) {
         vcpu_switch(thread->tcbArch.tcbVCPU);
     }
-    hw_asid = pde_pde_invalid_get_stored_hw_asid(stored_hw_asid);
+    hw_asid = (hw_asid_t)pde_pde_invalid_get_stored_hw_asid(stored_hw_asid);
     armv_contextSwitch_HWASID(cap_pd, hw_asid);
 
 #ifdef CONFIG_BENCHMARK_TRACK_UTILISATION

--- a/include/arch/riscv/arch/fastpath/fastpath.h
+++ b/include/arch/riscv/arch/fastpath/fastpath.h
@@ -91,7 +91,7 @@ static inline void fastpath_copy_mrs(word_t length, tcb_t *src, tcb_t *dest)
     /* assuming that length < n_msgRegisters */
     for (i = 0; i < length; i ++) {
         /* assuming that the message registers simply increment */
-        reg = msgRegisters[0] + i;
+        reg = (register_t)(msgRegisters[0] + i);
         setRegister(dest, reg, getRegister(src, reg));
     }
 }

--- a/include/arch/riscv/arch/machine.h
+++ b/include/arch/riscv/arch/machine.h
@@ -147,7 +147,7 @@ word_t PURE getRestartPC(tcb_t *thread);
 void setNextPC(tcb_t *thread, word_t v);
 
 /* Cleaning memory before user-level access. Does not flush cache. */
-static inline void clearMemory(void *ptr, unsigned int bits)
+static inline void clearMemory(void *ptr, word_t bits)
 {
     memzero(ptr, BIT(bits));
 }

--- a/include/arch/x86/arch/64/mode/fastpath/fastpath.h
+++ b/include/arch/x86/arch/64/mode/fastpath/fastpath.h
@@ -103,7 +103,7 @@ static inline void fastpath_copy_mrs(word_t length, tcb_t *src, tcb_t *dest)
     /* assuming that length < n_msgRegisters */
     for (i = 0; i < length; i ++) {
         /* assuming that the message registers simply increment */
-        reg = msgRegisters[0] + i;
+        reg = (register_t)(msgRegisters[0] + i);
         setRegister(dest, reg, getRegister(src, reg));
     }
 }

--- a/include/arch/x86/arch/machine.h
+++ b/include/arch/x86/arch/machine.h
@@ -358,7 +358,7 @@ static inline void x86_load_fsgs_base(tcb_t *thread, cpu_id_t cpu)
 }
 
 /* Cleaning memory before user-level access. Does not flush cache. */
-static inline void clearMemory(void *ptr, unsigned int bits)
+static inline void clearMemory(void *ptr, word_t bits)
 {
     memzero(ptr, BIT(bits));
 }

--- a/src/fastpath/fastpath.c
+++ b/src/fastpath/fastpath.c
@@ -39,7 +39,7 @@ void NORETURN fastpath_call(word_t cptr, word_t msgInfo)
      * saved fault. */
     if (unlikely(fastpath_mi_check(msgInfo) ||
                  fault_type != seL4_Fault_NullFault)) {
-        slowpath(SysCall);
+        slowpath((syscall_t)SysCall);
     }
 
     /* Lookup the cap */
@@ -48,7 +48,7 @@ void NORETURN fastpath_call(word_t cptr, word_t msgInfo)
     /* Check it's an endpoint */
     if (unlikely(!cap_capType_equals(ep_cap, cap_endpoint_cap) ||
                  !cap_endpoint_cap_get_capCanSend(ep_cap))) {
-        slowpath(SysCall);
+        slowpath((syscall_t)SysCall);
     }
 
     /* Get the endpoint address */
@@ -60,13 +60,13 @@ void NORETURN fastpath_call(word_t cptr, word_t msgInfo)
 
     /* Check that there's a thread waiting to receive */
     if (unlikely(endpoint_ptr_get_state(ep_ptr) != EPState_Recv)) {
-        slowpath(SysCall);
+        slowpath((syscall_t)SysCall);
     }
 
     /* ensure we are not single stepping the destination in ia32 */
 #if defined(CONFIG_HARDWARE_DEBUG_API) && defined(CONFIG_ARCH_IA32)
     if (unlikely(dest->tcbArch.tcbContext.breakpointState.single_step_enabled)) {
-        slowpath(SysCall);
+        slowpath((syscall_t)SysCall);
     }
 #endif
 
@@ -78,7 +78,7 @@ void NORETURN fastpath_call(word_t cptr, word_t msgInfo)
 
     /* Ensure that the destination has a valid VTable. */
     if (unlikely(! isValidVTableRoot_fp(newVTable))) {
-        slowpath(SysCall);
+        slowpath((syscall_t)SysCall);
     }
 
 #ifdef CONFIG_ARCH_AARCH32
@@ -101,12 +101,12 @@ void NORETURN fastpath_call(word_t cptr, word_t msgInfo)
     asid_map_t asid_map = findMapForASID(asid);
     if (unlikely(asid_map_get_type(asid_map) != asid_map_asid_map_vspace ||
                  VSPACE_PTR(asid_map_asid_map_vspace_get_vspace_root(asid_map)) != cap_pd)) {
-        slowpath(SysCall);
+        slowpath((syscall_t)SysCall);
     }
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
     /* Ensure the vmid is valid. */
     if (unlikely(!asid_map_asid_map_vspace_get_stored_vmid_valid(asid_map))) {
-        slowpath(SysCall);
+        slowpath((syscall_t)SysCall);
     }
     /* vmids are the tags used instead of hw_asids in hyp mode */
     stored_hw_asid.words[0] = asid_map_asid_map_vspace_get_stored_hw_vmid(asid_map);
@@ -125,42 +125,42 @@ void NORETURN fastpath_call(word_t cptr, word_t msgInfo)
     /* ensure only the idle thread or lower prio threads are present in the scheduler */
     if (unlikely(dest->tcbPriority < NODE_STATE(ksCurThread->tcbPriority) &&
                  !isHighestPrio(dom, dest->tcbPriority))) {
-        slowpath(SysCall);
+        slowpath((syscall_t)SysCall);
     }
 
     /* Ensure that the endpoint has has grant or grant-reply rights so that we can
      * create the reply cap */
     if (unlikely(!cap_endpoint_cap_get_capCanGrant(ep_cap) &&
                  !cap_endpoint_cap_get_capCanGrantReply(ep_cap))) {
-        slowpath(SysCall);
+        slowpath((syscall_t)SysCall);
     }
 
 #ifdef CONFIG_ARCH_AARCH32
     if (unlikely(!pde_pde_invalid_get_stored_asid_valid(stored_hw_asid))) {
-        slowpath(SysCall);
+        slowpath((syscall_t)SysCall);
     }
 #endif
 
     /* Ensure the original caller is in the current domain and can be scheduled directly. */
     if (unlikely(dest->tcbDomain != ksCurDomain && 0 < maxDom)) {
-        slowpath(SysCall);
+        slowpath((syscall_t)SysCall);
     }
 
 #ifdef CONFIG_KERNEL_MCS
     if (unlikely(dest->tcbSchedContext != NULL)) {
-        slowpath(SysCall);
+        slowpath((syscall_t)SysCall);
     }
 
     reply_t *reply = thread_state_get_replyObject_np(dest->tcbState);
     if (unlikely(reply == NULL)) {
-        slowpath(SysCall);
+        slowpath((syscall_t)SysCall);
     }
 #endif
 
 #ifdef ENABLE_SMP_SUPPORT
     /* Ensure both threads have the same affinity */
     if (unlikely(NODE_STATE(ksCurThread)->tcbAffinity != dest->tcbAffinity)) {
-        slowpath(SysCall);
+        slowpath((syscall_t)SysCall);
     }
 #endif /* ENABLE_SMP_SUPPORT */
 
@@ -265,7 +265,7 @@ void NORETURN fastpath_reply_recv(word_t cptr, word_t msgInfo)
      * saved fault. */
     if (unlikely(fastpath_mi_check(msgInfo) ||
                  fault_type != seL4_Fault_NullFault)) {
-        slowpath(SysReplyRecv);
+        slowpath((syscall_t)SysReplyRecv);
     }
 
     /* Lookup the cap */
@@ -275,7 +275,7 @@ void NORETURN fastpath_reply_recv(word_t cptr, word_t msgInfo)
     /* Check it's an endpoint */
     if (unlikely(!cap_capType_equals(ep_cap, cap_endpoint_cap) ||
                  !cap_endpoint_cap_get_capCanReceive(ep_cap))) {
-        slowpath(SysReplyRecv);
+        slowpath((syscall_t)SysReplyRecv);
     }
 
 #ifdef CONFIG_KERNEL_MCS
@@ -284,14 +284,14 @@ void NORETURN fastpath_reply_recv(word_t cptr, word_t msgInfo)
 
     /* check it's a reply object */
     if (unlikely(!cap_capType_equals(reply_cap, cap_reply_cap))) {
-        slowpath(SysReplyRecv);
+        slowpath((syscall_t)SysReplyRecv);
     }
 #endif
 
     /* Check there is nothing waiting on the notification */
     if (unlikely(NODE_STATE(ksCurThread)->tcbBoundNotification &&
                  notification_ptr_get_state(NODE_STATE(ksCurThread)->tcbBoundNotification) == NtfnState_Active)) {
-        slowpath(SysReplyRecv);
+        slowpath((syscall_t)SysReplyRecv);
     }
 
     /* Get the endpoint address */
@@ -299,7 +299,7 @@ void NORETURN fastpath_reply_recv(word_t cptr, word_t msgInfo)
 
     /* Check that there's not a thread waiting to send */
     if (unlikely(endpoint_ptr_get_state(ep_ptr) == EPState_Send)) {
-        slowpath(SysReplyRecv);
+        slowpath((syscall_t)SysReplyRecv);
     }
 
 #ifdef CONFIG_KERNEL_MCS
@@ -310,7 +310,7 @@ void NORETURN fastpath_reply_recv(word_t cptr, word_t msgInfo)
     if (unlikely(reply_ptr->replyTCB == NULL ||
                  call_stack_get_isHead(reply_ptr->replyNext) == 0 ||
                  SC_PTR(call_stack_get_callStackPtr(reply_ptr->replyNext)) != NODE_STATE(ksCurThread)->tcbSchedContext)) {
-        slowpath(SysReplyRecv);
+        slowpath((syscall_t)SysReplyRecv);
     }
 
     /* Determine who the caller is. */
@@ -320,7 +320,7 @@ void NORETURN fastpath_reply_recv(word_t cptr, word_t msgInfo)
     cte_t *callerSlot = TCB_PTR_CTE_PTR(NODE_STATE(ksCurThread), tcbCaller);
     cap_t callerCap = callerSlot->cap;
     if (unlikely(!fastpath_reply_cap_check(callerCap))) {
-        slowpath(SysReplyRecv);
+        slowpath((syscall_t)SysReplyRecv);
     }
 
     /* Determine who the caller is. */
@@ -330,7 +330,7 @@ void NORETURN fastpath_reply_recv(word_t cptr, word_t msgInfo)
     /* ensure we are not single stepping the caller in ia32 */
 #if defined(CONFIG_HARDWARE_DEBUG_API) && defined(CONFIG_ARCH_IA32)
     if (unlikely(caller->tcbArch.tcbContext.breakpointState.single_step_enabled)) {
-        slowpath(SysReplyRecv);
+        slowpath((syscall_t)SysReplyRecv);
     }
 #endif
 
@@ -341,11 +341,11 @@ void NORETURN fastpath_reply_recv(word_t cptr, word_t msgInfo)
     /* Change this as more types of faults are supported */
 #ifndef CONFIG_EXCEPTION_FASTPATH
     if (unlikely(fault_type != seL4_Fault_NullFault)) {
-        slowpath(SysReplyRecv);
+        slowpath((syscall_t)SysReplyRecv);
     }
 #else
     if (unlikely(fault_type != seL4_Fault_NullFault && fault_type != seL4_Fault_VMFault)) {
-        slowpath(SysReplyRecv);
+        slowpath((syscall_t)SysReplyRecv);
     }
 #endif
 
@@ -357,7 +357,7 @@ void NORETURN fastpath_reply_recv(word_t cptr, word_t msgInfo)
 
     /* Ensure that the destination has a valid MMU. */
     if (unlikely(! isValidVTableRoot_fp(newVTable))) {
-        slowpath(SysReplyRecv);
+        slowpath((syscall_t)SysReplyRecv);
     }
 
 #ifdef CONFIG_ARCH_AARCH32
@@ -378,12 +378,12 @@ void NORETURN fastpath_reply_recv(word_t cptr, word_t msgInfo)
     asid_map_t asid_map = findMapForASID(asid);
     if (unlikely(asid_map_get_type(asid_map) != asid_map_asid_map_vspace ||
                  VSPACE_PTR(asid_map_asid_map_vspace_get_vspace_root(asid_map)) != cap_pd)) {
-        slowpath(SysReplyRecv);
+        slowpath((syscall_t)SysReplyRecv);
     }
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
     /* Ensure the vmid is valid. */
     if (unlikely(!asid_map_asid_map_vspace_get_stored_vmid_valid(asid_map))) {
-        slowpath(SysReplyRecv);
+        slowpath((syscall_t)SysReplyRecv);
     }
 
     /* vmids are the tags used instead of hw_asids in hyp mode */
@@ -400,31 +400,31 @@ void NORETURN fastpath_reply_recv(word_t cptr, word_t msgInfo)
     /* Ensure the original caller can be scheduled directly. */
     dom = maxDom ? ksCurDomain : 0;
     if (unlikely(!isHighestPrio(dom, caller->tcbPriority))) {
-        slowpath(SysReplyRecv);
+        slowpath((syscall_t)SysReplyRecv);
     }
 
 #ifdef CONFIG_ARCH_AARCH32
     /* Ensure the HWASID is valid. */
     if (unlikely(!pde_pde_invalid_get_stored_asid_valid(stored_hw_asid))) {
-        slowpath(SysReplyRecv);
+        slowpath((syscall_t)SysReplyRecv);
     }
 #endif
 
     /* Ensure the original caller is in the current domain and can be scheduled directly. */
     if (unlikely(caller->tcbDomain != ksCurDomain && 0 < maxDom)) {
-        slowpath(SysReplyRecv);
+        slowpath((syscall_t)SysReplyRecv);
     }
 
 #ifdef CONFIG_KERNEL_MCS
     if (unlikely(caller->tcbSchedContext != NULL)) {
-        slowpath(SysReplyRecv);
+        slowpath((syscall_t)SysReplyRecv);
     }
 #endif
 
 #ifdef ENABLE_SMP_SUPPORT
     /* Ensure both threads have the same affinity */
     if (unlikely(NODE_STATE(ksCurThread)->tcbAffinity != caller->tcbAffinity)) {
-        slowpath(SysReplyRecv);
+        slowpath((syscall_t)SysReplyRecv);
     }
 #endif /* ENABLE_SMP_SUPPORT */
 
@@ -570,7 +570,7 @@ void NORETURN fastpath_signal(word_t cptr, word_t msgInfo)
     /* Check there's no saved fault. Can be removed if the current thread can't
      * have a fault while invoking the fastpath */
     if (unlikely(fault_type != seL4_Fault_NullFault)) {
-        slowpath(SysSend);
+        slowpath((syscall_t)SysSend);
     }
 
     /* Lookup the cap */
@@ -578,17 +578,17 @@ void NORETURN fastpath_signal(word_t cptr, word_t msgInfo)
 
     /* Check it's a notification */
     if (unlikely(!cap_capType_equals(cap, cap_notification_cap))) {
-        slowpath(SysSend);
+        slowpath((syscall_t)SysSend);
     }
 
     /* Check that we are allowed to send to this cap */
     if (unlikely(!cap_notification_cap_get_capNtfnCanSend(cap))) {
-        slowpath(SysSend);
+        slowpath((syscall_t)SysSend);
     }
 
     /* Check that the current domain hasn't expired */
     if (unlikely(isCurDomainExpired())) {
-        slowpath(SysSend);
+        slowpath((syscall_t)SysSend);
     }
 
     /* Get the notification address */
@@ -636,13 +636,13 @@ void NORETURN fastpath_signal(word_t cptr, word_t msgInfo)
     if (!sc) {
         sc = SC_PTR(notification_ptr_get_ntfnSchedContext(ntfnPtr));
         if (sc == NULL || sc->scTcb != NULL) {
-            slowpath(SysSend);
+            slowpath((syscall_t)SysSend);
         }
 
         /* Slowpath the case where dest has its FPU context in the FPU of a core*/
 #if defined(ENABLE_SMP_SUPPORT) && defined(CONFIG_HAVE_FPU)
         if (nativeThreadUsingFPU(dest)) {
-            slowpath(SysSend);
+            slowpath((syscall_t)SysSend);
         }
 #endif
     }
@@ -650,7 +650,7 @@ void NORETURN fastpath_signal(word_t cptr, word_t msgInfo)
     /* Only fastpath signal to threads which will not become the new highest prio thread on the
      * core of their SC, even if the currently running thread on the core is the idle thread. */
     if (NODE_STATE_ON_CORE(ksCurThread, sc->scCore)->tcbPriority < dest->tcbPriority) {
-        slowpath(SysSend);
+        slowpath((syscall_t)SysSend);
     }
 
     /* Simplified schedContext_resume that does not change state and reverts to the
@@ -660,7 +660,7 @@ void NORETURN fastpath_signal(word_t cptr, word_t msgInfo)
      * that will affect the conditions of this check */
     if (sc->scRefillMax > 0) {
         if (!(refill_ready(sc) && refill_sufficient(sc, 0))) {
-            slowpath(SysSend);
+            slowpath((syscall_t)SysSend);
         }
         schedulable = true;
     }

--- a/src/object/tcb.c
+++ b/src/object/tcb.c
@@ -561,7 +561,7 @@ static exception_t decodeConfigureSingleStepping(cap_t cap, bool_t call, word_t 
 
     tcb = TCB_PTR(cap_thread_cap_get_capTCBPtr(cap));
 
-    bp_num = getSyscallArg(0, buffer);
+    bp_num = (uint16_t)getSyscallArg(0, buffer);
     n_instrs = getSyscallArg(1, buffer);
 
     syserr = Arch_decodeConfigureSingleStepping(tcb, bp_num, n_instrs, false);
@@ -591,7 +591,7 @@ static exception_t decodeSetBreakpoint(cap_t cap, word_t *buffer)
     syscall_error_t error;
 
     tcb = TCB_PTR(cap_thread_cap_get_capTCBPtr(cap));
-    bp_num = getSyscallArg(0, buffer);
+    bp_num = (uint16_t)getSyscallArg(0, buffer);
     vaddr = getSyscallArg(1, buffer);
     type = getSyscallArg(2, buffer);
     size = getSyscallArg(3, buffer);
@@ -727,7 +727,7 @@ static exception_t decodeGetBreakpoint(cap_t cap, bool_t call, word_t *buffer)
     syscall_error_t error;
 
     tcb = TCB_PTR(cap_thread_cap_get_capTCBPtr(cap));
-    bp_num = getSyscallArg(0, buffer);
+    bp_num = (uint16_t)getSyscallArg(0, buffer);
 
     error = Arch_decodeGetBreakpoint(tcb, bp_num);
     if (error.type != seL4_NoError) {
@@ -754,7 +754,7 @@ static exception_t decodeUnsetBreakpoint(cap_t cap, word_t *buffer)
     syscall_error_t error;
 
     tcb = TCB_PTR(cap_thread_cap_get_capTCBPtr(cap));
-    bp_num = getSyscallArg(0, buffer);
+    bp_num = (uint16_t)getSyscallArg(0, buffer);
 
     error = Arch_decodeUnsetBreakpoint(tcb, bp_num);
     if (error.type != seL4_NoError) {

--- a/src/object/untyped.c
+++ b/src/object/untyped.c
@@ -204,7 +204,7 @@ exception_t decodeUntypedInvocation(word_t invLabel, word_t length, cte_t *slot,
         userError("Untyped Retype: Insufficient memory "
                   "(%lu * %lu bytes needed, %lu bytes available).",
                   (word_t)nodeWindow,
-                  (objectSize >= wordBits ? -1 : (1ul << objectSize)),
+                  (objectSize >= wordBits ? (word_t)-1 : (1ul << objectSize)),
                   (word_t)(untypedFreeBytes));
         current_syscall_error.type = seL4_NotEnoughMemory;
         current_syscall_error.memoryLeft = untypedFreeBytes;
@@ -236,7 +236,7 @@ static exception_t resetUntypedCap(cte_t *srcSlot)
     cap_t prev_cap = srcSlot->cap;
     word_t block_size = cap_untyped_cap_get_capBlockSize(prev_cap);
     void *regionBase = WORD_PTR(cap_untyped_cap_get_capPtr(prev_cap));
-    int chunk = CONFIG_RESET_CHUNK_BITS;
+    word_t chunk = CONFIG_RESET_CHUNK_BITS;
     word_t offset = FREE_INDEX_TO_OFFSET(cap_untyped_cap_get_capFreeIndex(prev_cap));
     exception_t status;
     bool_t deviceMemory = cap_untyped_cap_get_capIsDevice(prev_cap);
@@ -257,7 +257,7 @@ static exception_t resetUntypedCap(cte_t *srcSlot)
         srcSlot->cap = cap_untyped_cap_set_capFreeIndex(prev_cap, 0);
     } else {
         for (offset = ROUND_DOWN(offset - 1, chunk);
-             offset != - BIT(chunk); offset -= BIT(chunk)) {
+             offset != -BIT(chunk); offset -= BIT(chunk)) {
             clearMemory(GET_OFFSET_FREE_PTR(regionBase, offset), chunk);
             srcSlot->cap = cap_untyped_cap_set_capFreeIndex(prev_cap, OFFSET_TO_FREE_INDEX(offset));
             status = preemptionPoint();

--- a/src/util.c
+++ b/src/util.c
@@ -129,7 +129,7 @@ long PURE str_to_long(const char *str)
         if (res == -1 || res >= base) {
             return -1;
         }
-        val = val * base + res;
+        val = val * (long)base + res;
         str++;
         c = *str;
     }
@@ -300,7 +300,7 @@ static UNUSED CONST inline unsigned clz64(uint64_t x)
         count -= bits; // [1, 2, 3, ..., 64]
     }
 
-    return count - x;
+    return (unsigned)(count - x);
 }
 
 // Count trailing zeros.
@@ -426,27 +426,27 @@ static UNUSED CONST inline unsigned ctz64(uint64_t x)
 #ifdef CONFIG_CLZ_32
 CONST int __clzsi2(uint32_t x)
 {
-    return clz32(x);
+    return (int)clz32(x);
 }
 #endif
 
 #ifdef CONFIG_CLZ_64
 CONST int __clzdi2(uint64_t x)
 {
-    return clz64(x);
+    return (int)clz64(x);
 }
 #endif
 
 #ifdef CONFIG_CTZ_32
 CONST int __ctzsi2(uint32_t x)
 {
-    return ctz32(x);
+    return (int)ctz32(x);
 }
 #endif
 
 #ifdef CONFIG_CTZ_64
 CONST int __ctzdi2(uint64_t x)
 {
-    return ctz64(x);
+    return (int)ctz64(x);
 }
 #endif


### PR DESCRIPTION
This is in preparation for turning on -Wconversion:
- fastpath.h: Cast to register_t from a + b is safe
- fastpath.h: Cast to hw_asid_t is safe from bitfield.
- machine.h: Change clearMemory to take word_t type. This is aligned with arm.
- util.c: int cast to match up with compiler builtins
- util.c: long cast in str_to_long()
- fastpath.c: syscall_t cast for negative syscall numbers
- tcb.c: intentionally cast to breakpoint number type.
- untyped.c: Retype chunk to word_t.
