### PR TITLE
libsel4: export seL4_X86_IOSpace_CapData type

### DIFF
--- a/include/arch/x86/arch/32/mode/object/structures.bf
+++ b/include/arch/x86/arch/32/mode/object/structures.bf
@@ -98,17 +98,13 @@ block io_port_cap {
 #ifdef CONFIG_IOMMU
 
 -- IO Space Cap
+-- See also: seL4_X86_IOSpace_CapData in arch/shared_types.bf
 block io_space_cap {
     field       capDomainID     16
     field       capPCIDevice    16
 
     padding                     28
     field       capType         4
-}
-
-block io_space_capdata {
-    field domainID              16
-    field PCIDevice             16
 }
 
 -- IO Page Table Cap

--- a/include/arch/x86/arch/64/mode/object/structures.bf
+++ b/include/arch/x86/arch/64/mode/object/structures.bf
@@ -124,6 +124,7 @@ block io_port_cap {
 #ifdef CONFIG_IOMMU
 
 -- IO Space Cap
+-- See also: seL4_X86_IOSpace_CapData in arch/shared_types.bf
 block io_space_cap {
     padding 64
     field       capType         5
@@ -131,12 +132,6 @@ block io_space_cap {
     field       capPCIDevice    16
 
     padding                     27
-}
-
-block io_space_capdata {
-    padding 32
-    field domainID              16
-    field PCIDevice             16
 }
 
 -- IO Page Table Cap

--- a/libsel4/arch_include/x86/sel4/arch/shared_types.bf
+++ b/libsel4/arch_include/x86/sel4/arch/shared_types.bf
@@ -25,3 +25,15 @@ tagged_union seL4_Fault seL4_FaultType {
     tag VMFault 5
 #endif
 }
+
+#ifdef CONFIG_IOMMU
+
+block seL4_X86_IOSpace_CapData {
+#ifdef CONFIG_ARCH_X86_64
+    padding 32
+#endif
+    field domainID              16
+    field PCIDevice             16
+}
+
+#endif

--- a/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/types.bf
+++ b/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/types.bf
@@ -87,4 +87,5 @@ block Timeout {
     field seL4_FaultType 4
 }
 #endif
+
 #include <sel4/arch/shared_types.bf>

--- a/src/arch/x86/object/objecttype.c
+++ b/src/arch/x86/object/objecttype.c
@@ -144,9 +144,9 @@ cap_t CONST Arch_updateCapData(bool_t preserve, word_t data, cap_t cap)
 #ifdef CONFIG_IOMMU
     switch (cap_get_capType(cap)) {
     case cap_io_space_cap: {
-        io_space_capdata_t w = { { data } };
-        uint16_t PCIDevice = io_space_capdata_get_PCIDevice(w);
-        uint16_t domainID = io_space_capdata_get_domainID(w);
+        seL4_X86_IOSpace_CapData_t w = { { data } };
+        uint16_t PCIDevice = seL4_X86_IOSpace_CapData_get_PCIDevice(w);
+        uint16_t domainID = seL4_X86_IOSpace_CapData_get_domainID(w);
         if (!preserve && cap_io_space_cap_get_capPCIDevice(cap) == 0 &&
             domainID >= x86KSFirstValidIODomain &&
             domainID != 0                        &&


### PR DESCRIPTION
Previously, to create IOSpaceCap's one needed to replicate the layout of these structures in your own handwritten code.

Use the existing shared_types mechanism to expose helpers, and update the internal kernel implementation.

As far as I can tell this is not verified code.

Naming scheme is based on `seL4_CNode_CapData`.

Cross-ref: https://github.com/seL4/rust-sel4/pull/358#discussion_r3541708597