### PR TITLE
libsel4: add new seL4_UserVSpaceTop constant

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,7 @@ description indicates whether it is SOURCE-COMPATIBLE, BINARY-COMPATIBLE, or BRE
   the highest available address available to user level. The existing constant
   `seL4_UserTop` is a mix of inclusive and exclusive across existing platforms, however,
   changing this to be consistent would break userspace and require proof updates.
+  The existing `seL4_UserTop` define is deprecated.
 
 ### Platforms
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,10 @@ description indicates whether it is SOURCE-COMPATIBLE, BINARY-COMPATIBLE, or BRE
 
 * Add `seL4_DebugGetThreadAffinity()` syscall to return the current affinity of a thread
   in SMP configurations.
+* Add new libsel4 constant `seL4_UserVSpaceTop` which is a *inclusive* value representing
+  the highest available address available to user level. The existing constant
+  `seL4_UserTop` is a mix of inclusive and exclusive across existing platforms, however,
+  changing this to be consistent would break userspace and require proof updates.
 
 ### Platforms
 

--- a/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
@@ -243,7 +243,7 @@ SEL4_SIZE_SANITY(seL4_VSpaceEntryBits, seL4_VSpaceIndexBits, seL4_VSpaceBits);
  * Anything address above the range above triggers an
  * address size fault.
  */
-/* First address in the virtual address space that is not accessible to user level */
+/* Last address in the virtual address space that is accessible to user level */
 #if defined(CONFIG_ARM_PA_SIZE_BITS_44)
 #define seL4_UserTop 0x00000fffffffffff
 #elif defined(CONFIG_ARM_PA_SIZE_BITS_40)
@@ -253,6 +253,9 @@ SEL4_SIZE_SANITY(seL4_VSpaceEntryBits, seL4_VSpaceIndexBits, seL4_VSpaceBits);
 #endif
 
 #else
-/* First address in the virtual address space that is not accessible to user level */
+/* Last address in the virtual address space that is accessible to user level */
 #define seL4_UserTop 0x00007fffffffffff
 #endif
+
+/* Last address in the virtual address space that is accessible to user level */
+#define seL4_UserVSpaceTop seL4_UserTop

--- a/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
@@ -243,7 +243,7 @@ SEL4_SIZE_SANITY(seL4_VSpaceEntryBits, seL4_VSpaceIndexBits, seL4_VSpaceBits);
  * Anything address above the range above triggers an
  * address size fault.
  */
-/* Last address in the virtual address space that is accessible to user level */
+/* (Deprecated) Last address in the virtual address space that is accessible to user level */
 #if defined(CONFIG_ARM_PA_SIZE_BITS_44)
 #define seL4_UserTop 0x00000fffffffffff
 #elif defined(CONFIG_ARM_PA_SIZE_BITS_40)
@@ -253,7 +253,7 @@ SEL4_SIZE_SANITY(seL4_VSpaceEntryBits, seL4_VSpaceIndexBits, seL4_VSpaceBits);
 #endif
 
 #else
-/* Last address in the virtual address space that is accessible to user level */
+/* (Deprecated) Last address in the virtual address space that is accessible to user level */
 #define seL4_UserTop 0x00007fffffffffff
 #endif
 

