### PR TITLE
smp+mcs: fix bug involving ksCurThread migration

### DIFF
--- a/include/fastpath/fastpath.h
+++ b/include/fastpath/fastpath.h
@@ -24,7 +24,8 @@ static inline void maybeDonateSchedContext_fp(tcb_t *dest, sched_context_t *sc)
 #ifdef CONFIG_DEBUG_BUILD
     tcbDebugRemove(dest);
 #endif
-    /* The part of migrateTCB() that doesn't involve the slowpathed FPU save */
+    /* The part of migrateTCB() that doesn't involve the slowpathed FPU save or
+     * the switch to the idle thread. */
     dest->tcbAffinity = sc->scCore;
 #ifdef CONFIG_DEBUG_BUILD
     tcbDebugAppend(dest);

--- a/include/model/statedata.h
+++ b/include/model/statedata.h
@@ -120,6 +120,10 @@ extern paddr_t ksUserLogBuffer;
 #define SchedulerAction_ResumeCurrentThread ((tcb_t*)0)
 #define SchedulerAction_ChooseNewThread ((tcb_t*) 1)
 
+#define SchedulerAction_IsCandidateThread(schedulerAction) \
+    ((schedulerAction) != SchedulerAction_ResumeCurrentThread && \
+     (schedulerAction) != SchedulerAction_ChooseNewThread)
+
 #define MODE_NODE_STATE(_state)    MODE_NODE_STATE_ON_CORE(_state, getCurrentCPUIndex())
 #define ARCH_NODE_STATE(_state)    ARCH_NODE_STATE_ON_CORE(_state, getCurrentCPUIndex())
 #define NODE_STATE(_state)         NODE_STATE_ON_CORE(_state, getCurrentCPUIndex())

--- a/src/fastpath/fastpath.c
+++ b/src/fastpath/fastpath.c
@@ -706,7 +706,8 @@ void NORETURN fastpath_signal(word_t cptr, word_t msgInfo)
         if (NODE_STATE(ksCurThread)->tcbPriority > dest->tcbPriority || crossnode) {
             SCHED_ENQUEUE(dest);
         } else {
-            SCHED_APPEND(dest);
+            /* We know that this thread must be on the current core */
+            tcbSchedAppend(dest);
         }
     }
 

--- a/src/kernel/thread.c
+++ b/src/kernel/thread.c
@@ -371,6 +371,15 @@ static void scheduleChooseNewThread(void)
 
 void schedule(void)
 {
+#ifdef ENABLE_SMP_SUPPORT
+    /* Invariant: the current thread always belongs to the current core. */
+    assert(NODE_STATE(ksCurThread)->tcbAffinity == getCurrentCPUIndex());
+    /* Invariant: if a thread, ksSchedulerAction belongs to the current core */
+    assert(!SchedulerAction_IsCandidateThread(NODE_STATE(ksSchedulerAction)) ||
+           NODE_STATE(ksSchedulerAction)->tcbAffinity == getCurrentCPUIndex());
+    /* These invariants mean we don't need any remoteQueueUpdate calls, and
+       thus can call tcbSchedEnqueue/tcbSchedAppend directly. */
+#endif
 #ifdef CONFIG_KERNEL_MCS
     awaken();
     checkDomainTime();
@@ -380,7 +389,7 @@ void schedule(void)
         bool_t was_runnable;
         if (isSchedulable(NODE_STATE(ksCurThread))) {
             was_runnable = true;
-            SCHED_ENQUEUE_CURRENT_TCB;
+            tcbSchedEnqueue(NODE_STATE(ksCurThread));
         } else {
             was_runnable = false;
         }
@@ -399,7 +408,7 @@ void schedule(void)
                 || (candidate->tcbPriority < NODE_STATE(ksCurThread)->tcbPriority);
             if (fastfail &&
                 !isHighestPrio(ksCurDomain, candidate->tcbPriority)) {
-                SCHED_ENQUEUE(candidate);
+                tcbSchedEnqueue(candidate);
                 /* we can't, need to reschedule */
                 NODE_STATE(ksSchedulerAction) = SchedulerAction_ChooseNewThread;
                 scheduleChooseNewThread();
@@ -407,7 +416,7 @@ void schedule(void)
                 /* We append the candidate at the end of the scheduling queue, that way the
                  * current thread, that was enqueued at the start of the scheduling queue
                  * will get picked during chooseNewThread */
-                SCHED_APPEND(candidate);
+                tcbSchedAppend(candidate);
                 NODE_STATE(ksSchedulerAction) = SchedulerAction_ChooseNewThread;
                 scheduleChooseNewThread();
             } else {
@@ -479,6 +488,11 @@ void switchToThread(tcb_t *thread)
 
     tcbSchedDequeue(thread);
     NODE_STATE(ksCurThread) = thread;
+
+#ifdef ENABLE_SMP_SUPPORT
+    /* Invariant: the current thread always belongs to the current core. */
+    assert(NODE_STATE(ksCurThread)->tcbAffinity == getCurrentCPUIndex());
+#endif
 }
 
 void switchToIdleThread(void)
@@ -565,7 +579,8 @@ void possibleSwitchTo(tcb_t *target)
         } else if (NODE_STATE(ksSchedulerAction) != SchedulerAction_ResumeCurrentThread) {
             /* Too many threads want special treatment, use regular queues. */
             rescheduleRequired();
-            SCHED_ENQUEUE(target);
+            /* We know that this thread must be on the current core */
+            tcbSchedEnqueue(target);
         } else {
             NODE_STATE(ksSchedulerAction) = target;
         }
