### PR TITLE
x86,SMP: fix VMCheckBoundNotification call

### DIFF
--- a/src/arch/x86/smp/ipi.c
+++ b/src/arch/x86/smp/ipi.c
@@ -50,7 +50,7 @@ void handleRemoteCall(IpiRemoteCall_t call, word_t arg0, word_t arg1, word_t arg
 
             /* For a running VM notifications are already checked by handleVmexit */
             if (tcb != NODE_STATE(ksCurThread)) {
-                VMCheckBoundNotification();
+                VMCheckBoundNotification(tcb);
             }
             break;
 #endif


### PR DESCRIPTION
Missed from https://github.com/seL4/seL4/pull/1641.

I think the issue is that x86-64 is not built with VT-X in any of the CI runs, so we should fix that.