### PR TITLE
Replace all unreachable defaults with assert(0)

### DIFF
--- a/include/arch/arm/arch/32/mode/object/structures.h
+++ b/include/arch/arm/arch/32/mode/object/structures.h
@@ -304,6 +304,7 @@ static inline word_t CONST cap_get_archCapSizeBits(cap_t cap)
 
     default:
         /* Unreachable, but GCC can't figure that out */
+        assert(!"Unknown cap type");
         return 0;
     }
 }
@@ -350,6 +351,7 @@ static inline bool_t CONST cap_get_archCapIsPhysical(cap_t cap)
 
     default:
         /* Unreachable, but GCC can't figure that out */
+        assert(!"Unknown cap type");
         return false;
     }
 }
@@ -394,6 +396,7 @@ static inline void *CONST cap_get_archCapPtr(cap_t cap)
 
     default:
         /* Unreachable, but GCC can't figure that out */
+        assert(!"Unknown cap type");
         return NULL;
     }
 }

--- a/include/arch/arm/arch/64/mode/object/structures.h
+++ b/include/arch/arm/arch/64/mode/object/structures.h
@@ -113,6 +113,7 @@ static inline word_t CONST cap_get_archCapSizeBits(cap_t cap)
 
     default:
         /* Unreachable, but GCC can't figure that out */
+        assert(!"Unknown cap type");
         return 0;
     }
 }
@@ -155,6 +156,7 @@ static inline bool_t CONST cap_get_archCapIsPhysical(cap_t cap)
 
     default:
         /* Unreachable, but GCC can't figure that out */
+        assert(!"Unknown cap type");
         return false;
     }
 }
@@ -196,6 +198,7 @@ static inline void *CONST cap_get_archCapPtr(cap_t cap)
 
     default:
         /* Unreachable, but GCC can't figure that out */
+        assert(!"Unknown cap type");
         return NULL;
     }
 }

--- a/include/arch/arm/arch/object/structures.h
+++ b/include/arch/arm/arch/object/structures.h
@@ -26,6 +26,7 @@ static inline bool_t CONST Arch_isCapRevocable(cap_t derivedCap, cap_t srcCap)
 #endif
 
     default:
+        // @0aids: intentionally non-exhaustive?
         return false;
     }
 }

--- a/include/arch/riscv/arch/object/structures.h
+++ b/include/arch/riscv/arch/object/structures.h
@@ -145,6 +145,7 @@ static inline void *CONST cap_get_archCapPtr(cap_t cap)
 
 static inline bool_t CONST Arch_isCapRevocable(cap_t derivedCap, cap_t srcCap)
 {
+    // @0aids: intentionally non-exhaustive?
     return false;
 }
 

--- a/include/arch/x86/arch/64/mode/object/structures.h
+++ b/include/arch/x86/arch/64/mode/object/structures.h
@@ -150,6 +150,7 @@ static inline word_t CONST cap_get_modeCapSizeBits(cap_t cap)
         return seL4_PDPTBits;
 
     default:
+        assert(!"Unknown cap type");
         return 0;
     }
 }
@@ -169,6 +170,7 @@ static inline bool_t CONST cap_get_modeCapIsPhysical(cap_t cap)
         return true;
 
     default:
+        assert(!"Unknown cap type");
         return false;
     }
 }
@@ -187,6 +189,7 @@ static inline void *CONST cap_get_modeCapPtr(cap_t cap)
         return PDPT_PTR(cap_pdpt_cap_get_capPDPTBasePtr(cap));
 
     default:
+        assert(!"Unknown cap type");
         return NULL;
     }
 }

--- a/include/arch/x86/arch/object/structures.h
+++ b/include/arch/x86/arch/object/structures.h
@@ -310,6 +310,7 @@ static inline bool_t CONST Arch_isCapRevocable(cap_t derivedCap, cap_t srcCap)
         return cap_get_capType(srcCap) == cap_io_port_control_cap;
 
     default:
+        // @0aids: Intentionally non-exhaustive?
         return false;
     }
 }

--- a/src/object/objecttype.c
+++ b/src/object/objecttype.c
@@ -1019,6 +1019,7 @@ bool_t CONST isCapRevocable(cap_t derivedCap, cap_t srcCap)
         return true;
 
     default:
+        // @0aids: intentionally non-exhaustive?
         return false;
     }
 }


### PR DESCRIPTION
Better code convention so that whenever a new cap type is added, all related cap data functions obviously fail.

For `Arch_isCapRevocable` and `isCapRevocable`, should this be changed to exhaustive switches? 
(marked by my comments in this PR). 

Also are there any other places where this should be done?

Thanks!