### PR TITLE
github: bump GH action versions

### DIFF
--- a/.github/workflows/compilation-checks.yml
+++ b/.github/workflows/compilation-checks.yml
@@ -31,7 +31,7 @@ jobs:
         arch: [ARM, ARM_HYP, AARCH64, RISCV64, X64]
         compiler: [gcc, llvm]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: seL4/ci-actions/standalone-kernel@master
       with:
         ARCH: ${{ matrix.arch }}

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: seL4/ci-actions/seL4-manual@master
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: PDF
         path: checkout/manual/manual.pdf

--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -52,13 +52,13 @@ jobs:
         AWS_SSH: ${{ secrets.AWS_SSH }}
         GH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
     - name: Upload kernel builds
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: kernel-builds-${{ matrix.arch }}-${{ matrix.features }}
         path: artifacts/kernel-builds
         if-no-files-found: ignore
     - name: Upload logs
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: logs-${{ matrix.arch }}-${{ matrix.features }}
         path: logs.tar.xz

--- a/.github/workflows/sel4test-deploy.yml
+++ b/.github/workflows/sel4test-deploy.yml
@@ -64,7 +64,7 @@ jobs:
         march: ${{ matrix.march }}
         compiler: ${{ matrix.compiler }}
     - name: Upload images
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: images-${{ matrix.march }}-${{ matrix.compiler }}
         path: '*-images.tar.gz'
@@ -91,12 +91,12 @@ jobs:
     concurrency: hw-run-${{ strategy.job-index }}
     steps:
       - name: Get machine queue
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: seL4/machine_queue
           path: machine_queue
       - name: Download image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: images-${{ matrix.march }}-${{ matrix.compiler }}
       - name: Run

--- a/.github/workflows/xml_lint.yml
+++ b/.github/workflows/xml_lint.yml
@@ -32,7 +32,7 @@ jobs:
       run: sudo apt-get update
     - name: install xmllint
       run: sudo apt-get install libxml2-utils
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: run xmllint
       run: |
         find libsel4 -name "object-api*.xml" | \


### PR DESCRIPTION
Node 20 is deprecated. Bump GitHub action dependencies to versions that run on more recent node.