### PR TITLE
x86,c_traps: avoid PC corruption in kernel lock

### DIFF
--- a/src/arch/x86/c_traps.c
+++ b/src/arch/x86/c_traps.c
@@ -147,6 +147,16 @@ void VISIBLE NORETURN c_handle_syscall(word_t cptr, word_t msgInfo, syscall_t sy
         x86_enable_ibrs();
     }
 
+    /* Must happen before NODE_LOCK_SYS so that lock exit via IPI stall restores
+       the correct program counter. */
+    if (config_set(CONFIG_SYSENTER)) {
+        /* increment NextIP to skip sysenter */
+        NODE_STATE(ksCurThread)->tcbArch.tcbContext.registers[NextIP] += 2;
+    } else {
+        /* set FaultIP */
+        setRegister(NODE_STATE(ksCurThread), FaultIP, getRegister(NODE_STATE(ksCurThread), NextIP) - 2);
+    }
+
     NODE_LOCK_SYS;
 
     c_entry_hook();
@@ -155,14 +165,6 @@ void VISIBLE NORETURN c_handle_syscall(word_t cptr, word_t msgInfo, syscall_t sy
     benchmark_debug_syscall_start(cptr, msgInfo, syscall);
     ksKernelEntry.is_fastpath = 1;
 #endif /* TRACK_KERNEL_ENTRIES */
-
-    if (config_set(CONFIG_SYSENTER)) {
-        /* increment NextIP to skip sysenter */
-        NODE_STATE(ksCurThread)->tcbArch.tcbContext.registers[NextIP] += 2;
-    } else {
-        /* set FaultIP */
-        setRegister(NODE_STATE(ksCurThread), FaultIP, getRegister(NODE_STATE(ksCurThread), NextIP) - 2);
-    }
 
 #ifdef CONFIG_FASTPATH
     if (syscall == (syscall_t)SysCall) {


### PR DESCRIPTION
When we back out of the lock via IPI stall in `ipiStallCoreCallback()`, the `FaultIP`/`NextIP` are not updated yet and the lock exit code will set the wrong program counter.

Moving the `FaultIP`/`NextIP` update before the lock makes sure that all exit paths from the lock will restore to the correct program counter.

Even though this write happens outside the lock, it does not introduce a race. The only possible interference would be a `TCBWriteRegisters` syscall from another core along the lines of the following: other core enters syscall, current core gets to lock, makes FaultIP adjustment, other core exists syscall, current core overwrites effect. This path and analogous ones are not possible, because the `TCBWriteRegisters` call on the other core first leads to a stall  on this core before it proceeds, which means this core will be on idle and cannot attempt to enter the lock.

The fix is observable in the sel4bench SMP benchmark. Before, when run over multiple full iterations (n < 10 on haswell is usually enough, e.g. https://github.com/seL4/sel4bench/actions/runs/28563144172/job/84686342372), the benchmark hangs, because the TCB setup/teardown race with IPC operations on other cores and trigger the PC corruptions, which via multiple cascading VM faults eventually hang the main benchmark thread. After this change, the benchmark is stable for > 400 iterations on the same machine.
