### PR TITLE
github: provide base branch for preprocess check

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,3 +33,4 @@ jobs:
       with:
         L4V_ARCH: ${{ matrix.arch }}
         L4V_FEATURES: ${{ matrix.feature }}
+        BASE_REF: ${{ github.base_ref }}


### PR DESCRIPTION
For preprocess checks on pull requests, check against the base_ref of the pull request (e.g. master) instead of against the seL4 revision in the verification manifest.

If base_ref has advanced over the verification manifest revision, we do not want to see that difference again on pull requests, but only the difference the pull request causes itself.

Needs https://github.com/seL4/ci-actions/pull/452 before we can merge.

Closes #1299 