### PR TITLE
arm,hyp: default KernelArmVtimerUpdateVOffset OFF

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,8 @@ description indicates whether it is SOURCE-COMPATIBLE, BINARY-COMPATIBLE, or BRE
 
 * change default for `KernelArmHypEnableVCPUCP14SaveAndRestore` to `OFF` to provide equal defaults for
   verification and release builds. This affects AArch32/hyp only.
+* change default for `KernelArmVtimerUpdateVOffset` to `OFF`, which is the setting supported in
+  verification builds and used in most projects.
 
 ### Upgrade Notes
 

--- a/src/drivers/timer/config.cmake
+++ b/src/drivers/timer/config.cmake
@@ -82,5 +82,5 @@ config_option(
   "When set the kernel will update the VOFFSET \
     register of a VCPU when restoring it so that its view of Virtual time hasn't increased while it \
     was suspended.  When unset the VOFFSET won't be updated other than by the read and write register api."
-  DEFAULT ON
-  DEPENDS "KernelArmHypervisorSupport")
+  DEFAULT OFF
+  DEPENDS "KernelArmHypervisorSupport;NOT KernelVerificationBuild")


### PR DESCRIPTION
Set the default for `KernelArmVtimerUpdateVOffset` to `OFF`. This is the setting supported in verification builds, and it is also the setting used in most projects.