### PR TITLE
github: update artifact path

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -21,4 +21,4 @@ jobs:
     - uses: actions/upload-artifact@v4
       with:
         name: PDF
-        path: manual/manual.pdf
+        path: checkout/manual/manual.pdf


### PR DESCRIPTION
The upstream action in the ci-actions repository has changed slightly and leaves the PDF in a different location.