### PR TITLE
tcb: make validFaultHandler available

### DIFF
--- a/include/object/tcb.h
+++ b/include/object/tcb.h
@@ -182,6 +182,8 @@ static inline tcb_queue_t tcbAppend(tcb_t *tcb, tcb_queue_t queue)
     return new_queue;
 }
 
+/* Check for NullCap or EndpointCap with sufficient access rights */
+bool_t validFaultHandler(cap_t cap);
 #else
 
 tcb_queue_t tcbEPAppend(tcb_t *tcb, tcb_queue_t queue);

--- a/src/object/tcb.c
+++ b/src/object/tcb.c
@@ -1078,7 +1078,7 @@ exception_t decodeWriteRegisters(cap_t cap, word_t length, word_t *buffer)
 }
 
 #ifdef CONFIG_KERNEL_MCS
-static bool_t validFaultHandler(cap_t cap)
+bool_t validFaultHandler(cap_t cap)
 {
     switch (cap_get_capType(cap)) {
     case cap_endpoint_cap:


### PR DESCRIPTION
Make the function validFaultHandler available to the assert in sendFaultIPC in faulthandler.c.

(Broken in c119df03574b)