### PR TITLE
fixes for IPC queue reduction in MCS

### DIFF
--- a/include/fastpath/fastpath.h
+++ b/include/fastpath/fastpath.h
@@ -35,39 +35,15 @@ static inline void maybeDonateSchedContext_fp(tcb_t *dest, sched_context_t *sc)
 static inline void cancelIPC_fp(tcb_t *dest)
 {
     endpoint_t *ep_ptr;
-    tcb_queue_t queue;
     ep_ptr = EP_PTR(thread_state_get_blockingObject(dest->tcbState));
 
-    queue = ep_ptr_get_queue(ep_ptr);
-    queue = tcbEPDequeue(dest, queue);
-    ep_ptr_set_queue(ep_ptr, queue);
-
-    if (!queue.head) {
-        endpoint_ptr_set_state(ep_ptr, EPState_Idle);
-    }
+    tcbEPDequeue(dest, ep_ptr);
 
     /* we are in BlockedOnReceive, because fastpath_signal explicitly checks for it */
     assert(thread_state_get_tsType(dest->tcbState) == ThreadState_BlockedOnReceive);
     reply_t *reply = REPLY_PTR(thread_state_get_replyObject(dest->tcbState));
     if (reply != NULL) {
         reply_unlink(reply, dest);
-    }
-}
-
-/* Dequeue TCB from notification queue */
-static inline void ntfn_queue_dequeue_fp(tcb_t *dest, notification_t *ntfn_ptr)
-{
-    tcb_queue_t ntfn_queue;
-    ntfn_queue.head = (tcb_t *)notification_ptr_get_ntfnQueue_head(ntfn_ptr);
-    ntfn_queue.end = (tcb_t *)notification_ptr_get_ntfnQueue_tail(ntfn_ptr);
-
-    ntfn_queue = tcbEPDequeue(dest, ntfn_queue);
-
-    notification_ptr_set_ntfnQueue_head(ntfn_ptr, (word_t)ntfn_queue.head);
-    notification_ptr_set_ntfnQueue_tail(ntfn_ptr, (word_t)ntfn_queue.end);
-
-    if (!ntfn_queue.head) {
-        notification_ptr_set_state(ntfn_ptr, NtfnState_Idle);
     }
 }
 #endif

--- a/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
@@ -171,7 +171,7 @@ typedef enum {
 #define seL4_HugePageBits 30
 #define seL4_SlotBits 5
 #if defined(CONFIG_HARDWARE_DEBUG_API) || defined(CONFIG_ARM_HYP_ENABLE_VCPU_CP14_SAVE_AND_RESTORE) || \
-    (defined(CONFIG_ARM_HYPERVISOR_SUPPORT) && defined(CONFIG_ENABLE_SMP_SUPPORT) && defined(CONFIG_BENCHMARK_TRACK_UTILISATION))
+    (defined(CONFIG_ARM_HYPERVISOR_SUPPORT) && defined(CONFIG_ENABLE_SMP_SUPPORT) && defined(CONFIG_BENCHMARK_TRACK_UTILISATION) && !defined(CONFIG_KERNEL_MCS))
 #define seL4_TCBBits 12
 #else
 #define seL4_TCBBits 11

--- a/src/fastpath/fastpath.c
+++ b/src/fastpath/fastpath.c
@@ -680,7 +680,7 @@ void NORETURN fastpath_signal(word_t cptr, word_t msgInfo)
         cancelIPC_fp(dest);
     } else {
         /* Dequeue dest from the notification queue */
-        ntfn_queue_dequeue_fp(dest, ntfnPtr);
+        tcbNTFNDequeue(dest, ntfnPtr);
     }
 
     /* Wake up the signalled thread and transfer badge */


### PR DESCRIPTION
- Apply the changes from commit https://github.com/seL4/seL4/commit/771c9e43cef98a5ef7922a37014d4dd0a3de20c3 to the signal fast path, which was missed there.

- The IPC queue changes for MCS in commit https://github.com/seL4/seL4/commit/771c9e43cef98a5ef7922a37014d4dd0a3de20c3 has decreased the TCB size slightly, which brings TCB_SIZE_BITS down for config combinations that have MCS + SMP + HYP + benchmarking enabled from 12 to 11.
