### PR TITLE
CHANGES.md: add missing copyright

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -4,7 +4,6 @@ Upstream-Contact: seL4 team <support@sel4.systems>
 Source: http://sel4.systems
 
 Files:
-  CHANGES
   VERSION
   manual/VERSION
   manual/references.bib

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,7 @@
-<!-- SPDX-License-Identifier: CC-BY-SA-4.0 -->
+<!--
+  Copyright 2020 Data61, CSIRO (ABN 41 687 119 230)
+  SPDX-License-Identifier: CC-BY-SA-4.0
+-->
 
 # Revision History for seL4
 


### PR DESCRIPTION
When we renamed CHANGES to CHANGES.md, the copyright info from reuse/dep5 for CHANGES was not transferred.

Remove CHANGES from .reuse/dep5 and add info to CHANGES.md directly.

I do not know why the license check previously did not flag this, but it does flag it now after we are installing `python` and `reuse` via `venv`. It's possible that this selects a more recent `reuse` version.
