### PR TITLE
x86/vcpu: fix multiple VMs not working on single and multi cores

### DIFF
--- a/include/arch/x86/arch/model/statedata.h
+++ b/include/arch/x86/arch/model/statedata.h
@@ -36,10 +36,6 @@ NODE_STATE_DECLARE(interrupt_t, x86KSPendingInterrupt);
 /* Bitmask of all cores should receive the reschedule IPI */
 NODE_STATE_DECLARE(word_t, ipiReschedulePending);
 
-#ifdef CONFIG_VTX
-NODE_STATE_DECLARE(vcpu_t *, x86KSCurrentVCPU);
-#endif
-
 NODE_STATE_DECLARE(word_t, x86KSCurrentFSBase);
 NODE_STATE_DECLARE(word_t, x86KSCurrentGSBase);
 
@@ -49,6 +45,12 @@ NODE_STATE_DECLARE(word_t, x86KSCurrentGSBase);
 NODE_STATE_DECLARE(word_t, x86KSGPExceptReturnTo);
 
 NODE_STATE_TYPE_DECLARE(modeNodeState, mode);
+
+#ifdef CONFIG_VTX
+NODE_STATE_DECLARE(vcpu_t *, x86KSCurrentVCPU);
+NODE_STATE_DECLARE(struct vmxon_region, x86KSVMXOnRegion);
+#endif
+
 NODE_STATE_END(archNodeState);
 
 /* this is per core state grouped into a separate struct as it needs to be available

--- a/include/arch/x86/arch/object/vcpu.h
+++ b/include/arch/x86/arch/object/vcpu.h
@@ -232,6 +232,13 @@ typedef uint16_t vpid_t;
 #ifdef CONFIG_VTX
 #define VTX_TERNARY(vtx, nonvtx) vtx
 
+#define VMXON_REGION_SIZE 4096
+
+struct vmxon_region {
+    uint32_t revision;
+    char data[VMXON_REGION_SIZE - sizeof(uint32_t)];
+} ALIGN(VMXON_REGION_SIZE);
+
 enum vcpu_gp_register {
     VCPU_EAX = 0,
     VCPU_EBX,

--- a/src/arch/x86/64/c_traps.c
+++ b/src/arch/x86/64/c_traps.c
@@ -182,7 +182,7 @@ static void NORETURN restore_vmx(tcb_t *cur_thread, vcpu_t *vcpu)
 #ifdef CONFIG_X86_64_VTX_64BIT_GUESTS
         [stack_size]"i"(BIT(CONFIG_KERNEL_STACK_BITS)),
         [guest_msr]"r"(vcpu->guest_msr_registers),
-        [host_msr]"r"(vcpu->host_msr_registers)
+        [host_msr]"r"(&vcpu->host_msr_registers[n_vcpu_msr_register])
 #else /* not CONFIG_X86_64_VTX_64BIT_GUESTS */
         [stack_size]"i"(BIT(CONFIG_KERNEL_STACK_BITS))
 #ifdef ENABLE_SMP_SUPPORT

--- a/src/arch/x86/model/statedata.c
+++ b/src/arch/x86/model/statedata.c
@@ -55,6 +55,7 @@ uint32_t x86KSFirstValidIODomain;
 
 #ifdef CONFIG_VTX
 UP_STATE_DEFINE(vcpu_t *, x86KSCurrentVCPU);
+UP_STATE_DEFINE(struct vmxon_region, x86KSVMXOnRegion);
 #endif
 
 #ifdef CONFIG_PRINTING

--- a/src/arch/x86/object/vcpu.c
+++ b/src/arch/x86/object/vcpu.c
@@ -54,7 +54,7 @@ static struct PACKED {
 
 static msr_bitmaps_t msr_bitmap_region ALIGN(BIT(seL4_PageBits));
 
-static char null_ept_space[seL4_PageBits] ALIGN(BIT(seL4_PageBits));
+static char null_ept_space[BIT(seL4_PageBits)] ALIGN(BIT(seL4_PageBits));
 
 /* Cached value of the hardware defined vmcs revision */
 static uint32_t vmcs_revision;

--- a/src/arch/x86/object/vcpu.c
+++ b/src/arch/x86/object/vcpu.c
@@ -25,8 +25,6 @@
 #define VMX_EXIT_QUAL_TYPE_CLTS 2
 #define VMX_EXIT_QUAL_TYPE_LMSW 3
 
-#define VMXON_REGION_SIZE 4096
-
 const vcpu_gp_register_t crExitRegs[] = {
     VCPU_EAX, VCPU_ECX, VCPU_EDX, VCPU_EBX, VCPU_ESP, VCPU_EBP, VCPU_ESI, VCPU_EDI,
 #ifdef CONFIG_X86_64_VTX_64BIT_GUESTS
@@ -46,11 +44,6 @@ typedef struct msr_bitmaps {
     msr_bitmap_t low_msr_write;
     msr_bitmap_t high_msr_write;
 } msr_bitmaps_t;
-
-static struct PACKED {
-    uint32_t revision;
-    char data[VMXON_REGION_SIZE - sizeof(uint32_t)];
-} vmxon_region ALIGN(VMXON_REGION_SIZE);
 
 static msr_bitmaps_t msr_bitmap_region ALIGN(BIT(seL4_PageBits));
 
@@ -1217,13 +1210,14 @@ BOOT_CODE bool_t vtx_init(void)
     }
     write_cr4(read_cr4() | CR4_VMXE);
     /* we are required to set the VMCS region in the VMXON region */
-    vmxon_region.revision = vmcs_revision;
+    struct vmxon_region *vmxon_kptr = &ARCH_NODE_STATE(x86KSVMXOnRegion);
+    vmxon_kptr->revision = vmcs_revision;
     /* Before calling vmxon, we must check that CR0 and CR4 are not set to values
      * that are unsupported by vt-x */
     if (!vtx_check_fixed_values(read_cr0(), read_cr4())) {
         return false;
     }
-    if (vmxon(kpptr_to_paddr(&vmxon_region))) {
+    if (vmxon(kpptr_to_paddr(vmxon_kptr))) {
         printf("vt-x: vmxon failure\n");
         return false;
     }

--- a/src/model/statedata.c
+++ b/src/model/statedata.c
@@ -15,7 +15,7 @@
 #include <benchmark/benchmark_track.h>
 
 /* Collective cpu states, including both pre core architecture dependant and independent data */
-SMP_STATE_DEFINE(smpStatedata_t, ksSMP[CONFIG_MAX_NUM_NODES] ALIGN(L1_CACHE_LINE_SIZE));
+SMP_STATE_DEFINE(smpStatedata_t, ksSMP[CONFIG_MAX_NUM_NODES]);
 
 /* Global count of how many cpus there are */
 word_t ksNumCPUs;


### PR DESCRIPTION
Please see the commit messages for problems and solutions. Fixes VMs not working or exhibiting erratic behaviours when sharing one physical core or placed on multiple cores.