### PR TITLE
cmake: Fix timer frequency export to userspace

### DIFF
--- a/configs/seL4Config.cmake
+++ b/configs/seL4Config.cmake
@@ -202,7 +202,7 @@ config_set(KernelArchArmV8a ARCH_ARM_V8A "${KernelArchArmV8a}")
 config_set(KernelAArch64SErrorIgnore AARCH64_SERROR_IGNORE "${KernelAArch64SErrorIgnore}")
 
 # Export timer frequency to user space:
-if(KernelTimerFrequency)
+if(CONFIGURE_TIMER_FREQUENCY)
   config_set(KernelTimerFrequency TIMER_FREQUENCY "${CONFIGURE_TIMER_FREQUENCY}")
 endif()
 


### PR DESCRIPTION
Previously, this would only be exported if you set `-DKernelTimerFrequency=TRUE` in the CMake invocation; but it was intended to always set it. Instead do the conditional based on whether CONFIGURE_TIMER_FREQUENCY exists.