### PR TITLE
libsel4/riscv: avoid gcc 14.2 miscompilation

### DIFF
--- a/libsel4/arch_include/riscv/sel4/arch/syscalls.h
+++ b/libsel4/arch_include/riscv/sel4/arch/syscalls.h
@@ -687,8 +687,8 @@ LIBSEL4_INLINE_FUNC seL4_MessageInfo_t seL4_NBSendWaitWithMRs(seL4_CPtr dest, se
 
 LIBSEL4_INLINE_FUNC void seL4_Yield(void)
 {
-    register seL4_Word scno asm("a7") = seL4_SysYield;
-    asm volatile("ecall" :: "r"(scno));
+    riscv_sys_null(seL4_SysYield);
+    asm volatile("" ::: "memory");
 }
 
 #ifdef CONFIG_KERNEL_MCS


### PR DESCRIPTION
a7 is not changed by seL4_Yield, so the original declaration is correct.

However, in some loops GCC 14.2 with -O3 may drop the load to a7 if a7 is not declared as clobbered in the assembly block. This is a problem if *other* code does write to a7. For some reason GCC 14.2 does not recognise those other loads. GCC 14.3 and GCC 15 both work as expected.

The problem manifests in SCHED0011 in sel4test.

This change works around the GCC 14.2 problem because GCC 14.2 is the standard Debian trixie compiler and it is likely that people will hit the problem even if we say that GCC 14.2 should not be used. The workaround puts the load into the assembly block and declares it as being clobbered.

(Edit: workaround changed during the discussion below)

See also the discussion in #1650

I'm planning to update the default compiler in docker to something else, so that we're using a more reliable toolchain in general, but we still need to work around the issue for gcc 14.2.