### PR TITLE
python-deps: add typing_extensions and protobuf

### DIFF
--- a/tools/python-deps/setup.py
+++ b/tools/python-deps/setup.py
@@ -24,6 +24,8 @@ twine upload -r pypi dist/*
 
 from setuptools import setup
 
+# six and future are for python 2 compatibility and will be removed in the future.
+# They are currently kept so current sel4-deps still works with older code bases.
 DEPS = [
     'six',
     'future',
@@ -42,11 +44,13 @@ DEPS = [
     'guardonce',
     'autopep8==2.3.2',
     'libarchive-c',
+    'typing_extensions',
+    'protobuf>=3.19',  # nanopb 0.4.9.1 has requires_dist protobuf>=3.19
 ]
 
 setup(
     name='sel4-deps',
-    version='0.7.0',
+    version='0.8.0',
     description='Metapackage for downloading build dependencies for the seL4 microkernel',
     long_description="""
 This meta package depends on all python packages you need to build the seL4 microkernel and manual.


### PR DESCRIPTION
- Add typing_extensions to enable type annotations in older python 3.x versions.

- Add protobuf, because some Linux distros come with a too old protobuf and it is easier/nicer to reduce the distro package install list.

Needed for #1637 and related to https://github.com/seL4/docs/issues/317

After this is merged, we should

- [x] publish the pypi package
- [x] remove protobuf from the apt package install list
- [x] remove the protobuf apt install in docker
