### PR TITLE
aarch32,vspace: check stale mapping on page flush

### DIFF
--- a/libsel4/arch_include/arm/interfaces/object-api-arch.xml
+++ b/libsel4/arch_include/arm/interfaces/object-api-arch.xml
@@ -287,7 +287,8 @@
             </error>
             <error name="seL4_InvalidCapability">
                 <description>
-                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type or
+                    represents a stale mapping.
                 </description>
             </error>
         </method>
@@ -325,7 +326,8 @@
             </error>
             <error name="seL4_InvalidCapability">
                 <description>
-                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type or
+                    represents a stale mapping.
                 </description>
             </error>
         </method>
@@ -362,7 +364,8 @@
             </error>
             <error name="seL4_InvalidCapability">
                 <description>
-                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type or
+                    represents a stale mapping.
                 </description>
             </error>
         </method>
@@ -400,7 +403,8 @@
             </error>
             <error name="seL4_InvalidCapability">
                 <description>
-                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type or
+                    represents a stale mapping.
                 </description>
             </error>
         </method>

--- a/src/arch/arm/32/kernel/vspace.c
+++ b/src/arch/arm/32/kernel/vspace.c
@@ -2439,6 +2439,22 @@ static exception_t decodeARMFrameInvocation(word_t invLabel, word_t length,
             return EXCEPTION_SYSCALL_ERROR;
         }
 
+#ifndef CONFIG_ARM_HYPERVISOR_SUPPORT
+        /* When not in hypervisor mode, we flush via user virtual addresses and
+           need to make sure the mapping info in the cap is not stale. */
+        {
+            resolve_ret_t resolve_ret = resolveVAddr(pd.pd, vaddr);
+            if (unlikely(!resolve_ret.valid ||
+                         resolve_ret.frameSize != generic_frame_cap_get_capFSize(cap) ||
+                         resolve_ret.frameBase != addrFromPPtr((void *)generic_frame_cap_get_capFBasePtr(cap)))) {
+                userError("Page Flush: Attempting to use cap with stale mapping information.");
+                current_syscall_error.type = seL4_InvalidCapability;
+                current_syscall_error.invalidCapNumber = 0;
+                return EXCEPTION_SYSCALL_ERROR;
+            }
+        }
+#endif
+
         start = getSyscallArg(0, buffer);
         end =   getSyscallArg(1, buffer);
 

--- a/src/arch/arm/32/kernel/vspace.c
+++ b/src/arch/arm/32/kernel/vspace.c
@@ -2457,6 +2457,20 @@ static exception_t decodeARMFrameInvocation(word_t invLabel, word_t length,
         page_size = 1 << pageBitsForSize(generic_frame_cap_get_capFSize(cap));
         page_base = addrFromPPtr((void *)generic_frame_cap_get_capFBasePtr(cap));
 
+#ifndef CONFIG_ARM_HYPERVISOR_SUPPORT
+        /* When not in hypervisor mode, we flush via user virtual addresses and
+           need to make sure the mapping info in the cap is not stale. */
+        resolve_ret_t resolve_ret = resolveVAddr(pd.pd, vaddr);
+        if (unlikely(!resolve_ret.valid ||
+                     resolve_ret.frameSize != generic_frame_cap_get_capFSize(cap) ||
+                     resolve_ret.frameBase != page_base)) {
+            userError("Page Flush: Attempting to use cap with stale mapping information.");
+            current_syscall_error.type = seL4_InvalidCapability;
+            current_syscall_error.invalidCapNumber = 0;
+            return EXCEPTION_SYSCALL_ERROR;
+        }
+#endif
+
         if (start >= page_size || end > page_size) {
             userError("Page Flush: Requested range not inside page");
             current_syscall_error.type = seL4_InvalidArgument;


### PR DESCRIPTION
A frame cap with stale ASID/virtual address mapping info could be used to flush incorrect memory regions via ARMPageClean_Data, ARMPageInvalidate_Data, ARMPageCleanInvalidate_Data, or ARMPageUnify_Instruction. Add a stale mapping check using resolveVAddr to verify the page table entry still matches the cap's frame size and physical base address before authorising the flush.

This mirrors the AArch64 EL1 fix from PR #1282 for the AArch32 non-hypervisor configuration.

See also #1281