### PR TITLE
aarch32,riscv: exclusive KernelPaddrUserTop

### DIFF
--- a/src/arch/arm/config.cmake
+++ b/src/arch/arm/config.cmake
@@ -39,9 +39,8 @@ config_set(KernelArmPASizeBits44 ARM_PA_SIZE_BITS_44 "${KernelArmPASizeBits44}")
 config_set(KernelArmICacheVIPT ARM_ICACHE_VIPT "${KernelArmICacheVIPT}")
 
 if(KernelSel4ArchAarch32)
-  # 64-bit targets may be building in 32-bit mode,
-  # so make sure maximum paddr is 32-bit.
-  math(EXPR KernelPaddrUserTop "(1 << 32) - 1")
+  # Maximum paddr needs to be exclusive. Code is fine when it wraps to 0.
+  math(EXPR KernelPaddrUserTop "1 << 32")
 endif()
 
 include(src/arch/arm/armv/armv7-a/config.cmake)

--- a/src/arch/riscv/config.cmake
+++ b/src/arch/riscv/config.cmake
@@ -66,9 +66,8 @@ if(KernelSel4ArchRiscV32)
 endif()
 if(KernelPTLevels EQUAL 2)
   if(KernelSel4ArchRiscV32)
-    # seL4 on RISCV32 uses 32-bit ints for addresses,
-    # so limit the maximum paddr to 32-bits.
-    math(EXPR KernelPaddrUserTop "(1 << 32) - 1")
+    # Maximum paddr needs to be exclusive. Code is fine when it wraps to 0.
+    math(EXPR KernelPaddrUserTop "1 << 32")
   else()
     math(EXPR KernelPaddrUserTop "1 << 34")
   endif()

--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -808,9 +808,11 @@ BOOT_CODE bool_t create_untypeds(cap_t root_cnode_cap)
         start = ndks_boot.reserved[i].end;
     }
 
-    if (start < CONFIG_PADDR_USER_DEVICE_TOP) {
+    if (start <= CONFIG_PADDR_USER_DEVICE_TOP - 1) {
         region_t reg = paddr_to_pptr_reg((p_region_t) {
-            start, CONFIG_PADDR_USER_DEVICE_TOP
+            /* CONFIG_PADDR_USER_DEVICE_TOP cast to paddr_t can be 0.
+             * create_untypeds_for_region() can deal with that correctly. */
+            start, (paddr_t) CONFIG_PADDR_USER_DEVICE_TOP
         });
 
         if (!create_untypeds_for_region(root_cnode_cap, true, reg, first_untyped_slot)) {

--- a/tools/hardware/config.py
+++ b/tools/hardware/config.py
@@ -23,9 +23,6 @@ class Config:
         ''' Get page size in bits for this arch '''
         return 12  # 4096-byte pages
 
-    def get_smallest_kernel_object_alignment(self) -> int:
-        return 4  # seL4_MinUntypedBits is 4 for all configurations
-
     def get_device_page_bits(self) -> int:
         ''' Get page size in bits for mapping devices for this arch '''
         return self.get_page_bits()

--- a/tools/hardware/utils/memory.py
+++ b/tools/hardware/utils/memory.py
@@ -6,7 +6,6 @@
 
 from typing import List, Set, Tuple
 
-import hardware
 from hardware.config import Config
 from hardware.device import WrappedNode
 from hardware.fdt import FdtParser
@@ -112,11 +111,7 @@ def get_physical_memory(tree: FdtParser, config: Config) -> Tuple[List[Region], 
 def get_addrspace_exclude(regions: List[Region], config: Config):
     ''' Returns a list of regions that represents the inverse of the given region list. '''
     ret = set()
-    # We can't create untypeds that exceed the addrspace_max, so we round down to the smallest
-    # untyped size alignment so that the kernel will be able to turn the entire range into untypeds.
-    as_max = hardware.utils.align_down(config.addrspace_max,
-                                       config.get_smallest_kernel_object_alignment())
-    ret.add(Region(0, as_max))
+    ret.add(Region(0, config.addrspace_max))
 
     for reg in regions:
         if type(reg) == KernelRegionGroup:


### PR DESCRIPTION
The treatment of `KernelPaddrUserTop` was inconsistent between 32 and 64 bit architectures, because the desired 2^32 is not expressible on 32 bit systems. However, with a small tweak is safe to wrap it to 0 for untyped creation, which already deals gracefully with that case.

- Deal with (paddr_t) CONFIG_PADDR_USER_DEVICE_TOP potentially being 0 in boot.c

- Remove the special treatment of the top of the address space in hardware/utils/memory.py

- Remove now unused config.get_smallest_kernel_object_alignment()

This implements #1706, but merging is blocked until we have figured out what the impact on the Rust side is when `platform_gen.yaml` can produce output like

```yml
devices:
[..] 
- end: 0x100000000
  start: 0xfd000000
```

for 32 bit platforms (end = 2^32 above)

Test with: https://github.com/seL4/seL4_libs/pull/115