### PR TITLE
python-deps: constrain max protobuf version

### DIFF
--- a/tools/python-deps/setup.py
+++ b/tools/python-deps/setup.py
@@ -45,12 +45,15 @@ DEPS = [
     'autopep8==2.3.2',
     'libarchive-c',
     'typing_extensions',
-    'protobuf>=3.19',  # nanopb 0.4.9.1 has requires_dist protobuf>=3.19
+    # nanopb 0.4.9.1 has requires_dist protobuf>=3.19
+    # protoc on Ubuntu 22.04 requires protobuf<4; can be dropped after EOL of
+    # Ubuntu 22.04 in Apr 2027
+    'protobuf>=3.19,<4',
 ]
 
 setup(
     name='sel4-deps',
-    version='0.8.0',
+    version='0.9.0',
     description='Metapackage for downloading build dependencies for the seL4 microkernel',
     long_description="""
 This meta package depends on all python packages you need to build the seL4 microkernel and manual.


### PR DESCRIPTION
Ubuntu 22.04 LTS installs a protoc that does not work with protobuf>=4, so as long as that is supported we need to constrain the maximum version.

See also https://github.com/seL4/docs/pull/345#issuecomment-5141631808
