### PR TITLE
libsel4: IOSpace capdata with PCI bus/dev/fun

### DIFF
--- a/libsel4/arch_include/x86/sel4/arch/shared_types.bf
+++ b/libsel4/arch_include/x86/sel4/arch/shared_types.bf
@@ -33,7 +33,9 @@ block seL4_X86_IOSpace_CapData {
     padding 32
 #endif
     field domainID              16
-    field PCIDevice             16
+    field pciBus                8
+    field pciDev                5
+    field pciFun                3
 }
 
 #endif

--- a/src/arch/x86/object/objecttype.c
+++ b/src/arch/x86/object/objecttype.c
@@ -145,7 +145,11 @@ cap_t CONST Arch_updateCapData(bool_t preserve, word_t data, cap_t cap)
     switch (cap_get_capType(cap)) {
     case cap_io_space_cap: {
         seL4_X86_IOSpace_CapData_t w = { { data } };
-        uint16_t PCIDevice = seL4_X86_IOSpace_CapData_get_PCIDevice(w);
+        uint16_t PCIDevice = get_dev_id(
+                                 seL4_X86_IOSpace_CapData_get_pciBus(w),
+                                 seL4_X86_IOSpace_CapData_get_pciDev(w),
+                                 seL4_X86_IOSpace_CapData_get_pciFun(w)
+                             );
         uint16_t domainID = seL4_X86_IOSpace_CapData_get_domainID(w);
         if (!preserve && cap_io_space_cap_get_capPCIDevice(cap) == 0 &&
             domainID >= x86KSFirstValidIODomain &&


### PR DESCRIPTION
This generates a helper _new that looks like this:

    seL4_X86_IOSpace_CapData.words[0] = 0
        | (domainID & 0xffffull) << 16
        | (pciBus & 0xffull) << 8
        | (pciDev & 0x1full) << 3
        | (pciFun & 0x7ull) << 0;

, which matches the layout the kernel expects.

In contrast to what we thought when we merged commit b57b3de, seL4 does actually rely on the layout of the PCIDevice field for the 'lookup_vtd_context_slot' function. Thus, to make it easier for userspace to generate the capData for an IOSpace cap we have the capData have fields for bus/dev/fun in the bitfield generator.

In addition, the C capDL loader does pack these values itself with its own hardcoded layout in 'showPCI'; and furthermore the existing kernel API (for X86IRQIssueIRQHandlerMSI) takes 'pci_bus','pci_dev', and 'pci_func' arguments.

This is technically a breaking change over the last commit, but the previous commit was well, the previous commit, so I don't expect it to break anyone. And it doesn't break anyone doing the packing directly themselves.