### PR TITLE
aarch64: use valid MemAttr values for Stage-2 PT

### DIFF
--- a/src/arch/arm/64/kernel/vspace.c
+++ b/src/arch/arm/64/kernel/vspace.c
@@ -219,10 +219,10 @@ BOOT_CODE void map_kernel_frame(paddr_t paddr, pptr_t vaddr, vm_rights_t vm_righ
     word_t attr_index;
     word_t shareable;
     if (vm_attributes_get_armPageCacheable(attributes)) {
-        attr_index = NORMAL;
+        attr_index = config_set(CONFIG_ARM_HYPERVISOR_SUPPORT) ? S2_NORMAL : NORMAL;
         shareable = SMP_TERNARY(SMP_SHARE, 0);
     } else {
-        attr_index = DEVICE_nGnRnE;
+        attr_index = config_set(CONFIG_ARM_HYPERVISOR_SUPPORT) ? S2_DEVICE_nGnRnE : DEVICE_nGnRnE;
         shareable = 0;
     }
     armKSGlobalKernelPT[GET_KPT_INDEX(vaddr, KLVL_FRM_ARM_PT_LVL(3))] = pte_pte_4k_page_new(uxn, paddr,
@@ -279,7 +279,11 @@ BOOT_CODE void map_kernel_window(void)
                                                                                                                         1,                        /* access flag */
                                                                                                                         SMP_TERNARY(SMP_SHARE, 0),        /* Inner-shareable if SMP enabled, otherwise unshared */
                                                                                                                         0,                        /* VMKernelOnly */
+#ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
+                                                                                                                        S2_NORMAL
+#else
                                                                                                                         NORMAL
+#endif
                                                                                                                     );
         vaddr += BIT(seL4_LargePageBits);
     }
@@ -1994,7 +1998,11 @@ exception_t benchmark_arch_map_logBuffer(word_t frame_cptr)
                              1,                         /* access flag */
                              SMP_TERNARY(SMP_SHARE, 0), /* Inner-shareable if SMP enabled, otherwise unshared */
                              0,                         /* VMKernelOnly */
+#ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
+                             S2_NORMAL_INNER_WTC_OUTER_WTC);
+#else
                              NORMAL_WT);
+#endif
 
     cleanByVA_PoU((vptr_t)armKSGlobalLogPTE, addrFromKPPtr(armKSGlobalLogPTE));
     invalidateTranslationSingle(KS_LOG_PPTR);


### PR DESCRIPTION
For AArch64 with hypervisor mode, the kernel uses the Stage 2 translation table format. However, for the boot-time setup of the kernel virtual address space, the code uses the "NORMAL" value as defined for Stage 1 by the `MAIR_EL1` register that we configure.

`NORMAL` is thus `0b0100`, which is a reserved value of MemAttr[3:0] as per D8.6.5 "Stage 2 memory type and Cacheability attributes when FWB is disabled" (ARM DDI 0487 L.b, page D8-6660). This references K1.2.19 "Reserved values in System and memory-mapped registers and translation table entries" (K1-14400), which allows for either:

> - The unallocated value maps onto any of the allocated values, but
>   otherwise does not cause CONSTRAINED UNPREDICTABLE behavior.
> - The unallocated value causes effects that could be achieved by a
>   combination of more than one of the allocated values.
> - The unallocated value causes the field to have no functional effect.

Hence, the mappings for the kernel VSpace could result in basically any cache behaviour (Write-back, Write-through, or Non-cacheable, or a combination of all 3).

------

