### PR TITLE
suspend: move call to setThreadState

### DIFF
--- a/src/kernel/thread.c
+++ b/src/kernel/thread.c
@@ -80,12 +80,12 @@ void suspend(tcb_t *target)
          * running */
         updateRestartPC(target);
     }
-    setThreadState(target, ThreadState_Inactive);
     tcbSchedDequeue(target);
 #ifdef CONFIG_KERNEL_MCS
     tcbReleaseRemove(target);
     schedContext_cancelYieldTo(target);
 #endif
+    setThreadState(target, ThreadState_Inactive);
 }
 
 void restart(tcb_t *target)


### PR DESCRIPTION
The call to setThreadState within suspend is
moved to the end of the function, in order to
preserve invariants about the queues.