--- a/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/constants.h
@@ -145,3 +145,6 @@ typedef enum {
 
 /* First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xe0000000
+
+/* Last address in the virtual address space that is accessible to user level */
+#define seL4_UserVSpaceTop (seL4_UserTop - 1)

--- a/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/constants.h
@@ -143,7 +143,7 @@ typedef enum {
 /* IPC buffer is 512 bytes, giving size bits of 9 */
 #define seL4_IPCBufferSizeBits 9
 
-/* First address in the virtual address space that is not accessible to user level */
+/* (Deprecated) First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xe0000000
 
 /* Last address in the virtual address space that is accessible to user level */

--- a/libsel4/sel4_arch_include/riscv32/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/riscv32/sel4/sel4_arch/constants.h
@@ -127,6 +127,9 @@ typedef enum {
 /* First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0x80000000lu
 
+/* Last address in the virtual address space that is accessible to user level */
+#define seL4_UserVSpaceTop (seL4_UserTop - 1)
+
 #ifdef CONFIG_ENABLE_BENCHMARKS
 /* size of kernel log buffer in bytes */
 #define seL4_LogBufferSize (LIBSEL4_BIT(20))

--- a/libsel4/sel4_arch_include/riscv32/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/riscv32/sel4/sel4_arch/constants.h
@@ -124,7 +124,7 @@ typedef enum {
 #endif
 #endif /* __ASSEMBLER__ */
 
-/* First address in the virtual address space that is not accessible to user level */
+/* (Deprecated) First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0x80000000lu
 
 /* Last address in the virtual address space that is accessible to user level */

--- a/libsel4/sel4_arch_include/riscv64/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/riscv64/sel4/sel4_arch/constants.h
@@ -128,6 +128,9 @@ typedef enum {
 /* First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0x0000003ffffff000
 
+/* Last address in the virtual address space that is accessible to user level */
+#define seL4_UserVSpaceTop (seL4_UserTop - 1)
+
 #ifdef CONFIG_ENABLE_BENCHMARKS
 /* size of kernel log buffer in bytes */
 #define seL4_LogBufferSize (LIBSEL4_BIT(20))

--- a/libsel4/sel4_arch_include/riscv64/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/riscv64/sel4/sel4_arch/constants.h
@@ -125,7 +125,7 @@ typedef enum {
 #endif
 #endif /* __ASSEMBLER__ */
 
-/* First address in the virtual address space that is not accessible to user level */
+/* (Deprecated) First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0x0000003ffffff000
 
 /* Last address in the virtual address space that is accessible to user level */

--- a/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/constants.h
@@ -156,3 +156,5 @@ typedef enum {
 /* First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0x00007ffffffff000
 
+/* Last address in the virtual address space that is accessible to user level */
+#define seL4_UserVSpaceTop (seL4_UserTop - 1)

--- a/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/constants.h
@@ -153,7 +153,7 @@ typedef enum {
 /* IPC buffer is 1024 bytes, giving size bits of 10 */
 #define seL4_IPCBufferSizeBits 10
 
-/* First address in the virtual address space that is not accessible to user level */
+/* (Deprecated) First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0x00007ffffffff000
 
 /* Last address in the virtual address space that is accessible to user level */

--- a/libsel4/sel4_plat_include/allwinnerA20/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/allwinnerA20/sel4/plat/api/constants.h
@@ -9,7 +9,7 @@
 #include <sel4/config.h>
 #include <sel4/arch/constants_cortex_a7.h>
 
-/* First address in the virtual address space that is not accessible to user level */
+/* (Deprecated) First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xa0000000
 
 /* Last address in the virtual address space that is accessible to user level */

--- a/libsel4/sel4_plat_include/allwinnerA20/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/allwinnerA20/sel4/plat/api/constants.h
@@ -11,3 +11,6 @@
 
 /* First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xa0000000
+
+/* Last address in the virtual address space that is accessible to user level */
+#define seL4_UserVSpaceTop (seL4_UserTop - 1)

--- a/libsel4/sel4_plat_include/am335x/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/am335x/sel4/plat/api/constants.h
@@ -9,7 +9,7 @@
 #include <sel4/config.h>
 #include <sel4/arch/constants_cortex_a8.h>
 
-/* First address in the virtual address space that is not accessible to user level */
+/* (Deprecated) First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xe0000000
 
 /* Last address in the virtual address space that is accessible to user level */

--- a/libsel4/sel4_plat_include/am335x/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/am335x/sel4/plat/api/constants.h
@@ -11,3 +11,6 @@
 
 /* First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xe0000000
+
+/* Last address in the virtual address space that is accessible to user level */
+#define seL4_UserVSpaceTop (seL4_UserTop - 1)

--- a/libsel4/sel4_plat_include/apq8064/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/apq8064/sel4/plat/api/constants.h
@@ -9,7 +9,7 @@
 #include <sel4/config.h>
 #include <sel4/arch/constants_cortex_a15.h>
 
-/* First address in the virtual address space that is not accessible to user level */
+/* (Deprecated) First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xe0000000
 
 /* Last address in the virtual address space that is accessible to user level */

--- a/libsel4/sel4_plat_include/apq8064/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/apq8064/sel4/plat/api/constants.h
@@ -12,3 +12,5 @@
 /* First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xe0000000
 
+/* Last address in the virtual address space that is accessible to user level */
+#define seL4_UserVSpaceTop (seL4_UserTop - 1)

--- a/libsel4/sel4_plat_include/bcm2711/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/bcm2711/sel4/plat/api/constants.h
@@ -11,7 +11,7 @@
 #include <sel4/arch/constants_cortex_a72.h>
 
 #if CONFIG_WORD_SIZE == 32
-/* First address in the virtual address space that is not accessible to user level */
+/* (Deprecated) First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xa0000000
 
 /* Last address in the virtual address space that is accessible to user level */

--- a/libsel4/sel4_plat_include/bcm2711/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/bcm2711/sel4/plat/api/constants.h
@@ -13,6 +13,9 @@
 #if CONFIG_WORD_SIZE == 32
 /* First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xa0000000
+
+/* Last address in the virtual address space that is accessible to user level */
+#define seL4_UserVSpaceTop (seL4_UserTop - 1)
 #else
 /* otherwise this is defined at the arch level */
 #endif

--- a/libsel4/sel4_plat_include/bcm2837/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/bcm2837/sel4/plat/api/constants.h
@@ -13,6 +13,9 @@
 #if CONFIG_WORD_SIZE == 32
 /* First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xe0000000
+
+/* Last address in the virtual address space that is accessible to user level */
+#define seL4_UserVSpaceTop (seL4_UserTop - 1)
 #else
 /* otherwise this is defined at the arch level */
 #endif

--- a/libsel4/sel4_plat_include/bcm2837/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/bcm2837/sel4/plat/api/constants.h
@@ -11,7 +11,7 @@
 #include <sel4/arch/constants_cortex_a53.h>
 
 #if CONFIG_WORD_SIZE == 32
-/* First address in the virtual address space that is not accessible to user level */
+/* (Deprecated) First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xe0000000
 
 /* Last address in the virtual address space that is accessible to user level */

--- a/libsel4/sel4_plat_include/exynos4/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/exynos4/sel4/plat/api/constants.h
@@ -9,7 +9,7 @@
 #include <sel4/config.h>
 #include <sel4/arch/constants_cortex_a9.h>
 
-/* First address in the virtual address space that is not accessible to user level */
+/* (Deprecated) First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xe0000000
 
 /* Last address in the virtual address space that is accessible to user level */

--- a/libsel4/sel4_plat_include/exynos4/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/exynos4/sel4/plat/api/constants.h
@@ -11,3 +11,6 @@
 
 /* First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xe0000000
+
+/* Last address in the virtual address space that is accessible to user level */
+#define seL4_UserVSpaceTop (seL4_UserTop - 1)

--- a/libsel4/sel4_plat_include/exynos5/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/exynos5/sel4/plat/api/constants.h
@@ -22,7 +22,7 @@
 #error "unsupported core"
 #endif
 
-/* First address in the virtual address space that is not accessible to user level */
+/* (Deprecated) First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xe0000000
 
 /* Last address in the virtual address space that is accessible to user level */

--- a/libsel4/sel4_plat_include/exynos5/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/exynos5/sel4/plat/api/constants.h
@@ -24,3 +24,6 @@
 
 /* First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xe0000000
+
+/* Last address in the virtual address space that is accessible to user level */
+#define seL4_UserVSpaceTop (seL4_UserTop - 1)

--- a/libsel4/sel4_plat_include/hikey/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/hikey/sel4/plat/api/constants.h
@@ -13,6 +13,9 @@
 #if CONFIG_WORD_SIZE == 32
 /* First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xe0000000
+
+/* Last address in the virtual address space that is accessible to user level */
+#define seL4_UserVSpaceTop (seL4_UserTop - 1)
 #else
 /* otherwise this is defined at the arch level */
 #endif

--- a/libsel4/sel4_plat_include/hikey/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/hikey/sel4/plat/api/constants.h
@@ -11,7 +11,7 @@
 #include <sel4/arch/constants_cortex_a53.h>
 
 #if CONFIG_WORD_SIZE == 32
-/* First address in the virtual address space that is not accessible to user level */
+/* (Deprecated) First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xe0000000
 
 /* Last address in the virtual address space that is accessible to user level */

--- a/libsel4/sel4_plat_include/imx6/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/imx6/sel4/plat/api/constants.h
@@ -9,7 +9,7 @@
 #include <sel4/config.h>
 #include <sel4/arch/constants_cortex_a9.h>
 
-/* First address in the virtual address space that is not accessible to user level */
+/* (Deprecated) First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xe0000000
 
 /* Last address in the virtual address space that is accessible to user level */

--- a/libsel4/sel4_plat_include/imx6/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/imx6/sel4/plat/api/constants.h
@@ -11,3 +11,6 @@
 
 /* First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xe0000000
+
+/* Last address in the virtual address space that is accessible to user level */
+#define seL4_UserVSpaceTop (seL4_UserTop - 1)

--- a/libsel4/sel4_plat_include/imx7/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/imx7/sel4/plat/api/constants.h
@@ -9,7 +9,7 @@
 #include <sel4/config.h>
 #include <sel4/arch/constants_cortex_a7.h>
 
-/* First address in the virtual address space that is not accessible to user level */
+/* (Deprecated) First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xe0000000
 
 /* Last address in the virtual address space that is accessible to user level */

--- a/libsel4/sel4_plat_include/imx7/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/imx7/sel4/plat/api/constants.h
@@ -11,3 +11,6 @@
 
 /* First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xe0000000
+
+/* Last address in the virtual address space that is accessible to user level */
+#define seL4_UserVSpaceTop (seL4_UserTop - 1)

--- a/libsel4/sel4_plat_include/imx8mm-evk/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/imx8mm-evk/sel4/plat/api/constants.h
@@ -10,7 +10,7 @@
 #include <sel4/arch/constants_cortex_a53.h>
 
 #if CONFIG_WORD_SIZE == 32
-/* First address in the virtual address space that is not accessible to user level */
+/* (Deprecated) First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xe0000000
 
 /* Last address in the virtual address space that is accessible to user level */

--- a/libsel4/sel4_plat_include/imx8mm-evk/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/imx8mm-evk/sel4/plat/api/constants.h
@@ -12,6 +12,9 @@
 #if CONFIG_WORD_SIZE == 32
 /* First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xe0000000
+
+/* Last address in the virtual address space that is accessible to user level */
+#define seL4_UserVSpaceTop (seL4_UserTop - 1)
 #else
 /* otherwise this is defined at the arch level */
 #endif

--- a/libsel4/sel4_plat_include/imx8mp-evk/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/imx8mp-evk/sel4/plat/api/constants.h
@@ -10,7 +10,7 @@
 #include <sel4/arch/constants_cortex_a53.h>
 
 #if CONFIG_WORD_SIZE == 32
-/* First address in the virtual address space that is not accessible to user level */
+/* (Deprecated) First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xe0000000
 
 /* Last address in the virtual address space that is accessible to user level */

--- a/libsel4/sel4_plat_include/imx8mp-evk/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/imx8mp-evk/sel4/plat/api/constants.h
@@ -12,6 +12,9 @@
 #if CONFIG_WORD_SIZE == 32
 /* First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xe0000000
+
+/* Last address in the virtual address space that is accessible to user level */
+#define seL4_UserVSpaceTop (seL4_UserTop - 1)
 #else
 /* otherwise this is defined at the arch level */
 #endif

--- a/libsel4/sel4_plat_include/imx8mq-evk/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/imx8mq-evk/sel4/plat/api/constants.h
@@ -10,7 +10,7 @@
 #include <sel4/arch/constants_cortex_a53.h>
 
 #if CONFIG_WORD_SIZE == 32
-/* First address in the virtual address space that is not accessible to user level */
+/* (Deprecated) First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xe0000000
 
 /* Last address in the virtual address space that is accessible to user level */

--- a/libsel4/sel4_plat_include/imx8mq-evk/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/imx8mq-evk/sel4/plat/api/constants.h
@@ -12,6 +12,9 @@
 #if CONFIG_WORD_SIZE == 32
 /* First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xe0000000
+
+/* Last address in the virtual address space that is accessible to user level */
+#define seL4_UserVSpaceTop (seL4_UserTop - 1)
 #else
 /* otherwise this is defined at the arch level */
 #endif

--- a/libsel4/sel4_plat_include/maaxboard/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/maaxboard/sel4/plat/api/constants.h
@@ -13,6 +13,9 @@
 #if CONFIG_WORD_SIZE == 32
 /* First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xe0000000
+
+/* Last address in the virtual address space that is accessible to user level */
+#define seL4_UserVSpaceTop (seL4_UserTop - 1)
 #else
 /* otherwise this is defined at the arch level */
 #endif

--- a/libsel4/sel4_plat_include/maaxboard/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/maaxboard/sel4/plat/api/constants.h
@@ -11,7 +11,7 @@
 #include <sel4/arch/constants_cortex_a53.h>
 
 #if CONFIG_WORD_SIZE == 32
-/* First address in the virtual address space that is not accessible to user level */
+/* (Deprecated) First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xe0000000
 
 /* Last address in the virtual address space that is accessible to user level */

--- a/libsel4/sel4_plat_include/omap3/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/omap3/sel4/plat/api/constants.h
@@ -11,3 +11,6 @@
 
 /* First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xf0000000
+
+/* Last address in the virtual address space that is accessible to user level */
+#define seL4_UserVSpaceTop (seL4_UserTop - 1)

--- a/libsel4/sel4_plat_include/omap3/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/omap3/sel4/plat/api/constants.h
@@ -9,7 +9,7 @@
 #include <sel4/config.h>
 #include <sel4/arch/constants_cortex_a8.h>
 
-/* First address in the virtual address space that is not accessible to user level */
+/* (Deprecated) First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xf0000000
 
 /* Last address in the virtual address space that is accessible to user level */

--- a/libsel4/sel4_plat_include/qemu-arm-virt/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/qemu-arm-virt/sel4/plat/api/constants.h
@@ -21,9 +21,11 @@
 #error "unsupported core"
 #endif
 
-/* First address in the virtual address space that is not accessible to user level */
 
 #if CONFIG_WORD_SIZE == 32
-
+/* First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop CONFIG_USER_TOP
+
+/* Last address in the virtual address space that is accessible to user level */
+#define seL4_UserVSpaceTop (CONFIG_USER_TOP - 1)
 #endif

--- a/libsel4/sel4_plat_include/qemu-arm-virt/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/qemu-arm-virt/sel4/plat/api/constants.h
@@ -23,7 +23,7 @@
 
 
 #if CONFIG_WORD_SIZE == 32
-/* First address in the virtual address space that is not accessible to user level */
+/* (Deprecated) First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop CONFIG_USER_TOP
 
 /* Last address in the virtual address space that is accessible to user level */

--- a/libsel4/sel4_plat_include/tk1/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/tk1/sel4/plat/api/constants.h
@@ -9,7 +9,7 @@
 #include <sel4/config.h>
 #include <sel4/arch/constants_cortex_a15.h>
 
-/* First address in the virtual address space that is not accessible to user level */
+/* (Deprecated) First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xe0000000
 
 /* Last address in the virtual address space that is accessible to user level */

--- a/libsel4/sel4_plat_include/tk1/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/tk1/sel4/plat/api/constants.h
@@ -11,3 +11,6 @@
 
 /* First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xe0000000
+
+/* Last address in the virtual address space that is accessible to user level */
+#define seL4_UserVSpaceTop (seL4_UserTop - 1)

--- a/libsel4/sel4_plat_include/zynq7000/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/zynq7000/sel4/plat/api/constants.h
@@ -9,7 +9,7 @@
 #include <sel4/config.h>
 #include <sel4/arch/constants_cortex_a9.h>
 
-/* First address in the virtual address space that is not accessible to user level */
+/* (Deprecated) First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xe0000000
 
 /* Last address in the virtual address space that is accessible to user level */

--- a/libsel4/sel4_plat_include/zynq7000/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/zynq7000/sel4/plat/api/constants.h
@@ -11,3 +11,6 @@
 
 /* First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xe0000000
+
+/* Last address in the virtual address space that is accessible to user level */
+#define seL4_UserVSpaceTop (seL4_UserTop - 1)

--- a/libsel4/sel4_plat_include/zynqmp/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/zynqmp/sel4/plat/api/constants.h
@@ -17,6 +17,9 @@
 #if CONFIG_WORD_SIZE == 32
 /* First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xe0000000
+
+/* Last address in the virtual address space that is accessible to user level */
+#define seL4_UserVSpaceTop (seL4_UserTop - 1)
 #else
 /* otherwise this is defined at the architecture level */
 #endif

--- a/libsel4/sel4_plat_include/zynqmp/sel4/plat/api/constants.h
+++ b/libsel4/sel4_plat_include/zynqmp/sel4/plat/api/constants.h
@@ -15,7 +15,7 @@
 #include <sel4/arch/constants_cortex_a53.h>
 
 #if CONFIG_WORD_SIZE == 32
-/* First address in the virtual address space that is not accessible to user level */
+/* (Deprecated) First address in the virtual address space that is not accessible to user level */
 #define seL4_UserTop 0xe0000000
 
 /* Last address in the virtual address space that is accessible to user level */


### PR DESCRIPTION
This is a consistent, inclusive-top value that is conveying similar information to that of seL4_UserTop. We are adding this so as to not break existing userspace, but it will make it easier for userspace to deal with other platforms.

Fixes #1693.

Test with: https://github.com/seL4/seL4_libs/pull/112