@@ -573,6 +588,11 @@ void possibleSwitchTo(tcb_t *target)
     }
 #endif
 
+#ifdef ENABLE_SMP_SUPPORT
+    /* Invariant: if a thread, ksSchedulerAction belongs to the current core */
+    assert(!SchedulerAction_IsCandidateThread(NODE_STATE(ksSchedulerAction)) ||
+           NODE_STATE(ksSchedulerAction)->tcbAffinity == getCurrentCPUIndex());
+#endif
 }
 
 void setThreadState(tcb_t *tptr, _thread_state_t ts)
@@ -702,8 +722,13 @@ void timerTick(void)
 
 void rescheduleRequired(void)
 {
-    if (NODE_STATE(ksSchedulerAction) != SchedulerAction_ResumeCurrentThread
-        && NODE_STATE(ksSchedulerAction) != SchedulerAction_ChooseNewThread
+#ifdef ENABLE_SMP_SUPPORT
+    /* Invariant: if a thread, ksSchedulerAction belongs to the current core */
+    assert(!SchedulerAction_IsCandidateThread(NODE_STATE(ksSchedulerAction)) ||
+           NODE_STATE(ksSchedulerAction)->tcbAffinity == getCurrentCPUIndex());
+#endif
+
+    if (SchedulerAction_IsCandidateThread(NODE_STATE(ksSchedulerAction))
 #ifdef CONFIG_KERNEL_MCS
         && isSchedulable(NODE_STATE(ksSchedulerAction))
 #endif
@@ -712,7 +737,7 @@ void rescheduleRequired(void)
         assert(refill_sufficient(NODE_STATE(ksSchedulerAction)->tcbSchedContext, 0));
         assert(refill_ready(NODE_STATE(ksSchedulerAction)->tcbSchedContext));
 #endif
-        SCHED_ENQUEUE(NODE_STATE(ksSchedulerAction));
+        tcbSchedEnqueue(NODE_STATE(ksSchedulerAction));
     }
     NODE_STATE(ksSchedulerAction) = SchedulerAction_ChooseNewThread;
 }

--- a/src/model/smp.c
+++ b/src/model/smp.c
@@ -25,7 +25,30 @@ void migrateTCB(tcb_t *tcb, word_t new_core)
      */
     fpuRelease(tcb);
 #endif /* CONFIG_HAVE_FPU */
-    tcb->tcbAffinity = new_core;
+    if (tcb == NODE_STATE(ksCurThread)) {
+        /**
+         * Switch the current thread to the idle thread. This is necessary to
+         * preserve the invariant the the current thread (NODE_STATE(ksCurThread))
+         * variable is always running on the current core.
+         *
+         */
+        switchToIdleThread();
+
+        /* Like rescheduleRequired but specific.
+         * This is broadly similar to how invokeTCB_SetAffinity() behaves.
+         */
+        tcb_t *action = NODE_STATE(ksSchedulerAction);
+        if (action == tcb || action == SchedulerAction_ResumeCurrentThread) {
+            NODE_STATE(ksSchedulerAction) = SchedulerAction_ChooseNewThread;
+        }
+
+        tcb->tcbAffinity = new_core;
+        if (isSchedulable(tcb)) {
+            SCHED_ENQUEUE(tcb);
+        }
+    } else {
+        tcb->tcbAffinity = new_core;
+    }
 #ifdef CONFIG_DEBUG_BUILD
     tcbDebugAppend(tcb);
 #endif

--- a/src/object/schedcontext.c
+++ b/src/object/schedcontext.c
@@ -211,6 +211,14 @@ static exception_t invokeSchedContext_YieldTo(sched_context_t *sc, bool_t call)
             tcbSchedEnqueue(tcb);
             rescheduleRequired();
 
+            /* We know that both the TCB is on the current core per earlier check,
+             * and that ksCurThread is on the current core by invariant.
+             * So neither of these needed a remoteQueueUpdate().
+             * @TODO: Guarantee sc->scCore == tcb->tcbAffinity?
+             */
+            SMP_COND_STATEMENT(assert(tcb->tcbAffinity == getCurrentCPUIndex()));
+            SMP_COND_STATEMENT(assert(NODE_STATE(ksCurThread)->tcbAffinity == getCurrentCPUIndex()));
+
             /* we are scheduling the thread associated with sc,
              * so we don't need to write to the ipc buffer
              * until the caller is scheduled again */
@@ -332,6 +340,11 @@ void schedContext_bindTCB(sched_context_t *sc, tcb_t *tcb)
         // verification work, so the work around is to use rescheduleRequired()
         //possibleSwitchTo(tcb);
     }
