### PR TITLE
Add extra DSB to seL4_ARM_Page_Unify_Instruction

### DIFF
--- a/src/arch/arm/32/kernel/vspace.c
+++ b/src/arch/arm/32/kernel/vspace.c
@@ -1788,8 +1788,10 @@ static void doFlush(int invLabel, vptr_t start, vptr_t end, paddr_t pstart)
         /* ...then invalidate the corresponding instruction lines
            to point of unification... */
         invalidateCacheRange_I(start, end, pstart);
-        /* ...then invalidate branch predictors. */
+        /* ...then invalidate branch predictors... */
         branchFlushRange(start, end, pstart);
+        /* ... then wait for the completion of invalidations. */
+        dsb();
         /* Ensure new instructions come from fresh cache lines. */
         isb();
         break;

--- a/src/arch/arm/64/kernel/vspace.c
+++ b/src/arch/arm/64/kernel/vspace.c
@@ -1134,6 +1134,8 @@ static void doFlush(word_t invLabel, vptr_t start, vptr_t end, paddr_t pstart)
         /* ...then invalidate the corresponding instruction lines
            to point of unification... */
         invalidateCacheRange_I(start, end, pstart);
+        /* ... then wait for the completion of invalidations... */
+        dsb();
         /* ... and ensure new instructions come from fresh cache lines. */
         isb();
         break;


### PR DESCRIPTION
EDIT: this applies to aarch32 as well, and also targets functions `seL4_ARMPDUnify_Instruction()` and `seL4_ARMPageUnify_Instruction()`.

This PR fixes a missing dsb during I-cache invalidation for all addresses on aarch64. It is similar to the commit https://github.com/seL4/seL4/commit/21888e6a954d5f6853514cf4710f2115a773afb0.

I didn't try to reproduce the issue on real hardware.

## Description
The erroneous execution occurs when functions `seL4_ARM_Page_Unify_Instruction()` or `seL4_ARM_VSpace_Unify_Instruction()` are called, the kernel will perform the following cache maintenance operations (`dc cvau -> dmb -> dsb -> ic iallu -> isb -> isb`):
https://github.com/seL4/seL4/blob/df6cb8475392a5adbdbc2ba0882decf13ca66103/src/arch/arm/64/kernel/vspace.c#L1128-L1139

these include calling the function `invalidateCacheRange_I()`:
https://github.com/seL4/seL4/blob/df6cb8475392a5adbdbc2ba0882decf13ca66103/src/arch/arm/machine/cache.c#L135-L148

and for processors with VIPT I-cache (e.g. Cortex A35, A53 and A55) and the kernel is built as a hypervisor, it calls the function `invalidate_I_PoU` https://github.com/seL4/seL4/blob/df6cb8475392a5adbdbc2ba0882decf13ca66103/include/arch/arm/arch/64/mode/machine.h#L305-L313

This is not sufficient to guarantee that by the time `isb` (or other context synchronization events, e.g. exception return) is executed, the effects of i-cache invalidation instructions have completed. Therefore, a userspace application calling the unification functions has to perform another `dsb` followed by an `isb`, before it can guarantee that the unification operation has completed for later instructions of itself.

## Justification
Instructions for I-cache invalidation can be checked by the [herd](https://developer.arm.com/herd7) memory model tool (7.58). With the following program adapted from [SM.B%2Bcachesync-isb.litmus](https://github.com/herd/herdtools7/blob/ArmARM-M.c/catalogue/aarch64-ifetch/tests/DIC0-IDC0/SM.B%2Bcachesync-isb.litmus),
```
AArch64 SM.B+cachesync-isb
variant=ifetch
{
  0:X0=NOP; 0:X1=P0:m0; 0:X9=0;
}
P0              ;
    STR W0,[X1] ;
    DC CVAU,X1  ;
    DSB ISH     ;
    IC IALLU    ;
    DSB ISH     ;
    ISB         ;
m0: B l0        ;
    MOV W9,#1   ;
l0:             ;
exists 0:X9=0
```
the herd tools should return a single consistent execution, indicating that the instruction written by the first line will be observed by the branch instruction at `m0`. If the `dsb` instruction after `ic iallu` is removed, the tool should return an additional consistent execution that observes the old instruction.

## Note
I found the use of `dmb` and `dsb` in the kernel to be messy. For example, the function `invalidate_I_PoU()` is used in other places
https://github.com/seL4/seL4/blob/df6cb8475392a5adbdbc2ba0882decf13ca66103/src/arch/arm/machine/cache.c#L196-L208

and this PR adds an unnecessary (and costly) `dsb` call to these well-synchronised executions.