### PR TITLE
arm,cmake: make verification and release equal

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,12 +21,19 @@ description indicates whether it is SOURCE-COMPATIBLE, BINARY-COMPATIBLE, or BRE
 
 ---
 
-## Upcoming release: BINARY COMPATIBLE
+## Upcoming release: BREAKING
 
 ### Changes
 
+#### ARM
+
+* change default for `KernelArmHypEnableVCPUCP14SaveAndRestore` to `OFF` to provide equal defaults for
+  verification and release builds. This affects AArch32/hyp only.
 
 ### Upgrade Notes
+
+AArch32 with hypervisor mode enabled only: if the option `KernelArmHypEnableVCPUCP14SaveAndRestore` is required, manually set it to `ON` in the build.
+
 ---
 
 ## 15.0.0 2026-03-31: BREAKING

--- a/src/arch/arm/config.cmake
+++ b/src/arch/arm/config.cmake
@@ -97,7 +97,7 @@ config_option(
     context for performance (or other) reasons, we can just turn them off \
     and trap them instead, and have the VCPUs' accesses to CP14 \
     intercepted and delivered to the VM Monitor as fault messages"
-  DEFAULT ON
+  DEFAULT OFF
   DEPENDS "KernelSel4ArchArmHyp;NOT KernelVerificationBuild"
   DEFAULT_DISABLED OFF)
 


### PR DESCRIPTION
Make verification and release builds equal by setting the default for `KernelArmHypEnableVCPUCP14SaveAndRestore` to `OFF`. The option is still available to set in non-verification builds, only the default changes.