+
+#ifdef ENABLE_SMP_SUPPORT
+    /* Invariant: the current thread always belongs to the current core. */
+    assert(NODE_STATE(ksCurThread)->tcbAffinity == getCurrentCPUIndex());
+#endif
 }
 
 void schedContext_unbindTCB(sched_context_t *sc)
@@ -379,6 +392,11 @@ void schedContext_donate(sched_context_t *sc, tcb_t *to)
     to->tcbSchedContext = sc;
 
     SMP_COND_STATEMENT(migrateTCB(to, sc->scCore));
+
+#ifdef ENABLE_SMP_SUPPORT
+    /* Invariant: the current thread always belongs to the current core. */
+    assert(NODE_STATE(ksCurThread)->tcbAffinity == getCurrentCPUIndex());
+#endif
 }
 
 void schedContext_bindNtfn(sched_context_t *sc, notification_t *ntfn)

--- a/src/object/schedcontrol.c
+++ b/src/object/schedcontrol.c
@@ -71,6 +71,12 @@ static exception_t invokeSchedControl_ConfigureFlags(sched_context_t *target, wo
         }
     }
 
+#ifdef ENABLE_SMP_SUPPORT
+    /* Invariant: the current thread always belongs to the current core.
+     * sel4test: SCHED0022 */
+    assert(NODE_STATE(ksCurThread)->tcbAffinity == getCurrentCPUIndex());
+#endif
+
     target->scBadge = badge;
     target->scSporadic = (flags & seL4_SchedContext_Sporadic) != 0;
 

--- a/src/object/tcb.c
+++ b/src/object/tcb.c
@@ -118,6 +118,7 @@ void tcbSchedEnqueue(tcb_t *tcb)
     assert(isSchedulable(tcb));
     assert(refill_sufficient(tcb->tcbSchedContext, 0));
 #endif
+    assert(tcb != NODE_STATE(ksIdleThread));
 
     if (!thread_state_get_tcbQueued(tcb->tcbState)) {
         tcb_queue_t queue;
@@ -468,6 +469,7 @@ void remoteTCBStall(tcb_t *tcb)
 
     if (
 #ifdef CONFIG_KERNEL_MCS
+// XX: Why is this correct?
         tcb->tcbSchedContext &&
 #endif
         tcb->tcbAffinity != getCurrentCPUIndex() &&


### PR DESCRIPTION
We identified a bug where passive-server migration involving the current thread would not cause remote IPIs to be sent.

We fix this by adding a new invariant for SMP that the current thread is always running on the current core, as well as that the current ksSchedulerAction candidate must be a thread on the current core.

Thus, anytime we change the affinity of a thread we need to make sure it is not the current thread, and if so we switch to the idle thread and reschedule ourselves.

This invariant means that the schedule() function will only ever talk about threads running on the current core, and allows several of the TCB_SCHED_ENQUEUE/append calls to be changed to the current-core-only tcbSchedEnqueue call.

This is #1662 with many of the unrelated/debug changes removed. Fixes #941.