### PR TITLE
aarch64,types: make hw_asid_t 16 bit for non-hyp

### DIFF
--- a/include/arch/arm/arch/32/mode/types.h
+++ b/include/arch/arm/arch/32/mode/types.h
@@ -14,3 +14,5 @@ compile_assert(long_is_32bits, sizeof(unsigned long) == 4)
 #define wordBits (1 << wordRadix)
 
 typedef uint32_t timestamp_t;
+
+typedef uint8_t  hw_asid_t;

--- a/include/arch/arm/arch/64/mode/machine.h
+++ b/include/arch/arm/arch/64/mode/machine.h
@@ -161,6 +161,26 @@ static inline bool_t checkTCR_EL2(void)
     return (tcr_el2 == TCR_EL2_DEFAULT);
 }
 
+/* Supported ASID size field of ID_AA64MMFR0_EL1 */
+#define ID_AA64MMFR0_EL1_ASIDBITS(x)  (((x) >> 4) & 0xf)
+#define ID_AA64MMFR0_EL1_ASIDBITS_16  2
+/* Selected ASID size in TCR_EL1 */
+#define TCR_EL1_AS                    BIT(36)
+
+/* For non-hyp AArch64 configs, check that 16-bit ASIDs are supported
+ * and enabled. */
+static inline bool_t check16BitASID(void)
+{
+    word_t id_aa64mmfr0_el1 = 0;
+    word_t tcr_el1 = 0;
+
+    MRS("id_aa64mmfr0_el1", id_aa64mmfr0_el1);
+    MRS("tcr_el1", tcr_el1);
+
+    return ID_AA64MMFR0_EL1_ASIDBITS(id_aa64mmfr0_el1) == ID_AA64MMFR0_EL1_ASIDBITS_16 &&
+           (tcr_el1 & TCR_EL1_AS);
+}
+
 static inline void setCurrentKernelVSpaceRoot(ttbr_t ttbr)
 {
     dsb();

--- a/include/arch/arm/arch/64/mode/types.h
+++ b/include/arch/arm/arch/64/mode/types.h
@@ -14,3 +14,9 @@ compile_assert(long_is_64bits, sizeof(unsigned long) == 8)
 #define wordBits (1 << wordRadix)
 
 typedef uint64_t timestamp_t;
+
+#ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
+typedef uint8_t  hw_asid_t;
+#else
+typedef uint16_t hw_asid_t;
+#endif

--- a/include/arch/arm/arch/types.h
+++ b/include/arch/arm/arch/types.h
@@ -23,8 +23,6 @@ typedef word_t node_id_t;
 typedef word_t cpu_id_t;
 typedef word_t dom_t;
 
-typedef uint8_t  hw_asid_t;
-
 enum hwASIDConstants {
     hwASIDMax = 255,
     hwASIDBits = 8

--- a/src/arch/arm/kernel/boot.c
+++ b/src/arch/arm/kernel/boot.c
@@ -194,6 +194,14 @@ BOOT_CODE static bool_t init_cpu(void)
         vcpu_boot_init();
     }
 
+#ifdef CONFIG_ARCH_AARCH64
+    /* After activate_kernel_vspace(), so printf() is available. */
+    if (!config_set(CONFIG_ARM_HYPERVISOR_SUPPORT) && !check16BitASID()) {
+        printf("ERROR: kernel requires 16-bit ASIDs\n");
+        return false;
+    }
+#endif
+
 #ifdef CONFIG_HARDWARE_DEBUG_API
     if (!Arch_initHardwareBreakpoints()) {
         printf("Kernel built with CONFIG_HARDWARE_DEBUG_API, but this board doesn't "


### PR DESCRIPTION
Currently all supported AArch64 platforms have 8 bit VMIDs. When new platforms are added that have larger VMIDs (e.g. Orin), they either need to be added to the #ifdef or we need to refactor this further.

Previously the AArch64 non-hyp code expected 16 bit hardware ASIDs, but used an 8-bit type, with the consequence of flushing the wrong TLB entries when there are more than 256 threads.

Fixes #1735