### PR TITLE
mcs: add cmake file for verified AARCH64 MCS

### DIFF
--- a/configs/AARCH64_MCS_verified.cmake
+++ b/configs/AARCH64_MCS_verified.cmake
@@ -1,0 +1,12 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2024, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/include/AARCH64_verified_include.cmake)
+
+set(KernelPlatform "tx2" CACHE STRING "")
+set(KernelIsMCS ON CACHE BOOL "")
+set(KernelStaticMaxPeriodUs "(60 * 60 * MS_IN_S * US_IN_MS)" CACHE STRING "")


### PR DESCRIPTION
To build the verified configuration of AARCH64 MCS.