### PR TITLE
mcs: add check for preemption to `SysReplyRecv`

### DIFF
--- a/src/api/syscall.c
+++ b/src/api/syscall.c
@@ -594,8 +594,12 @@ exception_t handleSyscall(syscall_t syscall)
         case SysReplyRecv: {
             cptr_t reply = getRegister(NODE_STATE(ksCurThread), replyRegister);
             ret = handleInvocation(false, false, true, true, reply);
-            /* reply cannot error and is not preemptible */
-            assert(ret == EXCEPTION_NONE);
+            /* reply is not preemptible, but to ease verification we check explicitly */
+            if (unlikely(ret != EXCEPTION_NONE)) {
+                mcsPreemptionPoint();
+                checkInterrupt(/* was_interrupt_entry */ false);
+                break;
+            }
             handleRecv(true, true);
             break;
         }


### PR DESCRIPTION
To ease verification, in the SysReplyRecv case of handleSyscall, add the explicit check for preemption, even though the call to handleInvocation should not be preemptible.