### PR TITLE
mcs: idle threads should have maximum period

### DIFF
--- a/include/kernel/sporadic.h
+++ b/include/kernel/sporadic.h
@@ -46,7 +46,8 @@
  * than 2^62. */
 #define MAX_PERIOD_US (getMaxUsToTicks() / 8)
 #endif /* CONFIG_KERNEL_STATIC_MAX_PERIOD_US != 0 */
-#define MAX_RELEASE_TIME (UINT64_MAX - 5 * usToTicks(MAX_PERIOD_US))
+#define MAX_PERIOD_TICKS (usToTicks(MAX_PERIOD_US))
+#define MAX_RELEASE_TIME (UINT64_MAX - 5 * MAX_PERIOD_TICKS)
 
 /* Short hand for accessing refill queue items */
 static inline refill_t *refill_index(sched_context_t *sc, word_t index)

--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -484,7 +484,7 @@ BOOT_CODE void create_idle_thread(void)
         SMP_COND_STATEMENT(NODE_STATE_ON_CORE(ksIdleThread, i)->tcbAffinity = i);
 #ifdef CONFIG_KERNEL_MCS
         configure_sched_context(NODE_STATE_ON_CORE(ksIdleThread, i), SC_PTR(&ksIdleThreadSC[SMP_TERNARY(i, 0)]),
-                                usToTicks(CONFIG_BOOT_THREAD_TIME_SLICE * US_IN_MS));
+                                MAX_PERIOD_TICKS);
         SMP_COND_STATEMENT(NODE_STATE_ON_CORE(ksIdleThread, i)->tcbSchedContext->scCore = i;)
         NODE_STATE_ON_CORE(ksIdleSC, i) = SC_PTR(&ksIdleThreadSC[SMP_TERNARY(i, 0)]);
 #endif


### PR DESCRIPTION
mcs: idle threads should have maximum period

Setting this to the boot thread time slice makes no sense, as the only case where this would matter not being the maximum is if round-robin is occurring. This just means when you're in the idle thread you're constantly getting interrupts every 5ms, for no reason at all. This would mess with any power savings you'd see from an idle core in `wfi`, for example.

I'd argue that BOOT_THREAD_TIME_SLICE sort of doesn't matter either for MCS (and it should be instead `getMaxTicksToUs()` as well); userland can configure this if it wants instead of the kernel parameter existing. But I suppose it doesn't matter that much and might break existing userspace.