### PR TITLE
x86_64/vspace: made init_syscall_msrs not bootcode

### DIFF
--- a/src/arch/x86/64/kernel/vspace.c
+++ b/src/arch/x86/64/kernel/vspace.c
@@ -327,7 +327,7 @@ BOOT_CODE void init_tss(tss_t *tss)
            sizeof(x86KSGlobalState[CURRENT_CPU_INDEX()].x86KStss.io_map));
 }
 
-BOOT_CODE void init_syscall_msrs(void)
+void init_syscall_msrs(void)
 {
     x86_wrmsr(IA32_LSTAR_MSR, (uint64_t)&handle_fastsyscall);
     // mask bit 9 in the kernel (which is the interrupt enable bit)


### PR DESCRIPTION
`init_syscall_msrs()` is also called by `vcpu_restore_host_msrs()` so should not be BOOT_CODE.