### PR TITLE
configs: proofs now generic in RISC-V config; add stm32mp2 for AArch64

### DIFF
--- a/configs/AARCH64_stm32mp2_verified.cmake
+++ b/configs/AARCH64_stm32mp2_verified.cmake
@@ -1,0 +1,10 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2025, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/include/AARCH64_verified_include.cmake)
+
+set(KernelPlatform "stm32mp2" CACHE STRING "")

--- a/configs/RISCV64_ariane_verified.cmake
+++ b/configs/RISCV64_ariane_verified.cmake
@@ -1,0 +1,10 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2024, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/include/RISCV64_verified_include.cmake)
+
+set(KernelPlatform "ariane" CACHE STRING "")

--- a/configs/RISCV64_bananapi-f3_verified.cmake
+++ b/configs/RISCV64_bananapi-f3_verified.cmake
@@ -1,0 +1,10 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2024, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/include/RISCV64_verified_include.cmake)
+
+set(KernelPlatform "bananapi-f3" CACHE STRING "")

--- a/configs/RISCV64_cheshire_verified.cmake
+++ b/configs/RISCV64_cheshire_verified.cmake
@@ -1,0 +1,10 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2024, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/include/RISCV64_verified_include.cmake)
+
+set(KernelPlatform "cheshire" CACHE STRING "")

--- a/configs/RISCV64_hifive-p550_verified.cmake
+++ b/configs/RISCV64_hifive-p550_verified.cmake
@@ -1,0 +1,10 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2024, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/include/RISCV64_verified_include.cmake)
+
+set(KernelPlatform "hifive-p550" CACHE STRING "")

--- a/configs/RISCV64_polarfire_verified.cmake
+++ b/configs/RISCV64_polarfire_verified.cmake
@@ -1,0 +1,10 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2024, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/include/RISCV64_verified_include.cmake)
+
+set(KernelPlatform "polarfire" CACHE STRING "")

--- a/configs/RISCV64_rocketchip-zcu102_verified.cmake
+++ b/configs/RISCV64_rocketchip-zcu102_verified.cmake
@@ -1,0 +1,11 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2024, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/include/RISCV64_verified_include.cmake)
+
+set(KernelPlatform "rocketchip" CACHE STRING "")
+set(KernelRiscVPlatform "rocketchip-zcu102" CACHE STRING "")

--- a/configs/RISCV64_rocketchip_verified.cmake
+++ b/configs/RISCV64_rocketchip_verified.cmake
@@ -1,0 +1,10 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2024, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/include/RISCV64_verified_include.cmake)
+
+set(KernelPlatform "rocketchip" CACHE STRING "")

--- a/configs/RISCV64_star64_verified.cmake
+++ b/configs/RISCV64_star64_verified.cmake
@@ -1,0 +1,10 @@
+#!/usr/bin/env -S cmake -P
+#
+# Copyright 2024, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/include/RISCV64_verified_include.cmake)
+
+set(KernelPlatform "star64" CACHE STRING "")


### PR DESCRIPTION
- add a verified config for stm32mp2 (AArch64); proofs are passing unchanged
- add verified configs for all supported non-simulation RISC-V platforms

Related to https://github.com/seL4/l4v/pull/1024, but can be merged independently.