### PR TITLE
x86_64/c_traps.c: fix compile error

### DIFF
--- a/src/arch/x86/64/c_traps.c
+++ b/src/arch/x86/64/c_traps.c
@@ -14,7 +14,7 @@
 #include <api/syscall.h>
 
 #ifdef CONFIG_VTX
-static void NORETURN vmlaunch_failed(word_t failInvalid, word_t failValid)
+static void NORETURN USED vmlaunch_failed(word_t failInvalid, word_t failValid)
 {
     NODE_LOCK_SYS;
 


### PR DESCRIPTION
Fix compile error from https://github.com/seL4/seL4/pull/1667.