### PR TITLE
VT-d: Properly invalidate IOMMU caches

### DIFF
--- a/src/arch/x86/object/iospace.c
+++ b/src/arch/x86/object/iospace.c
@@ -132,7 +132,9 @@ void unmapVTDContextEntry(cap_t cap)
                false
            );
 
+    /* Changes to a context-table entry */
     flushCacheRange(cte, VTD_CTE_SIZE_BITS);
+    invalidate_context_cache();
     invalidate_iotlb();
     setThreadState(NODE_STATE(ksCurThread), ThreadState_Restart);
     return;
@@ -151,7 +153,10 @@ static exception_t performX86IOPTInvocationMapContextRoot(cap_t cap, cte_t *ctSl
                                                           vtd_cte_t *vtd_context_slot)
 {
     *vtd_context_slot = vtd_cte;
+    /* Changes to a context-table entry */
     flushCacheRange(vtd_context_slot, VTD_CTE_SIZE_BITS);
+    invalidate_context_cache();
+    invalidate_iotlb();
     ctSlot->cap = cap;
 
     return EXCEPTION_NONE;
@@ -160,7 +165,9 @@ static exception_t performX86IOPTInvocationMapContextRoot(cap_t cap, cte_t *ctSl
 static exception_t performX86IOPTInvocationMapPT(cap_t cap, cte_t *ctSlot, vtd_pte_t iopte, vtd_pte_t *ioptSlot)
 {
     *ioptSlot = iopte;
+    /* Changes to Second-stage page-tables */
     flushCacheRange(ioptSlot, VTD_PTE_SIZE_BITS);
+    invalidate_iotlb();
     ctSlot->cap = cap;
 
     return EXCEPTION_NONE;
@@ -287,7 +294,9 @@ static exception_t performX86IOInvocationMap(cap_t cap, cte_t *ctSlot, vtd_pte_t
 {
     ctSlot->cap = cap;
     *ioptSlot = iopte;
+    /* changes to Second-stage page-tables */
     flushCacheRange(ioptSlot, VTD_PTE_SIZE_BITS);
+    invalidate_iotlb();
 
     return EXCEPTION_NONE;
 }
@@ -426,7 +435,10 @@ void deleteIOPageTable(cap_t io_pt_cap)
                                     0,      /* Translation Type   */
                                     0       /* Present            */
                                 );
+            /* Changes to a context-table entry */
             flushCacheRange(vtd_context_slot, VTD_CTE_SIZE_BITS);
+            invalidate_context_cache();
+            /* IOTLB is invalidated later */
         } else {
             io_address = cap_io_page_table_cap_get_capIOPTMappedAddress(io_pt_cap);
             lu_ret = lookupIOPTSlot_resolve_levels(vtd_pte, io_address >> PAGE_BITS, level - 1, level - 1);
@@ -444,7 +456,9 @@ void deleteIOPageTable(cap_t io_pt_cap)
                                    0,  /* Read Permission  */
                                    0   /* Write Permission */
                                );
+            /* Changes to Second-stage page-tables */
             flushCacheRange(lu_ret.ioptSlot, VTD_PTE_SIZE_BITS);
+            /* IOTLB is invalidated later */
         }
         invalidate_iotlb();
     }
@@ -482,6 +496,7 @@ void unmapIOPage(cap_t cap)
                            0   /* Write Permission */
                        );
 
+    /* Changes to Second-stage page-tables */
     flushCacheRange(lu_ret.ioptSlot, VTD_PTE_SIZE_BITS);
     invalidate_iotlb();
 }

--- a/src/plat/pc99/machine/intel-vtd.c
+++ b/src/plat/pc99/machine/intel-vtd.c
@@ -335,7 +335,10 @@ BOOT_CODE static void vtd_map_reserved_page(vtd_cte_t *vtd_context_table, int co
                                 0,                        /* Translation Type                       */
                                 true);                    /* Present                                */
         x86KSFirstValidIODomain++;
+        /* Changes to a context-table entry */
         flushCacheRange(vtd_context_slot, VTD_CTE_SIZE_BITS);
+        invalidate_context_cache();
+        invalidate_iotlb();
     } else {
         iopt = (vtd_pte_t *)paddr_to_pptr(vtd_cte_ptr_get_asr(vtd_context_slot));
     }
@@ -353,14 +356,18 @@ BOOT_CODE static void vtd_map_reserved_page(vtd_cte_t *vtd_context_table, int co
         if (i == 0) {
             /* Now put the mapping in */
             *vtd_pte_slot = vtd_pte_new(addr, 1, 1);
+            /* Changes to Second-stage page-tables */
             flushCacheRange(vtd_pte_slot, VTD_PTE_SIZE_BITS);
+            invalidate_iotlb();
         } else {
             if (!vtd_pte_ptr_get_write(vtd_pte_slot)) {
                 iopt = (vtd_pte_t *) it_alloc_paging();
                 flushCacheRange(iopt, seL4_IOPageTableBits);
 
                 *vtd_pte_slot = vtd_pte_new(pptr_to_paddr(iopt), 1, 1);
+                /* Changes to Second-stage page-tables */
                 flushCacheRange(vtd_pte_slot, VTD_PTE_SIZE_BITS);
+                invalidate_iotlb();
             } else {
                 iopt = (vtd_pte_t *)paddr_to_pptr(vtd_pte_ptr_get_addr(vtd_pte_slot));
             }


### PR DESCRIPTION
Properly invalidates the IOMMU's caches as dictated by Table 28 in the [Intel® Virtualization Technology for Directed I/O Architecture Specification 5.2](https://www.intel.com/content/www/us/en/content-details/919688/intel-virtualization-technology-for-directed-i-o-architecture-specification.html) manual.

Observed failure mode without the fix is that DMA transfers fail for memory regions that have been mapped into the IO-Space.