See also: [Microkit commit a683b3ccb7b5dcfe503498fd92901d1adb9d3a47]( https://github.com/seL4/microkit/commit/a683b3ccb7b5), which corrected this for the Microkit loader and broke SMP booting: https://github.com/seL4/microkit/issues/493.

When making the same fix to the seL4_tools elfloader as the Microkit loader (see commit 'elfloader(aarch64): fix MemAttr for stage 2 PTs' an [PR #264](https://github.com/seL4/seL4_tools/pull/264)), and not changing seL4, we see that SMP fails to boot (but unicore boot works) in the same way as for Microkit: the primary core releases the other cores to start in `release_secondary_cpus` and waits for them all to be ready:

    while (ksNumCPUs != CONFIG_MAX_NUM_NODES)

And the other cores are all themselves spinning on

    while (!node_boot_lock);'

waiting to be released: i.e. the `_Atomic` boot lock serialisation is not seen by the observers on the other cores. When we make this commit's change to seL4, it works. Note that per B2.11 "Mismatched memory attributes" (p. B2-304), mismatched MemAttr values can cause a loss of coherency. Specifically, the primary core in seL4 boots and switches its page tables out for the seL4-defined ones, but secondary cores do not: they rely on the page tables set up by the loader (which is why this is mismatched). The assembler output for my kernel shows it uses STLR/LDAR to access the boot lock.

```
;     node_boot_lock = 1;
8040003974: 52800020    mov     w0, #0x1                // =1
8040003978: 889ffe60    stlr    w0, [x19]

;     while (!node_boot_lock);
804000336c: 9139e273    add     x19, x19, #0xe78
8040003370: 88dffe60    ldar    w0, [x19]
8040003374: 34ffffe0    cbz     w0, 0x8040003370 <init_kernel+0x30>
```

As an extra piece of evidence, if we make the loader use instead `0b0101` (Normal inner non-cacheable outer-non-cacheable), keeping seL4 the same, we see the same hang with the secondary cores not seeing the lock being released. The hypothesis in my mind is the entries cached in the TLB/the part of the CPU that deals with atomic ordering only sees a match when the MemAttr is the 'same'; but this is just a guess. Regardless, the previous behaviour of the loader was incorrect, and so is the current behaviour of seL4.

-----

However, correcting both seL4 and the loader (elfloader or Microkit) causes crashes or errors in kernelspace after boot:

On Non-SMP Microkit:

```
Bootstrapping kernel
available phys memory regions: 1
  [40000000..c0000000)
reserved virt address space regions: 2
  [8040000000..804024a000)
  [804024a000..80402a3000)
Booting all finished, dropped to user space
INFO  [sel4_capdl_initializer::initialize] Starting CapDL

KERNEL DATA ABORT!
Faulting instruction: 0x8040010ac4
FAR: 0x804003c9e1 ESR (DFSR): 0x96000021
halting...
Kernel entry via Interrupt, irq 3
```

corresponding to the line:

```
;     ksKernelEntry.core = CURRENT_CPU_INDEX();
8040010abc: 91278000    add     x0, x0, #0x9e0
8040010ac0: 531d6421    ubfiz   w1, w1, #3, #26
8040010ac4: b8401002    ldur    w2, [x0, #0x1]
```

On SMP Microkit, I see:

```
LDR|INFO|CPU0: jumping to kernel
Bootstrapping kernel
available phys memory regions: 1
  [40000000..c0000000)
reserved virt address space regions: 2
  [8040000000..8040260000)
  [8040260000..80402b9000)
clock_sync_test[2]: t0 = 93550917, t = 93550921, td = 4
clock_sync_test[3]: t0 = 93591265, t = 93591271, td = 6
clock_sync_test[1]: t0 = 93632679, t = 93632682, td = 3
Booting all finished, dropped to user space
INFO  [sel4_capdl_initializer::initialize] Starting CapDL initializer
<<seL4(CPU 0) [decodeUntypedInvocation/127 T0x80bfc05800 "rootserver" @229154]: Untyped Retype: Destination cap invalid or read-only.>>
panicked at /home/julia/.cargo/git/checkouts/rust-sel4-7f729501fe9eabcc/9102a13/crates/sel4-capdl-initializer/src/initialize.rs:76:31:
Error: SeL4Error(FailedLookup)
(aborted)

KERNEL DATA ABORT!
Faulting instruction: 0x8040010b48
FAR: 0x80400490d9 ESR (DFSR): 0x96000021
halting...
Kernel entry via Unknown (0)
```

Both of these are alignment faults on `ksKernelEntry`, which doesn't make sense to me: the kernel's head.S `_start` clears the A bit in SCTLR (`sctlr_el2=0x30c51835` on maaxboard) which should allow unaligned accesses to normal memory. The definitions of `pte_page` and `pte_4k_page` place MemAttr in the right spot, so it's not that: `[5:2]` (although it calls then AttrIndex).

**NOTE**: This currently breaks seL4 boot.

Test with: https://github.com/seL4/seL4_tools/pull/264