### PR TITLE
arch64,hyp: Set SWIO bit of HCR_EL2 reg always

### DIFF
--- a/include/arch/arm/armv/armv8-a/64/armv/vcpu.h
+++ b/include/arch/arm/armv/armv8-a/64/armv/vcpu.h
@@ -15,11 +15,11 @@
 
 /* Note that the HCR_DC for ARMv8 disables S1 translation if enabled */
 /* Trap SMC and override CPSR.AIF */
-#define HCR_COMMON ( HCR_VM | HCR_RW | HCR_AMO | HCR_IMO | HCR_FMO | HCR_TSC)
+#define HCR_COMMON ( HCR_VM | HCR_SWIO | HCR_RW | HCR_AMO | HCR_IMO | HCR_FMO | HCR_TSC)
 
 /* Allow native tasks to run at EL0, but restrict access */
 #define HCR_NATIVE ( HCR_COMMON | HCR_TGE | HCR_TVM | HCR_TTLB | HCR_DC \
-                   | HCR_TAC | HCR_SWIO |  HCR_TSC )
+                   | HCR_TAC | HCR_TSC )
 
 #ifdef CONFIG_DISABLE_WFI_WFE_TRAPS
 #define HCR_VCPU   ( HCR_COMMON)


### PR DESCRIPTION
According to the architecture specification the effect of this bit being set is:
"Causes Non-secure EL1 execution of the data cache invalidate by set/way instructions to be treated as data cache clean and invalidate by set/way"

Without this bit set, the set/way cache operations can be used by one VM to invalidate the dirty lines of data belonging to another protection domain if they share a cache which breaks isolation.

Some implementations define this bit as RES1 which already effictively implements this change.

Supported implementations that don't define as RES1:
- Cortex-A57
- Cortex-A72

Supported implementations that do define as RES1:
- Cortex-A35
- Cortex-A53
- Cortex-A55
- Cortex-A76