### PR TITLE
x86: fix EPT rights

### DIFF
--- a/include/arch/x86/arch/kernel/vspace.h
+++ b/include/arch/x86/arch/kernel/vspace.h
@@ -111,6 +111,7 @@ exception_t decodeIA32PageDirectoryInvocation(word_t invLabel, word_t length, ct
 exception_t decodeX86FrameInvocation(word_t invLabel, word_t length, cte_t *cte, cap_t cap,
                                      bool_t call, word_t *buffer);
 
+uint32_t CONST ReadableFromVMRights(vm_rights_t vm_rights);
 uint32_t CONST WritableFromVMRights(vm_rights_t vm_rights);
 uint32_t CONST SuperUserFromVMRights(vm_rights_t vm_rights);
 

--- a/src/arch/x86/kernel/ept.c
+++ b/src/arch/x86/kernel/ept.c
@@ -887,7 +887,7 @@ exception_t decodeX86EPTPageMap(
                   eptCacheFromVmAttr(vmAttr),
                   1,
                   WritableFromVMRights(vmRights),
-                  1);
+                  ReadableFromVMRights(vmRights));
 
         setThreadState(NODE_STATE(ksCurThread), ThreadState_Restart);
         return performEPTPageMapPTE(cap, cte, lu_ret.ptSlot, pte, pml4);
@@ -934,7 +934,7 @@ exception_t decodeX86EPTPageMap(
                              eptCacheFromVmAttr(vmAttr),
                              1,
                              WritableFromVMRights(vmRights),
-                             1);
+                             ReadableFromVMRights(vmRights));
 
         ept_pde_t pde2 = ept_pde_ept_pde_2m_new(
                              paddr + BIT(EPT_PD_INDEX_OFFSET),
@@ -943,7 +943,7 @@ exception_t decodeX86EPTPageMap(
                              eptCacheFromVmAttr(vmAttr),
                              1,
                              WritableFromVMRights(vmRights),
-                             1);
+                             ReadableFromVMRights(vmRights));
 
         setThreadState(NODE_STATE(ksCurThread), ThreadState_Restart);
         return performEPTPageMapPDE(cap, cte, lu_ret.pdSlot, pde1, pde2, pml4);

--- a/src/arch/x86/kernel/vspace.c
+++ b/src/arch/x86/kernel/vspace.c
@@ -586,13 +586,28 @@ exception_t handleVMFault(tcb_t *thread, vm_fault_type_t vm_faultType)
     }
 }
 
+uint32_t CONST ReadableFromVMRights(vm_rights_t vm_rights)
+{
+    switch (vm_rights) {
+    case VMKernelOnly:
+        return 0;
+
+    case VMReadOnly:
+    case VMReadWrite:
+        return 1;
+
+    default:
+        fail("Invalid VM rights");
+    }
+}
+
 uint32_t CONST WritableFromVMRights(vm_rights_t vm_rights)
 {
     switch (vm_rights) {
+    case VMKernelOnly:
     case VMReadOnly:
         return 0;
 
-    case VMKernelOnly:
     case VMReadWrite:
         return 1;
 


### PR DESCRIPTION
Fixes two bugs related to access rights for EPT mappings.

EPTs are always mapped with read-access although they have a dedicated read-bit.
Also `WritableFromVMRights(KernelOnly)` returns `1` which results in a frame with no rights to be mapped with full read/write access rights.