### PR TITLE
Pre-RFC: Multikernel Kernel Boot Code / Loader Changes

### DIFF
--- a/config.cmake
+++ b/config.cmake
@@ -150,12 +150,25 @@ config_string(KernelNumPriorities NUM_PRIORITIES
 config_string(KernelMaxNumNodes MAX_NUM_NODES "Max number of CPU cores to boot" DEFAULT 1
               DEPENDS "${KernelNumDomains} EQUAL 1" UNQUOTE)
 
-# Set CONFIG_ENABLE_SMP_SUPPORT as an alias of CONFIG_MAX_NUM_NODES > 1
 if(KernelMaxNumNodes GREATER 1)
-  config_set(KernelEnableSMPSupport ENABLE_SMP_SUPPORT ON)
+    config_set(KernelEnableSMPSupport ENABLE_SMP_SUPPORT ON)
 else()
-  config_set(KernelEnableSMPSupport ENABLE_SMP_SUPPORT OFF)
+    config_set(KernelEnableSMPSupport ENABLE_SMP_SUPPORT OFF)
 endif()
+
+config_option(
+    KernelEnableMultikernelSupport ENABLE_MULTIKERNEL_SUPPORT
+    "Multikernel support"
+    DEFAULT OFF
+)
+
+# XXX: HACK.
+config_string(
+    KernelMultikernelNumCPUs MULTIKERNEL_NUM_CPUS
+    "Multikernel number of CPUs"
+    DEFAULT 1
+    UNQUOTE
+)
 
 config_string(
   KernelStackBits

--- a/include/api/types.h
+++ b/include/api/types.h
@@ -138,7 +138,7 @@ extern struct debug_syscall_error current_debug_error;
     do {                                                                       \
         out_error(ANSI_BOLD "<<" ANSI_GREEN "seL4(CPU %" SEL4_PRIu_word ")"    \
                 ANSI_BOLD " [%s/%d T%p \"%s\" @%lx]: " M ">>" ANSI_RESET "\n", \
-                CURRENT_CPU_INDEX(),                                           \
+                NODE_STATE(boot_cpu_id),                                       \
                 __func__, __LINE__, NODE_STATE(ksCurThread),                   \
                 THREAD_NAME,                                                   \
                 (word_t)getRestartPC(NODE_STATE(ksCurThread)),                 \

--- a/include/arch/arm/arch/64/mode/object/structures.bf
+++ b/include/arch/arm/arch/64/mode/object/structures.bf
@@ -347,6 +347,22 @@ block ttbr {
     field_high base_address         48
 }
 
+-- ARM ARM DDI 0478H.a ID020222
+-- D13.2.101 'MPIDR_EL1, Multiprocessor Affinity Register'
+-- In a multiprocessor system, provides an additional PE identification mechanism.
+-- Read Only
+block mpidr_el1 {
+    padding             24          -- RES0 [63:40]
+    field Aff3          8           -- Aff3 [39:32]
+    padding             1           -- RES1 [31]
+    field U             1           -- U    [30]
+    padding             5           -- RES0 [29:25]
+    field MT            1           -- MT   [24]
+    field Aff2          8           -- Aff2 [23:16]
+    field Aff1          8           -- Aff1 [15:8]
+    field Aff0          8           -- Aff0 [7:0]
+}
+
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
 #ifdef CONFIG_ARM_GIC_V3_SUPPORT
 block virq_invalid {

--- a/include/arch/arm/arch/bootinfo.h
+++ b/include/arch/arm/arch/bootinfo.h
@@ -10,21 +10,22 @@
 #include <plat/machine/devices_gen.h>
 #include <kernel/vspace.h>
 
-/* The max number of free memory regions is:
- * +1 for each available physical memory region (elements in avail_p_regs)
- * +1 for each MODE_RESERVED region, there might be none
- * +1 to allow the kernel to release its own boot data region
- * +1 for a possible gap between ELF images and rootserver objects
+/* The value for the max number of free memory region is basically an arbitrary
+ * choice. We could calculate the exact number, but just picking 16 will also
+ * do for now. Increase this value if the boot fails.
  */
-#define MAX_NUM_FREEMEM_REG (ARRAY_SIZE(avail_p_regs) + MODE_RESERVED + 1 + 1)
+#define MAX_NUM_FREEMEM_REG 16
+#define MAX_NUM_USER_RESERVED_REGIONS 16
 
 /* The regions reserved by the boot code are:
  * +1 for kernel
  * +1 for device tree binary
  * +1 for user image.
  * +1 for each the MODE_RESERVED region, there might be none
+ *
+ * +16 arbitary for the other arguments passed.
  */
-#define NUM_RESERVED_REGIONS (3 + MODE_RESERVED)
+#define NUM_RESERVED_REGIONS (3 + MODE_RESERVED + MAX_NUM_USER_RESERVED_REGIONS)
 
 
 /* The maximum number of reserved regions is:

--- a/include/arch/arm/arch/kernel/boot.h
+++ b/include/arch/arm/arch/kernel/boot.h
@@ -12,12 +12,4 @@ cap_t create_unmapped_it_frame_cap(pptr_t pptr, bool_t use_large);
 cap_t create_mapped_it_frame_cap(cap_t pd_cap, pptr_t pptr, vptr_t vptr, asid_t asid, bool_t use_large,
                                  bool_t executable);
 
-void init_kernel(
-    paddr_t ui_p_reg_start,
-    paddr_t ui_p_reg_end,
-    sword_t pv_offset,
-    vptr_t  v_entry,
-    paddr_t dtb_addr_p,
-    uint32_t dtb_size
-);
-
+void init_kernel(paddr_t loader_info_p);

--- a/include/basic_types.h
+++ b/include/basic_types.h
@@ -81,6 +81,7 @@ typedef word_t __attribute__((__may_alias__)) word_t_may_alias;
 typedef uint8_t seL4_Uint8;
 typedef uint16_t seL4_Uint16;
 typedef uint32_t seL4_Uint32;
+typedef uint64_t seL4_Uint64;
 typedef word_t seL4_Word;
 typedef cptr_t seL4_CPtr;
 typedef node_id_t seL4_NodeId;

--- a/include/bootinfo.h
+++ b/include/bootinfo.h
@@ -9,6 +9,7 @@
 #include <config.h>
 #include <types.h>
 #include <sel4/bootinfo_types.h>
+#include <sel4/loader_info.h>
 
 /* declare object-specific macros to hide the casting */
 #define BI_PTR(r) ((seL4_BootInfo*)(r))

--- a/include/hardware.h
+++ b/include/hardware.h
@@ -19,9 +19,7 @@
  *  - PPTR_TOP: The first virtual address after the end of the kernel's
  *    physical memory window.
  *
- *  - KERNEL_ELF_PADDR_BASE: The first physical address used to map the
- *    initial kernel image. The kernel ELF is mapped contiguously
- *    starting at this address.
+ *  - ksKernelElfPaddrBase
  *  - KERNEL_ELF_BASE: The first virtual address used to map the initial
  *    kernel image.
  *
@@ -40,7 +38,7 @@
  * from virtual to physical. This translation must be a single offset
  * for for the entire segment (i.e. the kernel image must be contiguous
  * both virtually and physically) */
-#define KERNEL_ELF_BASE_OFFSET (KERNEL_ELF_BASE - KERNEL_ELF_PADDR_BASE)
+#define KERNEL_ELF_BASE_OFFSET (KERNEL_ELF_BASE - ksKernelElfPaddrBase)
 
 #ifndef __ASSEMBLER__
 

--- a/include/kernel/boot.h
+++ b/include/kernel/boot.h
@@ -41,8 +41,8 @@ static inline bool_t is_reg_empty(region_t reg)
 
 p_region_t get_p_reg_kernel_img_boot(void);
 p_region_t get_p_reg_kernel_img(void);
-bool_t init_freemem(word_t n_available, const p_region_t *available,
-                    word_t n_reserved, const region_t *reserved,
+bool_t init_freemem(word_t n_available, p_region_t *available,
+                    word_t n_reserved, region_t *reserved,
                     v_region_t it_v_reg, word_t extra_bi_size_bits);
 bool_t reserve_region(p_region_t reg);
 void write_slot(slot_ptr_t slot_ptr, cap_t cap);
@@ -52,6 +52,7 @@ cap_t create_it_asid_pool(cap_t root_cnode_cap);
 void write_it_pd_pts(cap_t root_cnode_cap, cap_t it_pd_cap);
 void create_idle_thread(void);
 bool_t create_untypeds(cap_t root_cnode_cap);
+bool_t create_untypeds_for_region(cap_t root_cnode_cap, bool_t device_memory, region_t reg, seL4_SlotPos first_untyped_slot);
 void bi_finalise(void);
 void create_domain_cap(cap_t root_cnode_cap);
 

--- a/include/machine.h
+++ b/include/machine.h
@@ -34,6 +34,7 @@ static inline paddr_t CONST addrFromPPtr(const void *pptr)
  * the kernel ELF mapping, this function must be used. */
 static inline paddr_t CONST addrFromKPPtr(const void *pptr)
 {
+    assert(ksKernelElfPaddrBase != -1);
     assert((paddr_t)pptr >= KERNEL_ELF_BASE);
     assert((paddr_t)pptr <= KERNEL_ELF_TOP);
     return (paddr_t)pptr - KERNEL_ELF_BASE_OFFSET;

--- a/include/model/statedata.h
+++ b/include/model/statedata.h
@@ -88,6 +88,9 @@ NODE_STATE_DECLARE(timestamp_t, benchmark_kernel_time);
 NODE_STATE_DECLARE(timestamp_t, benchmark_kernel_number_entries);
 NODE_STATE_DECLARE(timestamp_t, benchmark_kernel_number_schedules);
 #endif /* CONFIG_BENCHMARK_TRACK_UTILISATION */
+#ifdef CONFIG_ENABLE_MULTIKERNEL_SUPPORT
+NODE_STATE_DECLARE(node_id_t, boot_cpu_id);
+#endif
 
 NODE_STATE_END(nodeState);
 
@@ -116,6 +119,10 @@ extern char ksIdleThreadSC[CONFIG_MAX_NUM_NODES][BIT(seL4_MinSchedContextBits)];
 #ifdef CONFIG_KERNEL_LOG_BUFFER
 extern paddr_t ksUserLogBuffer;
 #endif /* CONFIG_KERNEL_LOG_BUFFER */
+
+#ifdef CONFIG_ARCH_AARCH64
+extern paddr_t ksKernelElfPaddrBase;
+#endif
 
 #define SchedulerAction_ResumeCurrentThread ((tcb_t*)0)
 #define SchedulerAction_ChooseNewThread ((tcb_t*) 1)

--- a/libsel4/include/sel4/bootinfo.h
+++ b/libsel4/include/sel4/bootinfo.h
@@ -8,6 +8,7 @@
 
 #include <sel4/types.h>
 #include <sel4/bootinfo_types.h>
+#include <sel4/loader_info.h>
 #include <sel4/macros.h>
 
 void seL4_InitBootInfo(seL4_BootInfo *bi)

--- a/libsel4/include/sel4/loader_info.h
+++ b/libsel4/include/sel4/loader_info.h
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2025, UNSW
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <sel4/config.h>
+#include <sel4/macros.h>
+
+/**
+ *
+ * The Loader Info structure looks like this:
+ *
+ *            +---------------------------+
+ *            |                           |
+ *            |     Loader Info Header    |
+ *            |                           |
+ *            +---------------------------+
+*             |     Kernel Mem Region     |               (singular)
+ *            +---------------------------+
+ *            |        RAM Region 1       |
+ *            +---------------------------+           -+
+ *            |        RAM Region 2       |            |  fixed "RAM region" size
+ *            +---------------------------+           -+
+*             |     Root Task Region 1    |
+ *            +---------------------------+           -+
+ *            |     Root Task Region 2    |            |  (possibly) different fixed size
+ *            +---------------------------+           -+
+*             |     Reserved Region 1     |
+ *            +---------------------------+
+ *            |     Reserved Region 2     |
+ *            +---------------------------+
+ *
+ * An alternative would be to repurpose the ELF header structure but it's a bit
+ * complicated for this task.
+ *
+ *
+ */
+
+typedef struct seL4_LoaderInfo {
+    /* Should be SEL4_LOADER_INFO_MAGIC */
+    seL4_Uint32 magic;
+    /* The version of this seL4_LoaderInfo protocol.
+       For now, only SEL4_LOADER_INFO_VERSION_0 exists. */
+    seL4_Uint8 version;
+    // TODO: Might want 32-bit vs 64-bit? For now only 64-bit.
+    seL4_Uint8 _padding0[3];
+
+    /* Root task's entry point */
+    seL4_Uint64 root_task_entry;
+
+    // XXX: useful for domain partitioning later
+    /** This represents the kernel ELF's loaded physical address range. Only one. */
+    seL4_Uint8 num_kernel_regions;
+    /** This represents physical memory ranges useable by the kernel. Can have multiple.
+        On multikernel, this might not be all of available RAM.
+        This will be exposed as "normal" untyped capabilities, excluding any reserved
+        regions. */
+    seL4_Uint8 num_ram_regions;
+    /** This represents the physical memory address of the root task. */
+    seL4_Uint8 num_root_task_regions;
+    /** This represents reserved physical memory addresses.
+        No untyped capabilities will be created for these regions; nor will
+        seL4 try to write or read from these addreses.
+        Used in multikernel to mark other kernels' memory as reserved. */
+    seL4_Uint8 num_reserved_regions;
+    seL4_Uint8 num_mpidrs;
+    seL4_Uint8 _padding[3];
+} SEL4_PACKED seL4_LoaderInfo;
+
+
+#define SEL4_LOADER_INFO_MAGIC ((seL4_Uint32)0x73654c34)  /* "seL4" */
+
+#define SEL4_LOADER_INFO_VERSION_0 ((seL4_Uint8)0)        /* Version 0 */
+
+
+/* A region [start..end) of physical memory addresses.
+   The fields addresses have architecture-specific alignment requirements. */
+typedef struct seL4_Loader_KernelRegion {
+    seL4_Uint64 base;
+    seL4_Uint64 end;
+} SEL4_PACKED SEL4_ALIGNAS(seL4_Uint64) seL4_Loader_KernelRegion;
+
+/* A region [start..end) of physical memory addresses.
+   The fields addresses have architecture-specific alignment requirements. */
+typedef struct seL4_Loader_RamRegion {
+    seL4_Uint64 base;
+    seL4_Uint64 end;
+} SEL4_PACKED SEL4_ALIGNAS(seL4_Uint64) seL4_Loader_RamRegion;
+
+/* A region [start..end) of physical memory addresses.
+   Then, the base virtual address of this region. The virtual end is implicitly
+   defined based on the size of the physical region. */
+typedef struct seL4_Loader_RootTaskRegion {
+    seL4_Uint64 paddr_base;
+    seL4_Uint64 paddr_end;
+    seL4_Uint64 vaddr_base;
+    seL4_Uint8 _padding[8];
+} SEL4_PACKED SEL4_ALIGNAS(seL4_Uint64) seL4_Loader_RootTaskRegion;
+
+/* A region [start..end) of physical memory addresses.
+   The fields addresses have architecture-specific alignment requirements. */
+typedef struct seL4_Loader_ReservedRegion {
+    seL4_Uint64 base;
+    seL4_Uint64 end;
+} SEL4_PACKED SEL4_ALIGNAS(seL4_Uint64) seL4_Loader_ReservedRegion;
+
+
+/* Make sure that modifications to the structure don't change these offsets */
+SEL4_COMPILE_ASSERT(kernel_boot_header_size, sizeof(seL4_LoaderInfo) == 0x18);
+SEL4_COMPILE_ASSERT(kernel_boot_header_magic_offset, __builtin_offsetof(seL4_LoaderInfo, magic) == 0x0);
+SEL4_COMPILE_ASSERT(kernel_boot_header_version_offset, __builtin_offsetof(seL4_LoaderInfo, version) == 0x4);
+SEL4_COMPILE_ASSERT(kernel_boot_header_root_task_entry_offset, __builtin_offsetof(seL4_LoaderInfo, root_task_entry) == 0x8);
+SEL4_COMPILE_ASSERT(kernel_boot_header_num_kernel_regions_offset, __builtin_offsetof(seL4_LoaderInfo, num_kernel_regions) == 0x10);
+SEL4_COMPILE_ASSERT(kernel_boot_header_num_ram_regions_offset, __builtin_offsetof(seL4_LoaderInfo, num_ram_regions) == 0x11);
+SEL4_COMPILE_ASSERT(kernel_boot_header_num_root_task_regions_offset, __builtin_offsetof(seL4_LoaderInfo, num_root_task_regions) == 0x12);
+SEL4_COMPILE_ASSERT(kernel_boot_header_num_reserved_regions_offset, __builtin_offsetof(seL4_LoaderInfo, num_reserved_regions) == 0x13);
+
+SEL4_COMPILE_ASSERT(kernel_boot_kernel_region_size, sizeof(seL4_Loader_KernelRegion) == 0x10);
+SEL4_COMPILE_ASSERT(kernel_boot_kernel_region_align, _Alignof(seL4_Loader_KernelRegion) == _Alignof(seL4_Uint64));
+
+SEL4_COMPILE_ASSERT(kernel_boot_ram_region_size, sizeof(seL4_Loader_RamRegion) == 0x10);
+SEL4_COMPILE_ASSERT(kernel_boot_ram_region_align, _Alignof(seL4_Loader_RamRegion) == _Alignof(seL4_Uint64));
+
+SEL4_COMPILE_ASSERT(kernel_boot_root_task_region_size, sizeof(seL4_Loader_RootTaskRegion) == 0x20);
+SEL4_COMPILE_ASSERT(kernel_boot_root_task_region_align, _Alignof(seL4_Loader_RootTaskRegion) == _Alignof(seL4_Uint64));
+
+SEL4_COMPILE_ASSERT(kernel_boot_reserved_region_size, sizeof(seL4_Loader_ReservedRegion) == 0x10);
+SEL4_COMPILE_ASSERT(kernel_boot_reserved_region_align, _Alignof(seL4_Loader_ReservedRegion) == _Alignof(seL4_Uint64));

--- a/libsel4/include/sel4/macros.h
+++ b/libsel4/include/sel4/macros.h
@@ -17,6 +17,7 @@
 #endif
 
 #define SEL4_PACKED             __attribute__((packed))
+#define SEL4_ALIGNAS(ty)        __attribute__((aligned(_Alignof(ty))))
 #define SEL4_DEPRECATED(x)      __attribute__((deprecated(x)))
 #define SEL4_DEPRECATE_MACRO(x) _Pragma("deprecated") x
 

--- a/src/arch/arm/common_arm.lds
+++ b/src/arch/arm/common_arm.lds
@@ -12,13 +12,11 @@
 
 ENTRY(_start)
 
-KERNEL_OFFSET = KERNEL_ELF_BASE_RAW - KERNEL_ELF_PADDR_BASE_RAW;
-
 SECTIONS
 {
-    . = KERNEL_ELF_BASE_RAW;
+    . = KERNEL_ELF_BASE;
 
-    .boot . : AT(ADDR(.boot) - KERNEL_OFFSET)
+    .boot . :
     {
         *(.boot.text)
         *(.boot.rodata)
@@ -28,7 +26,7 @@ SECTIONS
 
     ki_boot_end = .;
 
-    .text . : AT(ADDR(.text) - KERNEL_OFFSET)
+    .text . :
     {
         /* Sit inside a large frame */
         . = ALIGN(64K);
@@ -48,18 +46,18 @@ SECTIONS
         *(.text)
     }
 
-    .rodata . : AT(ADDR(.rodata) - KERNEL_OFFSET)
+    .rodata . :
     {
         *(.rodata)
         *(.rodata.*)
     }
 
-    .data . : AT(ADDR(.data) - KERNEL_OFFSET)
+    .data . :
     {
         *(.data)
     }
 
-    .bss . (NOLOAD): AT(ADDR(.bss) - KERNEL_OFFSET)
+    .bss . (NOLOAD) :
     {
         *(.bss)
         *(COMMON) /* fallback in case '-fno-common' is not used */

--- a/src/arch/arm/kernel/boot.c
+++ b/src/arch/arm/kernel/boot.c
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: GPL-2.0-only
  */
 
+#include "sel4/loader_info.h"
+#include "util.h"
 #include <config.h>
 #include <assert.h>
 #include <kernel/boot.h>
@@ -23,6 +25,7 @@
 #include <arch/machine/timer.h>
 #include <arch/machine/fpu.h>
 #include <arch/machine/tlb.h>
+#include "bootinfo.h"
 
 #ifdef CONFIG_ARM_SMMU
 #include <drivers/smmu/smmuv2.h>
@@ -38,36 +41,27 @@ BOOT_BSS static volatile _Atomic int node_boot_lock;
 #endif /* ENABLE_SMP_SUPPORT */
 
 BOOT_BSS static region_t reserved[NUM_RESERVED_REGIONS];
+BOOT_BSS static p_region_t avail_p_regs[MAX_NUM_FREEMEM_REG];
+
+#ifdef CONFIG_ARM_GIC_V3_SUPPORT
+extern word_t mpidr_map[CONFIG_MULTIKERNEL_NUM_CPUS];
+#endif
 
 BOOT_CODE static bool_t arch_init_freemem(p_region_t ui_p_reg,
-                                          p_region_t dtb_p_reg,
+                                          word_t avail_p_regs_count,
+                                          int reserved_index_start,
                                           v_region_t it_v_reg,
                                           word_t extra_bi_size_bits)
 {
-    /* reserve the kernel image region */
-    reserved[0] = paddr_to_pptr_reg(get_p_reg_kernel_img());
 
-    int index = 1;
-
-    /* add the dtb region, if it is not empty */
-    if (dtb_p_reg.start) {
-        if (index >= ARRAY_SIZE(reserved)) {
-            printf("ERROR: no slot to add DTB to reserved regions\n");
-            return false;
-        }
-        reserved[index].start = (pptr_t) paddr_to_pptr(dtb_p_reg.start);
-        reserved[index].end = (pptr_t) paddr_to_pptr(dtb_p_reg.end);
-        index++;
-    }
+    int index = reserved_index_start;
 
     /* Reserve the user image region and the mode-reserved regions. For now,
      * only one mode-reserved region is supported, because this is all that is
      * needed.
      */
-    if (MODE_RESERVED > 1) {
-        printf("ERROR: MODE_RESERVED > 1 unsupported!\n");
-        return false;
-    }
+    compile_assert(mode_reserved_gt_1_unsupported, MODE_RESERVED <= 1);
+
     if (ui_p_reg.start < PADDR_TOP) {
         region_t ui_reg = paddr_to_pptr_reg(ui_p_reg);
         if (MODE_RESERVED == 1) {
@@ -105,12 +99,16 @@ BOOT_CODE static bool_t arch_init_freemem(p_region_t ui_p_reg,
             index++;
         }
 
+        assert(false);
         /* Reserve the ui_p_reg region still so it doesn't get turned into device UT. */
         reserve_region(ui_p_reg);
     }
 
-    /* avail_p_regs comes from the auto-generated code */
-    return init_freemem(ARRAY_SIZE(avail_p_regs), avail_p_regs,
+    /* reserve the kernel image region */
+    reserved[index] = paddr_to_pptr_reg(get_p_reg_kernel_img());
+    index += 1;
+
+    return init_freemem(avail_p_regs_count, avail_p_regs,
                         index, reserved,
                         it_v_reg, extra_bi_size_bits);
 }
@@ -331,15 +329,143 @@ BOOT_CODE static void release_secondary_cpus(void)
 
 /* Main kernel initialisation function. */
 
-static BOOT_CODE bool_t try_init_kernel(
-    paddr_t ui_p_reg_start,
-    paddr_t ui_p_reg_end,
-    sword_t pv_offset,
-    vptr_t  v_entry,
-    paddr_t dtb_phys_addr,
-    word_t  dtb_size
-)
+static BOOT_CODE bool_t try_init_kernel(paddr_t loader_info_p)
 {
+    // see below note about boot_node_id mpidr_el1_get_Aff0
+    node_id_t boot_node_id;
+    asm volatile("mrs %0, tpidr_el1" : "=r"(boot_node_id));
+
+    NODE_STATE(boot_cpu_id) = boot_node_id;
+
+    for (volatile uint64_t c = 0; c < (boot_node_id * 0x80000000); c++) {
+        asm volatile("" ::: "memory");
+    }
+
+    printf("loader info addr: 0x%lx\n", loader_info_p);
+
+    seL4_LoaderInfo *loader_info = (void *)loader_info_p;
+    if (loader_info->magic != SEL4_LOADER_INFO_MAGIC) {
+        printf("boot info magic wrong\n");
+        return false;
+    }
+    if (loader_info->version != SEL4_LOADER_INFO_VERSION_0) {
+        printf("boot info magic wrong\n");
+        return false;
+    }
+
+    vptr_t v_entry = loader_info->root_task_entry;
+
+    printf("root task v_entry: 0x%lx\n", v_entry);
+    // printf("root task pv_offset: 0x%lx 0x%lx\n", pv_offset, -pv_offset);
+
+    printf("num_kernel_regions: %d\n", loader_info->num_kernel_regions);
+    printf("num_ram_regions: %d\n", loader_info->num_ram_regions);
+    printf("num_root_task_regions: %d\n", loader_info->num_root_task_regions);
+    printf("num_reserved_regions: %d\n", loader_info->num_reserved_regions);
+
+    bool_t failed_checks = false;
+    if (loader_info->num_kernel_regions != 1) {
+        printf("only 1 kernel regions allowed\n");
+        failed_checks = true;
+    }
+    if (loader_info->num_ram_regions == 0) {
+        printf("need at least one ram region\n");
+        failed_checks = true;
+    }
+    if (loader_info->num_ram_regions > ARRAY_SIZE(avail_p_regs)) {
+        printf("too many ram regions: %d exceeds %d\n", loader_info->num_ram_regions, MAX_NUM_FREEMEM_REG);
+        failed_checks = true;
+    }
+    if (loader_info->num_root_task_regions == 0) {
+        printf("need at least one root task region\n");
+        failed_checks = true;
+    }
+    if (loader_info->num_reserved_regions > ARRAY_SIZE(reserved)) {
+        printf("too many reserved regions: %d exceeds %d\n", loader_info->num_reserved_regions, MAX_NUM_USER_RESERVED_REGIONS);
+        failed_checks = true;
+    }
+#ifdef CONFIG_ARM_GIC_V3_SUPPORT
+    if (loader_info->num_mpidrs > ARRAY_SIZE(mpidr_map)) {
+        printf("too many MPIDR values: %d exceeds %lu\n", loader_info->num_mpidrs, ARRAY_SIZE(mpidr_map));
+        failed_checks = true;
+    }
+#endif
+
+    if (failed_checks) {
+        printf("failed validation\n");
+        return false;
+    }
+
+    seL4_Loader_KernelRegion *kernel_regions = (void *)(loader_info_p + sizeof(seL4_LoaderInfo));
+    seL4_Loader_RamRegion *ram_regions = (void *)((word_t)kernel_regions + (loader_info->num_kernel_regions * sizeof(seL4_Loader_KernelRegion)));
+    seL4_Loader_RootTaskRegion *root_task_regions = (void *)((word_t)ram_regions + (loader_info->num_ram_regions * sizeof(seL4_Loader_RamRegion)));
+    seL4_Loader_ReservedRegion *reserved_regions = (void *)((word_t)root_task_regions + (loader_info->num_root_task_regions * sizeof(seL4_Loader_RootTaskRegion)));
+    uint64_t *mpidr_values = (void *)((word_t)reserved_regions + (loader_info->num_reserved_regions * sizeof(seL4_Loader_ReservedRegion)));
+    paddr_t end_of_loader_info = ((word_t)mpidr_values + (loader_info->num_mpidrs * sizeof(uint64_t)));
+
+    printf("kernel_regions addr: %p\n", kernel_regions);
+    printf("ram_regions addr: %p\n", ram_regions);
+    printf("root_task_regions addr: %p\n", root_task_regions);
+    printf("reserved_regions addr: %p\n", reserved_regions);
+    printf("mpidr_values addr: %p\n", mpidr_values);
+    printf("end of loader info addr: %p\n", (void *)end_of_loader_info);
+
+    // === Debugging: dump all ====
+
+    for (int i = 0; i < loader_info->num_kernel_regions; i++) {
+        printf("kernel_regions[%d].base = 0x%llx\n", i, kernel_regions[i].base);
+        printf("kernel_regions[%d].end = 0x%llx\n", i, kernel_regions[i].end);
+    }
+    for (int i = 0; i < loader_info->num_ram_regions; i++) {
+        printf("ram_regions[%d].base = 0x%llx\n", i, ram_regions[i].base);
+        printf("ram_regions[%d].end = 0x%llx\n", i, ram_regions[i].end);
+    }
+    for (int i = 0; i < loader_info->num_root_task_regions; i++) {
+        printf("root_task_regions[%d].paddr_base = 0x%llx\n", i, root_task_regions[i].paddr_base);
+        printf("root_task_regions[%d].paddr_end = 0x%llx\n", i, root_task_regions[i].paddr_end);
+        printf("root_task_regions[%d].vaddr_base = 0x%llx\n", i, root_task_regions[i].vaddr_base);
+    }
+    for (int i = 0; i < loader_info->num_reserved_regions; i++) {
+        printf("reserved_regions[%d].base = 0x%llx\n", i, reserved_regions[i].base);
+        printf("reserved_regions[%d].end = 0x%llx\n", i, reserved_regions[i].end);
+    }
+    for (int i = 0; i < loader_info->num_mpidrs; i++) {
+        printf("mpidr_values[%d] = 0x%llx\n", i, mpidr_values[i]);
+    }
+    // === end dump all
+
+
+#ifdef CONFIG_ARM_GIC_V3_SUPPORT
+    // relying on len(mpidr_map) == len(mpidrs)
+    for (int i = 0; i < ARRAY_SIZE(mpidr_map); i++) {
+        mpidr_map[i] = mpidr_values[i];
+    }
+
+#endif
+
+    // // TODO: ???
+    word_t dtb_size = 0;
+    paddr_t dtb_phys_addr = 0;
+    sword_t pv_offset;
+    paddr_t extra_device_addr_start;
+    word_t extra_device_size;
+    paddr_t ui_p_reg_start;
+    paddr_t ui_p_reg_end;
+
+    // HACK: This assumes 1 region.
+    assert(loader_info->num_kernel_regions == 1);
+    // TODO: This is not true due to alignment.
+    ksKernelElfPaddrBase = kernel_regions[0].base;
+    /// XXX: End?
+
+    // HACK: This assumes 1 region.
+    assert(loader_info->num_root_task_regions == 1);
+    ui_p_reg_start = root_task_regions[0].paddr_base;
+    ui_p_reg_end = root_task_regions[0].paddr_end;
+    // HACK: remove pv_offset code
+    pv_offset = root_task_regions[0].paddr_base - root_task_regions[0].vaddr_base;
+
+    // =======================================================
     cap_t root_cnode_cap;
     cap_t it_ap_cap;
     cap_t it_pd_cap;
@@ -366,6 +492,20 @@ static BOOT_CODE bool_t try_init_kernel(
     bi_frame_vptr = ipcbuf_vptr + BIT(PAGE_BITS);
     extra_bi_frame_vptr = bi_frame_vptr + BIT(seL4_BootInfoFrameBits);
 
+    /* Get the CPU ID of the CPU we are booting on. */
+    mpidr_el1_t mpidr_el1;
+    asm volatile("mrs %0, mpidr_el1" : "=r"(mpidr_el1.words[0]));
+
+    // // TODO: This is somewhat arbitrary for now...
+    // // XXX: How is this different to getCurrentCPUIndex()
+    // // XXX: What is difference between node_id_t and cpu_id_t?
+    // node_id_t boot_node_id = mpidr_el1_get_Aff0(mpidr_el1);
+
+    if (!IS_ALIGNED(ksKernelElfPaddrBase, seL4_LargePageBits)) {
+        printf("kernel elf paddr base is not aligned\n");
+        return false;
+    }
+
     /* setup virtual memory for the kernel */
     map_kernel_window();
 
@@ -377,6 +517,13 @@ static BOOT_CODE bool_t try_init_kernel(
 
     /* debug output via serial port is only available from here */
     printf("Bootstrapping kernel\n");
+
+    /* Convert to virtual addresses */
+    loader_info = ptrFromPAddr((paddr_t)loader_info);
+    kernel_regions = ptrFromPAddr((paddr_t)kernel_regions);
+    ram_regions = ptrFromPAddr((paddr_t)ram_regions);
+    root_task_regions = ptrFromPAddr((paddr_t)root_task_regions);
+    reserved_regions = ptrFromPAddr((paddr_t)reserved_regions);
 
     /* initialise the platform */
     init_plat();
@@ -429,7 +576,23 @@ static BOOT_CODE bool_t try_init_kernel(
         return false;
     }
 
-    if (!arch_init_freemem(ui_p_reg, dtb_p_reg, it_v_reg, extra_bi_size_bits)) {
+    /* safe because size checked before */
+    word_t avail_p_regs_count = loader_info->num_ram_regions;
+    for (int i = 0; i < avail_p_regs_count; i++) {
+        avail_p_regs[i].start = ram_regions[i].base;
+        avail_p_regs[i].end = ram_regions[i].end;
+    }
+
+    /* safe because size checked before */
+    word_t reserved_count = loader_info->num_reserved_regions;
+    for (int i = 0; i < reserved_count; i++) {
+        reserved[i].start = (pptr_t)paddr_to_pptr(reserved_regions[i].base);
+        reserved[i].end = (pptr_t)paddr_to_pptr(reserved_regions[i].end);
+        printf("reserved[%d] = {%lx, %lx}\n", i, reserved[i].start, reserved[i].end);
+    }
+
+    // XX: Why does this function exist.
+    if (!arch_init_freemem(ui_p_reg, avail_p_regs_count, reserved_count, it_v_reg, extra_bi_size_bits)) {
         printf("ERROR: free memory management initialization failed\n");
         return false;
     }
@@ -455,7 +618,19 @@ static BOOT_CODE bool_t try_init_kernel(
     init_smc(root_cnode_cap);
 #endif
 
+#ifdef CONFIG_ENABLE_MULTIKERNEL_SUPPORT
+    printf("MPIDR_EL1: %llx\n", mpidr_el1.words[0]);
+    printf("MPIDR_EL1:U: %s\n", mpidr_el1_get_U(mpidr_el1) ? "uniprocessor" : "multiprocessor");
+    printf("MPIDR_EL1:MT: %s\n", mpidr_el1_get_MT(mpidr_el1) ? "SMT" : "no SMT");
+    printf("MPIDR_EL1:Aff0: %llx\n", mpidr_el1_get_Aff0(mpidr_el1));
+    printf("MPIDR_EL1:Aff1: %llx\n", mpidr_el1_get_Aff1(mpidr_el1));
+    printf("MPIDR_EL1:Aff2: %llx\n", mpidr_el1_get_Aff2(mpidr_el1));
+    printf("MPIDR_EL1:Aff3: %llx\n", mpidr_el1_get_Aff3(mpidr_el1));
+
+    populate_bi_frame(boot_node_id, CONFIG_MULTIKERNEL_NUM_CPUS, ipcbuf_vptr, extra_bi_size);
+#else
     populate_bi_frame(0, CONFIG_MAX_NUM_NODES, ipcbuf_vptr, extra_bi_size);
+#endif
 
     /* put DTB in the bootinfo block, if present. */
     seL4_BootInfoHeader header;
@@ -520,7 +695,8 @@ static BOOT_CODE bool_t try_init_kernel(
     }
 
 #ifdef CONFIG_KERNEL_MCS
-    init_sched_control(root_cnode_cap, CONFIG_MAX_NUM_NODES);
+    // for multikernel, only want 1 schedcontrol cap
+    init_sched_control(root_cnode_cap, SMP_TERNARY(CONFIG_MAX_NUM_NODES, 1));
 #endif
 
     /* create the initial thread's IPC buffer */
@@ -626,41 +802,31 @@ static BOOT_CODE bool_t try_init_kernel(
     return true;
 }
 
-BOOT_CODE VISIBLE void init_kernel(
-    paddr_t ui_p_reg_start,
-    paddr_t ui_p_reg_end,
-    sword_t pv_offset,
-    vptr_t  v_entry,
-    paddr_t dtb_addr_p,
-    uint32_t dtb_size
-)
+BOOT_CODE VISIBLE void init_kernel(paddr_t loader_info_p)
 {
     bool_t result;
+
+    printf("hi\n");
+
+    // TODO: getCurrentCPUIndex() for multikernel.
 
 #ifdef ENABLE_SMP_SUPPORT
     /* we assume there exists a cpu with id 0 and will use it for bootstrapping */
     if (getCurrentCPUIndex() == 0) {
-        result = try_init_kernel(ui_p_reg_start,
-                                 ui_p_reg_end,
-                                 pv_offset,
-                                 v_entry,
-                                 dtb_addr_p, dtb_size);
+        result = try_init_kernel(loader_info_p);
     } else {
         result = try_init_kernel_secondary_core();
     }
 
 #else
-    result = try_init_kernel(ui_p_reg_start,
-                             ui_p_reg_end,
-                             pv_offset,
-                             v_entry,
-                             dtb_addr_p, dtb_size);
+    result = try_init_kernel(loader_info_p);
 
 #endif /* ENABLE_SMP_SUPPORT */
 
     if (!result) {
-        fail("ERROR: kernel init failed");
-        UNREACHABLE();
+        return;
+        // fail("ERROR: kernel init failed");
+        // UNREACHABLE();
     }
 
 #ifdef CONFIG_KERNEL_MCS

--- a/src/arch/arm/machine/gic_v3.c
+++ b/src/arch/arm/machine/gic_v3.c
@@ -55,7 +55,11 @@ volatile struct gic_rdist_sgi_ppi_map *gic_rdist_sgi_ppi_map[CONFIG_MAX_NUM_NODE
 #define MPIDR_MT(x)   (x & BIT(24))
 #define MPIDR_AFF_MASK(x) (x & 0xff00ffffff)
 
+#ifdef CONFIG_ENABLE_SMP_SUPPORT
 static word_t mpidr_map[CONFIG_MAX_NUM_NODES];
+#else
+word_t mpidr_map[CONFIG_MULTIKERNEL_NUM_CPUS];
+#endif
 
 static inline word_t get_mpidr(word_t core_id)
 {
@@ -64,8 +68,9 @@ static inline word_t get_mpidr(word_t core_id)
 
 static inline word_t get_current_mpidr(void)
 {
-    word_t core_id = CURRENT_CPU_INDEX();
-    return get_mpidr(core_id);
+    word_t mpidr_el1;
+    asm volatile("mrs %0, mpidr_el1" : "=r"(mpidr_el1));
+    return mpidr_el1;
 }
 
 static inline uint64_t mpidr_to_gic_affinity(void)
@@ -405,7 +410,8 @@ BOOT_CODE void cpu_initLocalIRQController(void)
     word_t mpidr = 0;
     SYSTEM_READ_WORD(MPIDR, mpidr);
 
-    mpidr_map[CURRENT_CPU_INDEX()] = mpidr;
+    // already init by boot code
+    // mpidr_map[CURRENT_CPU_INDEX()] = mpidr;
     active_irq[CURRENT_CPU_INDEX()] = IRQ_NONE;
 
     gicr_init();

--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -741,7 +741,7 @@ BOOT_CODE static bool_t provide_untyped_cap(
  * @param first_untyped_slot First available untyped boot info slot.
  * @return true on success, false on failure.
  */
-BOOT_CODE static bool_t create_untypeds_for_region(
+BOOT_CODE bool_t create_untypeds_for_region(
     cap_t      root_cnode_cap,
     bool_t     device_memory,
     region_t   reg,
@@ -960,25 +960,19 @@ BOOT_CODE static word_t init_avail_reg(word_t n_available,
 
 
 BOOT_CODE static bool_t check_reserved_memory(word_t n_reserved,
-                                              const region_t *reserved)
+                                              region_t *reserved)
 {
-    printf("Reserved virt address space regions: %"SEL4_PRIu_word"\n",
-           n_reserved);
+    bool_t needs_sort = false;
+
     /* Force ordering and exclusivity of reserved regions. */
     for (word_t i = 0; i < n_reserved; i++) {
         const region_t *r = &reserved[i];
-        printf("  [%"SEL4_PRIx_word"..%"SEL4_PRIx_word")\n", r->start, r->end);
+        const p_region_t p_r = pptr_to_paddr_reg(*r);
+        printf("  [%"SEL4_PRIx_word"..%"SEL4_PRIx_word")\n", p_r.start, p_r.end);
 
         /* Reserved regions must be sane, the size is allowed to be zero. */
         if (r->start > r->end) {
             printf("ERROR: reserved region %"SEL4_PRIu_word" has start > end\n", i);
-            return false;
-        }
-
-        /* Regions must be ordered and must not overlap. Regions are [start..end),
-           so the == case is fine. Directly adjacent regions are allowed. */
-        if ((i > 0) && (r->start < reserved[i - 1].end)) {
-            printf("ERROR: reserved region %"SEL4_PRIu_word" in wrong order\n", i);
             return false;
         }
     }
@@ -990,8 +984,8 @@ BOOT_CODE static bool_t check_reserved_memory(word_t n_reserved,
  * Dynamically initialise the available memory on the platform.
  * A region represents an area of memory.
  */
-BOOT_CODE bool_t init_freemem(word_t n_available, const p_region_t *available,
-                              word_t n_reserved, const region_t *reserved,
+BOOT_CODE bool_t init_freemem(word_t n_available, p_region_t *available,
+                              word_t n_reserved, region_t *reserved,
                               v_region_t it_v_reg, word_t extra_bi_size_bits)
 {
     if (!check_available_memory(n_available, available)) {

--- a/src/model/statedata.c
+++ b/src/model/statedata.c
@@ -70,6 +70,10 @@ UP_STATE_DEFINE(timestamp_t, benchmark_kernel_number_entries);
 UP_STATE_DEFINE(timestamp_t, benchmark_kernel_number_schedules);
 #endif /* CONFIG_BENCHMARK_TRACK_UTILISATION */
 
+#ifdef CONFIG_ENABLE_MULTIKERNEL_SUPPORT
+UP_STATE_DEFINE(node_id_t, boot_cpu_id);
+#endif
+
 /* Units of work we have completed since the last time we checked for
  * pending interrupts */
 word_t ksWorkUnitsCompleted;
@@ -108,3 +112,8 @@ kernel_entry_t ksKernelEntry;
 #ifdef CONFIG_KERNEL_LOG_BUFFER
 paddr_t ksUserLogBuffer;
 #endif /* CONFIG_KERNEL_LOG_BUFFER */
+
+#ifdef CONFIG_ARCH_AARCH64
+/* zero is a valid value; -1 is not */
+paddr_t ksKernelElfPaddrBase = -1;
+#endif

--- a/src/object/interrupt.c
+++ b/src/object/interrupt.c
@@ -264,7 +264,7 @@ void handleInterrupt(irq_t irq)
          */
         maskInterrupt(true, irq);
 #ifdef CONFIG_IRQ_REPORTING
-        printf("Received disabled IRQ: %d\n", (int)IRQT_TO_IRQ(irq));
+        printf("kernel %lx; Received disabled IRQ: %d\n", ksKernelElfPaddrBase, (int)IRQT_TO_IRQ(irq));
 #endif
         break;
 

--- a/tools/hardware/outputs/c_header.py
+++ b/tools/hardware/outputs/c_header.py
@@ -27,23 +27,12 @@ HEADER_TEMPLATE = '''/*
 
 #pragma once
 
-#define PHYS_BASE_RAW {{ "0x{:x}".format(physBase) }}
-
 #ifndef __ASSEMBLER__
 
 #include <config.h>
 #include <mode/hardware.h>  /* for KDEV_BASE */
 #include <linker.h>         /* for BOOT_RODATA */
 #include <basic_types.h>    /* for p_region_t, kernel_frame_t (arch/types.h) */
-
-/* Wrap raw physBase location constant to give it a symbolic name in C that's
- * visible to verification. This is necessary as there are no real constants
- * in C except enums, and enums constants must fit in an int.
- */
-static inline CONST word_t physBase(void)
-{
-    return PHYS_BASE_RAW;
-}
 
 /* INTERRUPTS */
 {% for irq in kernel_irqs %}
@@ -115,17 +104,6 @@ static const kernel_frame_t BOOT_RODATA *const kernel_device_frames = NULL;
 #define NUM_KERNEL_DEVICE_FRAMES 0
 {% endif %}
 
-/* PHYSICAL MEMORY */
-static const p_region_t BOOT_RODATA avail_p_regs[] = {
-    {% for reg in physical_memory %}
-    /* {{ reg.owner.path }} */
-    {
-        .start = {{ "0x{:x}".format(reg.base) }},
-        .end   = {{ "0x{:x}".format(reg.base + reg.size) }}
-    },
-    {% endfor %}
-};
-
 #endif /* !__ASSEMBLER__ */
 
 '''
@@ -186,8 +164,7 @@ def get_interrupts(tree: FdtParser, hw_yaml: HardwareYaml) -> List:
 
 
 def create_c_header_file(config, kernel_irqs: List, kernel_macros: Dict,
-                         kernel_regions: List, physBase: int, physical_memory,
-                         outputStream):
+                         kernel_regions: List, outputStream):
 
     jinja_env = jinja2.Environment(loader=jinja2.BaseLoader, trim_blocks=True,
                                    lstrip_blocks=True)
@@ -199,9 +176,7 @@ def create_c_header_file(config, kernel_irqs: List, kernel_macros: Dict,
             'config': config,
             'kernel_irqs': kernel_irqs,
             'kernel_macros': kernel_macros,
-            'kernel_regions': kernel_regions,
-            'physBase': physBase,
-            'physical_memory': physical_memory})
+            'kernel_regions': kernel_regions})
     data = template.render(template_args)
 
     with outputStream:
@@ -212,7 +187,6 @@ def run(tree: FdtParser, hw_yaml: HardwareYaml, config: Config, kernel_config_di
     if not args.header_out:
         raise ValueError('You need to specify a header-out to use c header output')
 
-    physical_memory, physBase = hardware.utils.memory.get_physical_memory(tree, config)
     kernel_regions, kernel_macros = get_kernel_devices(tree, hw_yaml, kernel_config_dict)
 
     create_c_header_file(
@@ -220,8 +194,6 @@ def run(tree: FdtParser, hw_yaml: HardwareYaml, config: Config, kernel_config_di
         get_interrupts(tree, hw_yaml),
         kernel_macros,
         kernel_regions,
-        physBase,
-        physical_memory,
         args.header_out)
 
 

--- a/tools/hardware/outputs/json.py
+++ b/tools/hardware/outputs/json.py
@@ -25,9 +25,15 @@ def make_json_list_of_regions(regions) -> List:
     ]
 
 
-def create_json_file(dev_mem, phys_mem, output_stream):
+def create_json_file(dev_mem, kernel_devs, phys_mem, output_stream):
     json_obj = {
         'devices': make_json_list_of_regions(dev_mem),
+        'kernel_devs': [
+            { 'start': r.base,
+              'end':   r.base + r.size,
+              'userAvailable': r.user_ok,
+            } for r in kernel_devs if r.size > 0
+        ],
         'memory':  make_json_list_of_regions(phys_mem)
     }
 

--- a/tools/hardware/outputs/yaml.py
+++ b/tools/hardware/outputs/yaml.py
@@ -25,7 +25,7 @@ def make_yaml_list_of_regions(regions) -> List:
     ]
 
 
-def create_yaml_file(dev_mem, phys_mem, outputStream):
+def create_yaml_file(dev_mem, kernel_devs, phys_mem, outputStream):
 
     yaml.add_representer(
         int,
@@ -33,6 +33,12 @@ def create_yaml_file(dev_mem, phys_mem, outputStream):
 
     yaml_obj = {
         'devices': make_yaml_list_of_regions(dev_mem),
+        'kernel_devs': [
+            { 'start': r.base,
+              'end':   r.base + r.size,
+              'userAvailable': r.user_ok,
+            } for r in kernel_devs if r.size > 0
+        ],
         'memory':  make_yaml_list_of_regions(phys_mem)
     }
 


### PR DESCRIPTION
This is a pre-RFC containing the code changes to the seL4 boot protocol done in Trustworthy System's [multikernel-manifest](https://github.com/au-ts/multikernel-manifest) repository around this time last year. This was previously shared [here for comments in our private fork](https://github.com/au-ts/seL4/pull/2)[^1]. The code has been pulled out from the kernel branch and almost certainly does not build and contains "dead" changes.

The code within this PR can be roughly categorised into three parts, and where attention should be focused:

1. `libsel4/include/sel4/loader_info.h`. This contains *an* implementation of a loader protocol. I'm not convinced this is the ideal solution, perhaps something with a set of TLV (tag-length-value) records would be better, or otherwise.


2. `ksKernelElfPaddrBase` in the statedata. This allows the same kernel image to be loaded at different physical addresses (since #1516 has been implemented) without recompiling. Thus the associated changes to `common_arm.lds` (note that this is not strictly necessary).

3. `src/arch/arm/kernel/boot.c` and specifically `try_init_kernel` which does the initialisation based on the loader info.

An additional, fourth change in `tools/hardware/outputs/json.py` allows the loader to map the UART for the kernel prior to the kernel switching virtual address spaces: this might be worth it standalone.

This doesn't include other changes necessary for the Multikernel, *just* the changes necessary to load the kernel memory, and userspace untyped regions (normal/device) at runtime with a single build of the kernel.

I'm opening a PR to prompt asynchronous discussion. The idea here is to use this to help write up a proper RFC for multikernel changes to work.

---

Ping of @dasch8-neutrality as I believe you did a summit talk on this (although I have not attended, so I don't know the contents of the talk).

Related: #1613.

[^1]: I will replicate the discussion from there.