### PR TITLE
github: use new build matrix

### DIFF
--- a/.github/workflows/sel4test-deploy.yml
+++ b/.github/workflows/sel4test-deploy.yml
@@ -32,6 +32,17 @@ jobs:
         manifest_repo: sel4test-manifest
         manifest: master.xml
 
+  build-matrix:
+    name: Build Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+    - id: matrix
+      uses: seL4/ci-actions/sel4test-hw-matrix@master
+      with:
+        matrix: build
+
   sim:
     name: Simulation
     needs: code
@@ -49,13 +60,10 @@ jobs:
 
   hw-build:
     name: HW Build
-    needs: code
+    needs: [code, build-matrix]
     runs-on: ubuntu-latest
     strategy:
-      matrix:
-        # There is no "rv32imac" hardware yet.
-        march: [armv7a, armv8a, nehalem, rv64imac]
-        compiler: [gcc, clang]
+      matrix: ${{ fromJson(needs.build-matrix.outputs.matrix) }}
     steps:
     - name: Build
       uses: seL4/ci-actions/sel4test-hw@master
@@ -63,10 +71,11 @@ jobs:
         xml: ${{ needs.code.outputs.xml }}
         march: ${{ matrix.march }}
         compiler: ${{ matrix.compiler }}
+        subgroup: ${{ matrix.subgroup }}
     - name: Upload images
       uses: actions/upload-artifact@v7
       with:
-        name: images-${{ matrix.march }}-${{ matrix.compiler }}
+        name: images-${{ matrix.march }}-${{ matrix.compiler }}${{ matrix.subgroup && format('-{0}', matrix.subgroup) }}
         path: '*-images.tar.gz'
 
   the_matrix:
@@ -83,7 +92,7 @@ jobs:
     name: HW Run
     if: ${{ github.repository_owner == 'seL4' }}
     runs-on: ubuntu-latest
-    needs: [sim, the_matrix]
+    needs: [the_matrix]
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.the_matrix.outputs.matrix) }}
@@ -98,7 +107,7 @@ jobs:
       - name: Download image
         uses: actions/download-artifact@v8
         with:
-          name: images-${{ matrix.march }}-${{ matrix.compiler }}
+          name: images-${{ matrix.march }}-${{ matrix.compiler }}${{ matrix.subgroup && format('-{0}', matrix.subgroup) }}
       - name: Run
         uses: seL4/ci-actions/sel4test-hw-run@master
         with:


### PR DESCRIPTION
Use the new build matrix from ci-actions that supports build subgroups for armv8a. This should speed up the hw-build from >50min to about 12:30min, now bounded by the riscv group, not armv8a.

See also https://github.com/seL4/ci-actions/pull/494
