### PR TITLE
x86, 32bit, SMP, HYP: Remove unused vcpu.kernelSP

### DIFF
--- a/include/arch/x86/arch/object/vcpu.h
+++ b/include/arch/x86/arch/object/vcpu.h
@@ -296,9 +296,6 @@ struct vcpu {
     /* General purpose registers that we have to save and restore as they
      * are not part of the vmcs */
     word_t gp_registers[n_vcpu_gp_register];
-#if defined(ENABLE_SMP_SUPPORT) && defined(CONFIG_ARCH_IA32)
-    word_t kernelSP;
-#endif
 
     /* TCB associated with this VCPU. */
     struct tcb *vcpuTCB;

--- a/src/arch/x86/32/c_traps.c
+++ b/src/arch/x86/32/c_traps.c
@@ -36,10 +36,6 @@ static void NORETURN restore_vmx(tcb_t *cur_thread, vcpu_t *vcpu)
     /* Do not support breakpoints in VMs, so just disable all breakpoints */
     loadAllDisabledBreakpointState(cur_thread);
 #endif
-#ifdef ENABLE_SMP_SUPPORT
-    NODE_STATE(vcpu->kernelSP = ((word_t)kernel_stack_alloc[getCurrentCPUIndex()]) + BIT(
-                                    CONFIG_KERNEL_STACK_BITS) - 4;
-#endif /* ENABLE_SMP_SUPPORT */
     if (vcpu->launched) {
     /* attempt to do a vmresume */
     asm volatile(

--- a/src/arch/x86/32/c_traps.c
+++ b/src/arch/x86/32/c_traps.c
@@ -37,33 +37,33 @@ static void NORETURN restore_vmx(tcb_t *cur_thread, vcpu_t *vcpu)
     loadAllDisabledBreakpointState(cur_thread);
 #endif
     if (vcpu->launched) {
-    /* attempt to do a vmresume */
-    asm volatile(
-        // Set our stack pointer to the top of the tcb so we can efficiently pop
-        "movl %0, %%esp\n"
-        "popl %%eax\n"
-        "popl %%ebx\n"
-        "popl %%ecx\n"
-        "popl %%edx\n"
-        "popl %%esi\n"
-        "popl %%edi\n"
-        "popl %%ebp\n"
-        // Now do the vmresume
-        "vmresume\n"
-        // if we get here we failed
+        /* attempt to do a vmresume */
+        asm volatile(
+            // Set our stack pointer to the top of the tcb so we can efficiently pop
+            "movl %0, %%esp\n"
+            "popl %%eax\n"
+            "popl %%ebx\n"
+            "popl %%ecx\n"
+            "popl %%edx\n"
+            "popl %%esi\n"
+            "popl %%edi\n"
+            "popl %%ebp\n"
+            // Now do the vmresume
+            "vmresume\n"
+            // if we get here we failed
 #ifdef ENABLE_SMP_SUPPORT
-        "movl (%%esp), %%esp\n"
+            "movl (%%esp), %%esp\n"
 #else
-        "leal kernel_stack_alloc + %c1, %%esp\n"
+            "leal kernel_stack_alloc + %c1, %%esp\n"
 #endif
-        "call vmlaunch_failed\n"
-        :
-        : "r"(&vcpu->gp_registers[VCPU_EAX]),
-        "i"(BIT(CONFIG_KERNEL_STACK_BITS) - sizeof(word_t))
-        // Clobber memory so the compiler is forced to complete all stores
-        // before running this assembler
-        : "memory"
-    );
+            "call vmlaunch_failed\n"
+            :
+            : "r"(&vcpu->gp_registers[VCPU_EAX]),
+            "i"(BIT(CONFIG_KERNEL_STACK_BITS) - sizeof(word_t))
+            // Clobber memory so the compiler is forced to complete all stores
+            // before running this assembler
+            : "memory"
+        );
     } else {
         /* attempt to do a vmlaunch */
         asm volatile(

--- a/src/arch/x86/smp/ipi.c
+++ b/src/arch/x86/smp/ipi.c
@@ -45,7 +45,7 @@ void handleRemoteCall(IpiRemoteCall_t call, word_t arg0, word_t arg1, word_t arg
         case IpiRemoteCall_ClearCurrentVCPU:
             clearCurrentVCPU();
             break;
-        case IpiRemoteCall_VMCheckBoundNotification:
+        case IpiRemoteCall_VMCheckBoundNotification: {
             tcb_t *tcb = (tcb_t *)arg0;
 
             /* For a running VM notifications are already checked by handleVmexit */
@@ -53,6 +53,7 @@ void handleRemoteCall(IpiRemoteCall_t call, word_t arg0, word_t arg1, word_t arg
                 VMCheckBoundNotification(tcb);
             }
             break;
+        }
 #endif
         default:
             Mode_handleRemoteCall((IpiModeRemoteCall_t)call, arg0, arg1, arg2);


### PR DESCRIPTION
User context already has a kernelSP, which is used. Also, the 64-bit also doesn't has this, so probably a leftover.

GCC 10.2.1 doesn't like declarations inside a case statement without a new context.

Related:
- https://github.com/seL4/ci-actions/pull/482
- https://github.com/seL4/seL4/pull/1669#discussion_r3297712666