### PR TITLE
bitfield_gen: fix illegal call of umm.base_name()

### DIFF
--- a/tools/bitfield_gen.py
+++ b/tools/bitfield_gen.py
@@ -3101,8 +3101,8 @@ if __name__ == '__main__':
         print("end", file=out_file)
     elif options.hol_proofs:
         def is_bit_type(tp):
-            return umm.is_base(tp) & (umm.base_name(tp) in
-                                      map(lambda e: e.name + '_C', det_values(blocks, unions)))
+            return umm.is_base(tp) and (umm.base_name(tp) in
+                                        map(lambda e: e.name + '_C', det_values(blocks, unions)))
 
         tps = umm.build_types(options.umm_types_file)
         type_map = {}


### PR DESCRIPTION
A previous commit introduced asserts and type checks, which reveal that `umm.base_name()` was called on non-base_name fields.

Use shortcut `and` as intended to guard by `umm.is_base()` instead of bitwise `&`.

This previously worked fine, because the non-sensical return values from `base_name()` were then ignored.