### PR TITLE
mcs: refactor some functions to ease verification

### DIFF
--- a/src/object/endpoint.c
+++ b/src/object/endpoint.c
@@ -93,12 +93,13 @@ void sendIPC(bool_t blocking, bool_t do_call, word_t badge,
             schedContext_donate(thread->tcbSchedContext, dest);
         }
 
-        /* blocked threads should have enough budget to get out of the kernel */
-        assert(dest->tcbSchedContext == NULL || refill_sufficient(dest->tcbSchedContext, 0));
-        assert(dest->tcbSchedContext == NULL || refill_ready(dest->tcbSchedContext));
         setThreadState(dest, ThreadState_Running);
-        if (sc_sporadic(dest->tcbSchedContext) && dest->tcbSchedContext != NODE_STATE(ksCurSC)) {
-            refill_unblock_check(dest->tcbSchedContext);
+        sched_context_t *dest_sc = dest->tcbSchedContext;
+        /* blocked threads should have enough budget to get out of the kernel */
+        assert(dest_sc == NULL || refill_sufficient(dest_sc, 0));
+        assert(dest_sc == NULL || refill_ready(dest_sc));
+        if (sc_sporadic(dest_sc) && dest_sc != NODE_STATE(ksCurSC)) {
+            refill_unblock_check(dest_sc);
         }
         possibleSwitchTo(dest);
 #else
@@ -138,9 +139,10 @@ void receiveIPC(tcb_t *thread, cap_t cap, bool_t isBlocking)
     reply_t *replyPtr = NULL;
     if (cap_get_capType(replyCap) == cap_reply_cap) {
         replyPtr = REPLY_PTR(cap_reply_cap_get_capReplyPtr(replyCap));
-        if (unlikely(replyPtr->replyTCB != NULL && replyPtr->replyTCB != thread)) {
+        tcb_t *reply_tcb = replyPtr->replyTCB;
+        if (unlikely(reply_tcb != NULL && reply_tcb != thread)) {
             userError("Reply object already has unexecuted reply!");
-            cancelIPC(replyPtr->replyTCB);
+            cancelIPC(reply_tcb);
         }
     }
 #endif
@@ -173,14 +175,16 @@ void receiveIPC(tcb_t *thread, cap_t cap, bool_t isBlocking)
                     &thread->tcbState, EP_REF(epptr));
 #ifdef CONFIG_KERNEL_MCS
                 thread_state_ptr_set_replyObject(&thread->tcbState, REPLY_REF(replyPtr));
-                if (replyPtr) {
-                    replyPtr->replyTCB = thread;
-                }
 #else
                 thread_state_ptr_set_blockingIPCCanGrant(
                     &thread->tcbState, cap_endpoint_cap_get_capCanGrant(cap));
 #endif
                 scheduleTCB(thread);
+#ifdef CONFIG_KERNEL_MCS
+                if (replyPtr) {
+                    replyPtr->replyTCB = thread;
+                }
+#endif
 
                 /* Place calling thread in endpoint queue */
                 queue = ep_ptr_get_queue(epptr);

--- a/src/object/tcb.c
+++ b/src/object/tcb.c
@@ -315,12 +315,11 @@ void tcbReleaseEnqueue(tcb_t *tcb)
     ticks_t new_time;
     tcb_queue_t queue;
 
-    new_time = tcbReadyTime(tcb);
     queue = NODE_STATE_ON_CORE(ksReleaseQueue, tcb->tcbAffinity);
+    new_time = tcbReadyTime(tcb);
 
     if (tcb_queue_empty(queue) || new_time < tcbReadyTime(queue.head)) {
         NODE_STATE_ON_CORE(ksReleaseQueue, tcb->tcbAffinity) = tcb_queue_prepend(queue, tcb);
-        NODE_STATE_ON_CORE(ksReprogram, tcb->tcbAffinity) = true;
     } else {
         if (tcbReadyTime(queue.end) <= new_time) {
             NODE_STATE_ON_CORE(ksReleaseQueue, tcb->tcbAffinity) = tcb_queue_append(queue, tcb);
@@ -332,6 +331,10 @@ void tcbReleaseEnqueue(tcb_t *tcb)
     }
 
     thread_state_ptr_set_tcbInReleaseQueue(&tcb->tcbState, true);
+
+    if (queue.head != NODE_STATE_ON_CORE(ksReleaseQueue, tcb->tcbAffinity).head) {
+        NODE_STATE_ON_CORE(ksReprogram, tcb->tcbAffinity) = true;
+    }
 }
 #endif
 


### PR DESCRIPTION
- separate the update of the release queue in tcbReleaseEnqueue from the setting of ksReprogramTimer, so that verification may reason uniformly abbout the update of the queue.

- use local variables in sendIPC and receiveIPC to avoid repeated accesses of the heap.

- move the update of the replyTCB field in receiveIPC so that the updates related to the thread state are grouped together, to more closely align with the Haskell specification.