### PR TITLE
Optimized `merge_regions` function.

### DIFF
--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -47,21 +47,18 @@ BOOT_CODE p_region_t get_p_reg_kernel_img(void)
 BOOT_CODE static void merge_regions(void)
 {
     /* Walk through reserved regions and see if any can be merged */
-    for (word_t i = 1; i < ndks_boot.resv_count;) {
-        if (ndks_boot.reserved[i - 1].end == ndks_boot.reserved[i].start) {
+    word_t top = 0;
+    for (word_t i = 1; i < ndks_boot.resv_count; i++) {
+        if (ndks_boot.reserved[top].end == ndks_boot.reserved[i].start) {
             /* extend earlier region */
-            ndks_boot.reserved[i - 1].end = ndks_boot.reserved[i].end;
-            /* move everything else down */
-            for (word_t j = i + 1; j < ndks_boot.resv_count; j++) {
-                ndks_boot.reserved[j - 1] = ndks_boot.reserved[j];
-            }
-
-            ndks_boot.resv_count--;
-            /* don't increment i in case there are multiple adjacent regions */
+            ndks_boot.reserved[top].end = ndks_boot.reserved[i].end;
         } else {
-            i++;
+            /* add region */
+            top++;
+            ndks_boot.reserved[top] = ndks_boot.reserved[i];
         }
     }
+    ndks_boot.resv_count = ndks_boot.resv_count > 0 ? top + 1 : 0;
 }
 
 BOOT_CODE bool_t reserve_region(p_region_t reg)


### PR DESCRIPTION
Current `merge_regions` function copies all regions after merged region causing the function to take quadratic time.
I wrote an optimized version that can operate in only linear time by have the `ndks_boot.reserved` overwrite itself.