### PR TITLE
mcs: fix missing cap fault info in `sendFaultIPC`

### DIFF
--- a/src/kernel/faulthandler.c
+++ b/src/kernel/faulthandler.c
@@ -31,11 +31,12 @@ void handleTimeout(tcb_t *tptr)
 bool_t sendFaultIPC(tcb_t *tptr, cap_t handlerCap, bool_t can_donate)
 {
     if (cap_get_capType(handlerCap) == cap_endpoint_cap) {
-        assert(cap_endpoint_cap_get_capCanSend(handlerCap));
-        assert(cap_endpoint_cap_get_capCanGrant(handlerCap) ||
-               cap_endpoint_cap_get_capCanGrantReply(handlerCap));
+        assert(validFaultHandler(handlerCap));
 
         tptr->tcbFault = current_fault;
+        if (seL4_Fault_get_seL4_FaultType(current_fault) == seL4_Fault_CapFault) {
+            tptr->tcbLookupFailure = current_lookup_fault;
+        }
         sendIPC(true, false,
                 cap_endpoint_cap_get_capEPBadge(handlerCap),
                 cap_endpoint_cap_get_capCanGrant(handlerCap),

--- a/src/object/tcb.c
+++ b/src/object/tcb.c
@@ -1082,19 +1082,15 @@ static bool_t validFaultHandler(cap_t cap)
 {
     switch (cap_get_capType(cap)) {
     case cap_endpoint_cap:
-        if (!cap_endpoint_cap_get_capCanSend(cap) ||
-            (!cap_endpoint_cap_get_capCanGrant(cap) &&
-             !cap_endpoint_cap_get_capCanGrantReply(cap))) {
-            return false;
-        }
-        break;
+        return (cap_endpoint_cap_get_capCanSend(cap) &&
+                (cap_endpoint_cap_get_capCanGrant(cap) ||
+                 cap_endpoint_cap_get_capCanGrantReply(cap)));
     case cap_null_cap:
         /* just has no fault endpoint */
-        break;
+        return true;
     default:
         return false;
     }
-    return true;
 }
 #endif
 


### PR DESCRIPTION
- refactor `validFaultHandler` for readability
- fix missing cap fault info in `sendFaultIPC` (`tptr->tcbLookupFailure` was not being set)