### PR TITLE
x86_64/c_traps.c: patch Virtual Machine escape

### DIFF
--- a/src/arch/x86/64/c_traps.c
+++ b/src/arch/x86/64/c_traps.c
@@ -180,18 +180,16 @@ static void NORETURN restore_vmx(tcb_t *cur_thread, vcpu_t *vcpu)
         "leaq kernel_stack_alloc + %c[stack_size], %%rsp\n"
 #endif
 #endif /* CONFIG_X86_64_VTX_64BIT_GUESTS */
-        "movq %[failed], %%rax\n"
+        "leaq vmlaunch_failed(%%rip), %%rax\n"
         "jmp *%%rax\n"
         :
         : [reg]"r"(&vcpu->gp_registers[VCPU_EAX]),
         [launched]"r"(&vcpu->launched),
 #ifdef CONFIG_X86_64_VTX_64BIT_GUESTS
-        [failed]"r"(vmlaunch_failed),
         [stack_size]"i"(BIT(CONFIG_KERNEL_STACK_BITS)),
         [guest_msr]"r"(&vcpu->guest_msr_registers[VCPU_GS]),
         [host_msr]"r"(&vcpu->host_msr_registers[n_vcpu_msr_register])
 #else /* not CONFIG_X86_64_VTX_64BIT_GUESTS */
-        [failed]"i"(&vmlaunch_failed),
         [stack_size]"i"(BIT(CONFIG_KERNEL_STACK_BITS))
 #ifdef ENABLE_SMP_SUPPORT
         , [stack_offset]"i"(OFFSETOF(nodeInfo_t, stackTop))


### PR DESCRIPTION
The original `restore_vmx()` inline assembly passes the vmlaunch_failed
function pointer as a standard register constraint ("r"). Consequently,
the compiler allocates this pointer to a general-purpose register before
the assembly block begins.

However, immediately prior to executing vmlaunch or vmresume, the kernel
restores the guest's state via a sequence of popq instructions that
overwrite every general-purpose register. If the VM entry fails (e.g.,
due to an invalid VMCS state), execution falls through to the failure
path, which then attempts to jump to the register originally holding the
function pointer.

Because this register was just overwritten with guest-controlled data,
the kernel will jump to an arbitrary memory address dictated by the
guest. A malicious guest OS can exploit this by placing a payload
address in the targeted register and intentionally corrupting its VMCS
state (e.g. by compromising the userspace VMM) to force an entry
failure, achieving full VM escape and arbitrary code execution in the
kernel.

This patch fixes the vulnerability by using a RIP-relative `lea`
instruction to calculate the handler's address dynamically at the exact
moment of failure, entirely bypassing the clobbered registers.

I've managed to trigger this bug by compiling the kernel with LLVM. On
a VM Entry fail, the kernel would just crash because it jumped to a
random location. But after the fix, it no longer crashes and was able to
print out the error message in `vmlaunch_failed()`.