### PR TITLE
aarch64,hyp: Add compile_assert for doFlush ranges

### DIFF
--- a/include/arch/arm/arch/64/mode/hardware.h
+++ b/include/arch/arm/arch/64/mode/hardware.h
@@ -303,5 +303,6 @@
 compile_assert(ut_max_less_than_canonical, CONFIG_PADDR_USER_DEVICE_TOP <= BIT(47));
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
 compile_assert(ut_max_is_canonical, (PPTR_BASE + CONFIG_PADDR_USER_DEVICE_TOP) <= BIT(48));
+compile_assert(ut_max_is_in_kernel_window, (PPTR_BASE + CONFIG_PADDR_USER_DEVICE_TOP) <= PPTR_TOP);
 #endif
 #endif


### PR DESCRIPTION
When the kernel executes in EL2, the kernel invocations for performing cache maintenance operations first translate the physical address into the kernel window and perform the maintenance operation via the kernel's own mapping.

To ensure that the mapping exists, the largest device UT address that's given to user level needs to be mapped in the kernel window, otherwise a translation fault can be generated.

Add a static_assert to capture this requirement.

(This compile_assert will fail on all platforms currently because the kernel window is smaller than 2^39, and all definitions of `CONFIG_PADDR_USER_DEVICE_TOP` are larger than 2^39).

